### PR TITLE
Read system keyring if not specified in config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-containerregistry v0.8.1-0.20220223122423-dd8d514a9b24
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	sigs.k8s.io/release-utils v0.5.0
 )
@@ -36,6 +37,7 @@ require (
 	github.com/aws/smithy-go v1.6.0 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.11.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/dimchansky/utfbom v1.1.0 // indirect
 	github.com/docker/cli v20.10.12+incompatible // indirect
@@ -49,6 +51,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect

--- a/pkg/build/apk_test.go
+++ b/pkg/build/apk_test.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemKeyringLocations(t *testing.T) {
+	dir, err := os.MkdirTemp("", "keyring-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c := Context{}
+	// Read the empty dir, passing only one empty location should err
+	_, err = c.loadSystemKeyring(dir)
+	require.Error(t, err)
+
+	// Write some dummy keyfiles
+	for _, h := range []string{"4a6a0840", "5243ef4b", "5261cecb", "6165ee59", "61666e3f"} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, fmt.Sprintf("alpine-devel@lists.alpinelinux.org-%s.rsa.pub", h)),
+			[]byte("testABC"), os.FileMode(0o644),
+		))
+	}
+
+	// Add a redme file to ensure we dont read it
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "README.txt"), []byte("testABC"), os.FileMode(0o644),
+	))
+
+	// Successful read
+	keyFiles, err := c.loadSystemKeyring(dir)
+	require.NoError(t, err)
+	require.Len(t, keyFiles, 5)
+	// should not take into account extraneous files
+	require.NotContains(t, keyFiles, filepath.Join(dir, "README.txt"))
+
+	// Unreadable directory should return error
+	require.NoError(t, os.Chmod(dir, 0o000))
+	_, err = c.loadSystemKeyring(dir)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This commit introduces a new function to read the system keyring by default instead of always requiring the user to specify it in the config file.  The purpose is to have keyring defaults that allow apko to adapt to its builder.

If the configuration file defines a set of keys, these will be used as the image keyring. If no keys are specified, apko will now try to find a key set from the building environment (currently just `/etc/apk/keys/`).

/cc @kaniini 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>