### PR TITLE
Small nitpicks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
+	go.lsp.dev/uri v0.3.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	sigs.k8s.io/release-utils v0.5.0
@@ -57,7 +58,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
-	go.lsp.dev/uri v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -73,7 +73,8 @@ func (*Context) loadSystemKeyring(locations ...string) ([]string, error) {
 func (bc *Context) InitApkKeyring() (err error) {
 	log.Printf("initializing apk keyring")
 
-	if err := os.MkdirAll(bc.WorkDir+"/etc/apk/keys", 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(bc.WorkDir, "etc/apk/keys"),
+		0755); err != nil {
 		return errors.Wrap(err, "failed to make keys dir")
 	}
 
@@ -125,7 +126,8 @@ func (bc *Context) InitApkKeyring() (err error) {
 		}
 
 		// #nosec G306 -- apk keyring must be publicly readable
-		if err := os.WriteFile(bc.WorkDir+"/"+element, data, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(bc.WorkDir, element), data,
+			0644); err != nil {
 			return errors.Wrap(err, "failed to write apk key")
 		}
 	}
@@ -140,7 +142,8 @@ func (bc *Context) InitApkRepositories() error {
 	data := strings.Join(bc.ImageConfiguration.Contents.Repositories, "\n")
 
 	// #nosec G306 -- apk repositories must be publicly readable
-	err := os.WriteFile(bc.WorkDir+"/etc/apk/repositories", []byte(data), 0644)
+	err := os.WriteFile(filepath.Join(bc.WorkDir, "etc/apk/repositories"),
+		[]byte(data), 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to write apk repositories list")
 	}
@@ -155,7 +158,8 @@ func (bc *Context) InitApkWorld() error {
 	data := strings.Join(bc.ImageConfiguration.Contents.Packages, "\n")
 
 	// #nosec G306 -- apk world must be publicly readable
-	err := os.WriteFile(bc.WorkDir+"/etc/apk/world", []byte(data), 0644)
+	err := os.WriteFile(filepath.Join(bc.WorkDir, "etc/apk/world"),
+		[]byte(data), 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to write apk world")
 	}

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -46,7 +46,7 @@ func (bc *Context) InitApkDB() error {
 // directory by trying some common locations. These can be overridden
 // by passing one or more directories as arguments.
 func (*Context) loadSystemKeyring(locations ...string) ([]string, error) {
-	ring := []string{}
+	var ring []string
 	if len(locations) == 0 {
 		locations = systemKeyringLocations
 	}


### PR DESCRIPTION
I've replaced concats with `filepath.Join()` since it's used in other places throughout project

Signed-off-by: panekj <me@panekj.dev>