### PR TITLE
refactor: more verbose image configuration summary

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -33,9 +33,10 @@ type Context struct {
 
 func (bc *Context) Summarize() {
 	log.Printf("build context:")
-	log.Printf("  image configuration: %v", bc.ImageConfiguration)
-	log.Printf("  working directory: %v", bc.WorkDir)
-	log.Printf("  tarball path: %v", bc.TarballPath)
+	log.Printf("  working directory: %s", bc.WorkDir)
+	log.Printf("  tarball path: %s", bc.TarballPath)
+	log.Printf("  use proot: %t", bc.UseProot)
+	bc.ImageConfiguration.Summarize()
 }
 
 func (bc *Context) BuildTarball() (string, error) {

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"log"
 	"os"
 
 	"github.com/pkg/errors"
@@ -78,4 +79,20 @@ func (ic *ImageConfiguration) ValidateServiceBundle() error {
 	ic.Contents.Packages = append(ic.Contents.Packages, "s6")
 
 	return nil
+}
+
+func (ic *ImageConfiguration) Summarize() {
+	log.Printf("image configuration:")
+	log.Printf("  contents:")
+	log.Printf("    repositories: %v", ic.Contents.Repositories)
+	log.Printf("    keyring:      %v", ic.Contents.Keyring)
+	log.Printf("    packages:     %v", ic.Contents.Packages)
+	log.Printf("  entrypoint:")
+	log.Printf("    type:    %s", ic.Entrypoint.Type)
+	log.Printf("    cmd:     %s", ic.Entrypoint.Command)
+	log.Printf("    service: %s", ic.Entrypoint.Services)
+	log.Printf("  accounts:")
+	log.Printf("    runas:  %s", ic.Accounts.RunAs)
+	log.Printf("    users:  %v", ic.Accounts.Users)
+	log.Printf("    groups: %v", ic.Accounts.Groups)
 }

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -87,12 +87,16 @@ func (ic *ImageConfiguration) Summarize() {
 	log.Printf("    repositories: %v", ic.Contents.Repositories)
 	log.Printf("    keyring:      %v", ic.Contents.Keyring)
 	log.Printf("    packages:     %v", ic.Contents.Packages)
-	log.Printf("  entrypoint:")
-	log.Printf("    type:    %s", ic.Entrypoint.Type)
-	log.Printf("    cmd:     %s", ic.Entrypoint.Command)
-	log.Printf("    service: %s", ic.Entrypoint.Services)
-	log.Printf("  accounts:")
-	log.Printf("    runas:  %s", ic.Accounts.RunAs)
-	log.Printf("    users:  %v", ic.Accounts.Users)
-	log.Printf("    groups: %v", ic.Accounts.Groups)
+	if ic.Entrypoint.Type != "" || ic.Entrypoint.Command != "" || len(ic.Entrypoint.Services) != 0 {
+		log.Printf("  entrypoint:")
+		log.Printf("    type:    %s", ic.Entrypoint.Type)
+		log.Printf("    cmd:     %s", ic.Entrypoint.Command)
+		log.Printf("    service: %v", ic.Entrypoint.Services)
+	}
+	if ic.Accounts.RunAs != "" || len(ic.Accounts.Users) != 0 || len(ic.Accounts.Groups) != 0 {
+		log.Printf("  accounts:")
+		log.Printf("    runas:  %s", ic.Accounts.RunAs)
+		log.Printf("    users:  %v", ic.Accounts.Users)
+		log.Printf("    groups: %v", ic.Accounts.Groups)
+	}
 }


### PR DESCRIPTION
Using https://github.com/distroless/alpine-base/blob/557cec6bd879f417e9fe781220218d684b592c85/.apko.yaml#L1-L6

Before:
```
2022/03/04 15:28:57 build context:                                                                                                                                                     
2022/03/04 15:28:57   image configuration: {{[http://dl-cdn.alpinelinux.org/alpine/edge/main] [] [alpine-base busybox-ifupdown]} {  map[]} { [] []}}
2022/03/04 15:28:57   working directory: /tmp/apko-1603924079
2022/03/04 15:28:57   tarball path:
```

After:
```
2022/03/04 15:28:57 build context:
2022/03/04 15:28:57   working directory: /tmp/apko-3530778821
2022/03/04 15:28:57   tarball path:
2022/03/04 15:28:57   use proot: false
2022/03/04 15:28:57 image configuration:
2022/03/04 15:28:57   contents:
2022/03/04 15:28:57     repositories: [http://dl-cdn.alpinelinux.org/alpine/edge/main]
2022/03/04 15:28:57     keyring:      []
2022/03/04 15:28:57     packages:     [alpine-base busybox-ifupdown]
2022/03/04 15:28:57   entrypoint:
2022/03/04 15:28:57     type:
2022/03/04 15:28:57     cmd:
2022/03/04 15:28:57     service: map[]
2022/03/04 15:28:57   accounts:
2022/03/04 15:28:57     runas:
2022/03/04 15:28:57     users:  []
2022/03/04 15:28:57     groups: []
```
