### PR TITLE
fetch APK keyring via https

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	go.lsp.dev/uri v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1126,6 +1126,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
+go.lsp.dev/uri v0.3.0 h1:KcZJmh6nFIBeJzTugn5JTU6OOyG0lDOo3R9KwTxTYbo=
+go.lsp.dev/uri v0.3.0/go.mod h1:P5sbO1IQR+qySTWOCnhnK7phBx+W3zbLqSMDJNTw88I=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -15,7 +15,9 @@
 package build
 
 import (
+	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -98,6 +100,16 @@ func (bc *Context) InitApkKeyring() (err error) {
 			data, err = os.ReadFile(element)
 			if err != nil {
 				return errors.Wrap(err, "failed to read apk key")
+			}
+		} else if asUrl.Scheme == "https" {
+			resp, err := http.Get(asUrl.String())
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch apk key")
+			}
+
+			data, err = io.ReadAll(resp.Body)
+			if err != nil {
+				return errors.Wrap(err, "failed to read apk key response")
 			}
 		} else {
 			return errors.Errorf("scheme %s not supported", asUrl.Scheme)

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -110,6 +110,11 @@ func (bc *Context) InitApkKeyring() (err error) {
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch apk key")
 			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode < 200 || resp.StatusCode > 299 {
+				return errors.New("failed to fetch apk key: http response indicated error")
+			}
 
 			data, err = io.ReadAll(resp.Body)
 			if err != nil {

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -89,6 +89,9 @@ func (bc *Context) InitApkKeyring() (err error) {
 	for _, element := range keyFiles {
 		log.Printf("installing key %v", element)
 
+		// Normalize the element as a URI, so that local paths
+		// are translated into file:// URLs, allowing them to be parsed
+		// into a url.URL{}.
 		asURI := uri.New(element)
 		asURL, err := url.Parse(string(asURI))
 		if err != nil {

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -89,20 +89,21 @@ func (bc *Context) InitApkKeyring() (err error) {
 	for _, element := range keyFiles {
 		log.Printf("installing key %v", element)
 
-		asUri := uri.New(element)
-		asUrl, err := url.Parse(string(asUri))
+		asURI := uri.New(element)
+		asURL, err := url.Parse(string(asURI))
 		if err != nil {
 			return errors.Wrap(err, "failed to parse key as URI")
 		}
 
 		var data []byte
-		if asUrl.Scheme == "file" {
+		switch asURL.Scheme {
+		case "file":
 			data, err = os.ReadFile(element)
 			if err != nil {
 				return errors.Wrap(err, "failed to read apk key")
 			}
-		} else if asUrl.Scheme == "https" {
-			resp, err := http.Get(asUrl.String())
+		case "https":
+			resp, err := http.Get(asURL.String())
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch apk key")
 			}
@@ -111,8 +112,8 @@ func (bc *Context) InitApkKeyring() (err error) {
 			if err != nil {
 				return errors.Wrap(err, "failed to read apk key response")
 			}
-		} else {
-			return errors.Errorf("scheme %s not supported", asUrl.Scheme)
+		default:
+			return errors.Errorf("scheme %s not supported", asURL.Scheme)
 		}
 
 		// #nosec G306 -- apk keyring must be publicly readable


### PR DESCRIPTION
Add support for fetching an APK keyring via https.  Closes #27.