### PR TITLE
Add goreleaser and ko build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,65 @@
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  cli:
+    name: Release the CLI
+    runs-on: ubuntu-latest
+
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+    - uses: actions/checkout@v2
+    - uses: sigstore/cosign-installer@main
+    - uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ko-build:
+    name: Release apko image
+    runs-on: ubuntu-latest
+
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+
+    env:
+      KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
+      KOFLAGS: --platform=all --bare
+      COSIGN_EXPERIMENTAL: "true"
+
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.17.x
+    - uses: imjasonh/setup-ko@v0.4
+      with:
+        version: v0.10.0
+    - uses: sigstore/cosign-installer@main
+    - uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Publish apko image
+      run: |
+        DIGEST=$(ko build ${KOFLAGS} --tags $(basename "${{ github.ref }}" ) ./cmd/apko)
+
+        # TODO: Add attributes with version, sha, etc.
+        cosign sign ${DIGEST}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+- id: "apko-build"
+  binary: apko
+  main: ./cmd/apko/main.go
+  env:
+  - CGO_ENABLED=0
+  goos:
+    # apko requires alpine, so only build linux binaries.
+    - linux
+  goarch:
+    - 386
+    - amd64
+    - arm64
+  hooks:
+    post:
+      - sh -c "COSIGN_EXPERIMENTAL=true cosign sign-blob --output-certificate dist/apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}.crt --output-signature dist/apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sig {{ .Path }}"
+
+archives:
+- name_template: "apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  files:
+    - LICENSE
+  wrap_in_directory: true
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+release:
+  draft: false
+  prerelease: true
+  name_template: "Release {{ .Tag }}"
+  extra_files:
+  - glob: dist/*.crt
+  - glob: dist/*.sig


### PR DESCRIPTION
Here's a sample release on my fork: https://github.com/mattmoor/apko/releases/tag/v0.0.11

I downloaded and verified the signature here (still not sure what the ctlog issue is cc @dlorenc ):
```
$ COSIGN_EXPERIMENTAL=true cosign verify-blob --signature apko_0.0.11_linux_arm64.sig --cert apko_0.0.11_linux_arm64.crt apko_0.0.11_linux_arm64/apko 
Verified OK
Error: verifying blob [apko_0.0.11_linux_arm64/apko]: signature not found in transparency log
main.go:46: error during command execution: verifying blob [apko_0.0.11_linux_arm64/apko]: signature not found in transparency log
```

We can verify the image signature:
```
$ COSIGN_EXPERIMENTAL=true cosign verify ghcr.io/mattmoor/apko:v0.0.11@sha256:7c29ab9bfadeff2367c298d99e8c27479823bdee114265f64beceb7547156753 | jq .

Verification for ghcr.io/mattmoor/apko@sha256:7c29ab9bfadeff2367c298d99e8c27479823bdee114265f64beceb7547156753 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.
[
  {
    "critical": {
      "identity": {
        "docker-reference": "ghcr.io/mattmoor/apko"
      },
      "image": {
        "docker-manifest-digest": "sha256:7c29ab9bfadeff2367c298d99e8c27479823bdee114265f64beceb7547156753"
      },
      "type": "cosign container image signature"
    },
    "optional": {
      "Bundle": {
        "SignedEntryTimestamp": "MEUCIQDTou5va1Gw9AmWJNXDcpB9W+ShLZS57QWaLjWfow5LxAIgYd/VMju4MCPKyHcar6y7eQ2Gi+ubaWOJEi1eZIxXXUM=",
        "Payload": {
          "body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhYzU2N2Y2ZmQ4OTk0ZjlmMjJmYzBhNTBlNTk2NWFiOGY2ZDVlMDk0ZjY3NjQ0YjZlZmZiMTI3NjcxNmYwMzEzIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJR3pNNHJDVGRuVDZYeDRmNXBwcEJPRFJNcFdOOHNyOERDQlNpUUovNGZPY0FpQXBaVzkrRXN6c0JEdHdxYkFUeVhLejhtSkg4RFliREh3TXAwM01VQ0lYY3c9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVUkhSRU5EUVhBclowRjNTVUpCWjBsVlFVeDJWa0UzWkZGb00xSmFVV0ZzVHpkeGJEUlBVbmw2VTNWbmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1MycEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWtWM1JIZFpSRlpSVVVSRmQyaDZZVmRrZW1SSE9YbGFWRUZsUm5jd2VRcE5ha0Y1VFdwUmQwNUVRVEJOZWtaaFJuY3dlVTFxUVhsTmFsRjNUa1JGTUUxNlFtRk5RazE0UlZSQlVFSm5UbFpDUVc5VVEwaE9jRm96VGpCaU0wcHNDazFHYTNkRmQxbElTMjlhU1hwcU1FTkJVVmxKUzI5YVNYcHFNRVJCVVdORVVXZEJSVTlSZW5Fd1EyazJUalE1WVRScWQyMXFiMWhrVEdFeWQya3paV2NLY0VSWVN5dDFXV05UVlZwWVIxVkplVGg2VTIweU1sQkhhblJ4Ym05QksycFFNemxtT0d4YVNsbFpkR0V6VGtWdVNtSkxWMjVHUm1JMllVOURRV0puZHdwblowY3dUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVWhuUkVGVVFtZE9Wa2hUVlVWRVJFRkxRbWRuY2tKblJVWkNVV05FUVhwQlRVSm5UbFpJVWsxQ0NrRm1PRVZCYWtGQlRVSXdSMEV4VldSRVoxRlhRa0pUTm1aa2FHWjNOQzk0YTFWclNsTlVkelZMWkN0bFdsRjZRMXBVUVdaQ1owNVdTRk5OUlVkRVFWY0taMEpTV1hkQ05XWnJWVmRzV25Gc05ucEtRMmhyZVV4UlMzTllSaXRxUW1OQ1owNVdTRkpGUlZaVVFsUm9iRVp2WkVoU2QyTjZiM1pNTW1Sd1pFZG9NUXBaYVRWcVlqSXdkbUpYUmpCa1J6RjJZak5KZGxsWVFuSmllVGgxV2pKc01HRklWbWxNTTJSMlkyMTBiV0pIT1ROamVUbDVXbGQ0YkZsWVRteE1ibXhvQ21KWGVFRmpiVlp0WTNrNU1GbFhaSHBNTTFsM1RHcEJkVTFVUlhkSVFWbExTM2RaUWtKQlIwUjJla0ZDUWtGUlQxRXpTbXhaV0ZKc1NVWktiR0pIVm1nS1l6SlZkMDlSV1V0TGQxbENRa0ZIUkhaNlFVSkJVVkZ5WVVoU01HTklUVFpNZVRrd1lqSjBiR0pwTldoWk0xSndZakkxZWt4dFpIQmtSMmd4V1c1V2VncGFXRXBxWWpJMU1GcFhOVEJNYlU1MllsUkJaa0puYjNKQ1owVkZRVmxQTDAxQlJVZENRa1o1V2xkYWVrd3pVbWhhTTAxMlpHcEJkVTFETkhoTlZFRXlDa0puYjNKQ1owVkZRVmxQTDAxQlJVUkNRMmN4VFVkRk5FMVhUbXBhYWtac1QxUkJlRnBYUlRGT1IxWnBUbFJOZVU1dFJtaE9hazVvVFVkWmVGbFVhM2NLV1ZkRmQwNUVRVEZOUW5OSFEybHpSMEZSVVVKbk56aDNRVkZWUlVSWE1XaGtTRkowWWpJNWVVd3lSbmRoTWpoM1JXZFpTMHQzV1VKQ1FVZEVkbnBCUWdwQloxRkZZMGhXZW1GRVFVdENaMmR4YUd0cVQxQlJVVVJCZDA1dVFVUkNhMEZxUVdrcmNDdHBReTlyYzFJd1RtVXJWV3MxYkhGdWFuUnVXRWh2UzNoaENtVk9SbE4wVDBGeE1WVnpXbEoyTW1wT09HOXZXRE5OWlVNNFlsVkJlREZaVkdJNFEwMUViRGhzTkZCdmQxWmhhSEFyVjNVeWFtMWpUMUpuUkdnd2RtSUtPVVZTUVhVNWEwVkNLMFJ1U210clQybGpOMjFJVURCU2JIWlJhVzlFZFZkcmVtOVhaWGM5UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PSJ9fX19",
          "integratedTime": 1645675473,
          "logIndex": 1496617,
          "logID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
        }
      },
      "Issuer": "https://token.actions.githubusercontent.com",
      "Subject": "https://github.com/mattmoor/apko/.github/workflows/release.yaml@refs/tags/v0.0.11"
    }
  }
]
```

We can download each architecture's SBOM with:
```
$ COSIGN_EXPERIMENTAL=true cosign download sbom ghcr.io/mattmoor/apko:v0.0.11@sha256:b18f1b5bdf2ddc2e4b2d30e24c94027996a1e0702dd0c8e930c43ba1c7d44b89 |& head -10
Found SBOM of media type: text/spdx
SPDXVersion: SPDX-2.2
DataLicense: CC0-1.0
SPDXID: SPDXRef-DOCUMENT
DocumentName: chainguard.dev/apko
DocumentNamespace: http://spdx.org/spdxpackages/chainguard.dev/apko
Creator: Tool: ko 0.10.0
Created: 2021-11-24T20:19:40Z

##### Package representing chainguard.dev/apko
```

Fixes: https://github.com/chainguard-dev/apko/issues/7