### PR TITLE
Add task to support running `apko` builds via Tekton.

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,17 @@
+# Copyright 2022 Chainguard, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+baseImageOverrides:
+  # TODO(mattmoor): Talk to kaniini about the best image to use here.
+  chainguard.dev/apko/cmd/apko: docker.io/alpine:latest

--- a/config/task.yaml
+++ b/config/task.yaml
@@ -1,0 +1,68 @@
+# Copyright 2022 Chainguard, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: apko
+spec:
+  description: "An apko task for building images."
+  params:
+    - name: dev.mink.sources.bundle
+      description: A self-extracting container image of source
+    - name: dev.mink.images.target
+      description: Where to publish an image.
+    - name: path
+      description: The bundle-relative path to the config file to build.
+      default: ./config.yaml
+
+  results:
+    - name: IMAGES
+      description: The list of images produced by this task (for chains)
+    - name: dev.mink.images.digest
+      description: The digest of the resulting image.
+
+  steps:
+    - name: extract-bundle
+      image: $(params["dev.mink.sources.bundle"])
+      workingDir: /workspace
+
+    - name: build-image
+      image: ko://chainguard.dev/apko/cmd/apko
+      workingDir: /workspace
+      args:
+      - build
+      - $(params["path"])
+      - $(params["dev.mink.images.target"])
+      # TODO(mattmoor): Move this to an emptyDir volume
+      - output.tar.gz
+
+    - name: push-image
+      # This is a version of "crane" with k8schain linked as
+      # a universal credential helper (for workload identity).
+      image: gcr.io/go-containerregistry/krane
+      workingDir: /workspace
+      args:
+      - push
+      - --image-refs=/tekton/results/IMAGES
+      - output.tar.gz
+      - $(params["dev.mink.images.target"])
+
+    # mink wants just the digest in its result, but the above produces
+    # a fully qualified digest.
+    - name: massage-digest
+      image: gcr.io/distroless/base:debug-nonroot
+      command: ["/busybox/sh", "-c"]
+      args:
+      - echo -n $(cat /tekton/results/IMAGES | cut -d'@' -f 2) > /tekton/results/dev.mink.images.digest


### PR DESCRIPTION
To build/install the task definition (w/ apko) you can run:
```
KO_DOCKER_REPO=ghcr.io/mattmoor ko apply -Bf config/
```

This task definition implements the interface defined in `github.com/mattmoor/mink`
to support uploading local source and directing where to publish images (so it can
be used with `mink apply` as well).

You can invoke this task imperatively with the following `mink` command:
```
$ mink run task apko --as=apko -- --path=./examples/nginx.yaml

2022/02/19 19:21:58 building image 'gcr.io/mattmoor-chainguard/images' from config file './examples/nginx.yaml'
2022/02/19 19:21:58 build context:
2022/02/19 19:21:58   image configuration: {{[https://dl-cdn.alpinelinux.org/alpine/edge/main] [/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub /etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub /etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub] [alpine-baselayout nginx]} {service-bundle  map[nginx:/usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"]}}
2022/02/19 19:21:58   working directory: /tmp/apko-2587090319
2022/02/19 19:21:58   tarball path:
2022/02/19 19:21:58 doing pre-flight checks
2022/02/19 19:21:58 building image fileystem in /tmp/apko-2587090319
2022/02/19 19:21:58 initializing apk database
2022/02/19 19:21:58 running: /sbin/apk add --initdb --root /tmp/apko-2587090319
2022/02/19 19:21:58 [apk] OK: 0 MiB in 0 packages
2022/02/19 19:21:58 initializing apk keyring
2022/02/19 19:21:58 installing key /etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
2022/02/19 19:21:58 installing key /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
2022/02/19 19:21:58 installing key /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
2022/02/19 19:21:58 installing key /etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
2022/02/19 19:21:58 installing key /etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
2022/02/19 19:21:58 initializing apk repositories
2022/02/19 19:21:58 initializing apk world
2022/02/19 19:21:58 synchronizing with desired apk world
2022/02/19 19:21:58 running: /sbin/apk fix --root /tmp/apko-2587090319 --no-cache --update-cache
2022/02/19 19:21:58 [apk] fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
(1/12) Installing musl (1.2.2-r7)
(2/12) Installing busybox (1.35.0-r2)
Executing busybox-1.35.0-r2.post-install
(3/12) Installing alpine-baselayout (3.2.0-r19)
Executing alpine-baselayout-3.2.0-r19.pre-install
Executing alpine-baselayout-3.2.0-r19.post-install
(4/12) Installing libcrypto1.1 (1.1.1m-r2)
(5/12) Installing pcre (8.45-r2)
(6/12) Installing libssl1.1 (1.1.1m-r2)
(7/12) Installing zlib (1.2.11-r3)
(8/12) Installing nginx (1.20.2-r0)
Executing nginx-1.20.2-r0.pre-install
Executing nginx-1.20.2-r0.post-install
(9/12) Installing skalibs (2.11.1.0-r0)
(10/12) Installing s6-ipcserver (2.11.0.1-r0)
(11/12) Installing execline (2.8.2.0-r0)
(12/12) Installing s6 (2.11.0.1-r0)
Executing s6-2.11.0.1-r0.pre-install
Executing busybox-1.35.0-r2.trigger
OK: 8 MiB in 12 packages
2022/02/19 19:21:58 generating supervision tree
2022/02/19 19:21:58 simple service: nginx => /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
2022/02/19 19:21:58   supervision dir: /tmp/apko-2587090319/sv/nginx
2022/02/19 19:21:58 finished building filesystem in /tmp/apko-2587090319
2022/02/19 19:21:59 built image layer tarball as /tmp/apko-1984638129.tar.gz
2022/02/19 19:21:59 building OCI image 'gcr.io/mattmoor-chainguard/images' from layer '/tmp/apko-1984638129.tar.gz'
2022/02/19 19:21:59 OCI layer digest: sha256:5b6a06005c97c31df81455008c3c92078a50c8b07bc394a98c2519f2945c47ff
2022/02/19 19:21:59 OCI layer diffID: sha256:775a08d0e0b33a95dff11e6ffe1511605e9e6ef2646ab39353deeb3344b75577
2022/02/19 19:21:59 output OCI image file to foo.tar.gz

2022/02/19 19:22:02 pushed blob: sha256:3ed57839e782bc6b1c084f25433ef6d92647ec9906070d2ecc48ec31cfa84650
2022/02/19 19:22:02 pushed blob: sha256:5b6a06005c97c31df81455008c3c92078a50c8b07bc394a98c2519f2945c47ff
2022/02/19 19:22:03 gcr.io/mattmoor-chainguard/images: digest: sha256:a2fdd03e2be33056b469fe472917e1c2d19670de04da7963e566cd078771c02e size: 427

gcr.io/mattmoor-chainguard/images@sha256:a2fdd03e2be33056b469fe472917e1c2d19670de04da7963e566cd078771c02e
```