### PR TITLE
update gorelease to use the sign step to sign the build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 /apko
+dist/
 
 # Test binary, built with `go test -c`
 *.test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,14 @@
+project_name: apko
+
 before:
   hooks:
     - go mod download
 
+env:
+  - COSIGN_EXPERIMENTAL=true
+
 builds:
-- id: "apko-build"
+- id: apko-build
   binary: apko
   main: ./cmd/apko/main.go
   env:
@@ -12,32 +17,36 @@ builds:
     # apko requires alpine, so only build linux binaries.
     - linux
   goarch:
-    - 386
+    - "386"
     - amd64
     - arm64
-  hooks:
-    post:
-      - sh -c "COSIGN_EXPERIMENTAL=true cosign sign-blob --output-certificate dist/apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}.crt --output-signature dist/apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sig {{ .Path }}"
+
+signs:
+  - id: apko-cosign
+    cmd: cosign
+    certificate: "${artifact}.crt"
+    args: ["sign-blob", "--output-signature", "${signature}", "--output-certificate", "${certificate}", "${artifact}"]
+    artifacts: all
 
 archives:
-- name_template: "apko_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  files:
+- files:
     - LICENSE
   wrap_in_directory: true
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
     - '^docs:'
     - '^test:'
+
 release:
   draft: false
   prerelease: true
   name_template: "Release {{ .Tag }}"
-  extra_files:
-  - glob: dist/*.crt
-  - glob: dist/*.sig


### PR DESCRIPTION
- update gorelease to use the sign step to sign the build artifacts

rehearsal: https://github.com/cpanato/apko/releases/tag/v99.99.99

my question is we will distribute the tar.gz it is not easier just the binary? otherwise, the user needs to download and unpack it just to get one file (besides the license)

follow up of https://github.com/chainguard-dev/apko/pull/15/files

cc @kaniini @mattmoor 