### PR TITLE
Multiarch support

### DIFF
--- a/config/task.yaml
+++ b/config/task.yaml
@@ -44,6 +44,7 @@ spec:
       args:
       - publish
       - --image-refs=/tekton/results/IMAGES
+      - --arch=x86_64
       - $(params["path"])
       - $(params["dev.mink.images.target"])
 

--- a/examples/alpine-base-rootless.yaml
+++ b/examples/alpine-base-rootless.yaml
@@ -1,12 +1,6 @@
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
-  keyring:
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
   packages:
     - alpine-base
 

--- a/examples/alpine-base.yaml
+++ b/examples/alpine-base.yaml
@@ -1,12 +1,6 @@
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
-  keyring:
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
   packages:
     - alpine-base
 

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -1,12 +1,6 @@
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
-  keyring:
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
-    - /etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
   packages:
     - alpine-baselayout
     - nginx

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220216180153-3d7835abdf40
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.1-0.20220223122423-dd8d514a9b24
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -35,6 +35,7 @@ type Context struct {
 	Assertions         []Assertion
 	WantSBOM           bool
 	SBOMPath           string
+	Arch               types.Architecture
 }
 
 func (bc *Context) Summarize() {
@@ -44,6 +45,7 @@ func (bc *Context) Summarize() {
 	log.Printf("  use proot: %t", bc.UseProot)
 	log.Printf("  source date: %s", bc.SourceDateEpoch)
 	log.Printf("  SBOM output path: %s", bc.SBOMPath)
+	log.Printf("  arch: %v", bc.Arch.ToAPK())
 	bc.ImageConfiguration.Summarize()
 }
 
@@ -212,6 +214,14 @@ func WithSBOM(path string) Option {
 func WithImageConfiguration(ic types.ImageConfiguration) Option {
 	return func(bc *Context) error {
 		bc.ImageConfiguration = ic
+		return nil
+	}
+}
+
+// WithArch sets the architecture for the build context.
+func WithArch(arch types.Architecture) Option {
+	return func(bc *Context) error {
+		bc.Arch = arch
 		return nil
 	}
 }

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -132,7 +132,7 @@ func publishTagFromImage(image v1.Image, imageRef string, hash v1.Hash) (name.Di
 		return name.Digest{}, fmt.Errorf("unable to parse reference: %w", err)
 	}
 
-	if err := remote.Write(imgRef, image, remote.WithAuthFromKeychain(kc)); err != nil {
+	if err := remote.Write(imgRef, image, remote.WithAuthFromKeychain(keychain)); err != nil {
 		return name.Digest{}, fmt.Errorf("failed to publish: %w", err)
 	}
 	return imgRef.Context().Digest(hash.String()), nil

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"runtime"
 	"time"
 
 	"chainguard.dev/apko/pkg/build/types"
@@ -35,7 +34,15 @@ import (
 	v1tar "github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time) (v1.Image, error) {
+var keychain = authn.NewMultiKeychain(
+	authn.DefaultKeychain,
+	google.Keychain,
+	authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogOutput(ioutil.Discard))),
+	authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
+	github.Keychain,
+)
+
+func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture) (v1.Image, error) {
 	log.Printf("building OCI image from layer '%s'", layerTarGZ)
 
 	v1Layer, err := v1tar.LayerFromFile(layerTarGZ)
@@ -79,8 +86,8 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 
 	cfg = cfg.DeepCopy()
 	cfg.Author = "github.com/chainguard-dev/apko"
-	cfg.Architecture = runtime.GOARCH
-	cfg.OS = runtime.GOOS
+	cfg.Architecture = string(arch)
+	cfg.OS = "linux"
 
 	if ic.Entrypoint.Command != "" {
 		cfg.Config.Entrypoint = []string{"/bin/sh", "-c", ic.Entrypoint.Command}
@@ -100,8 +107,8 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 	return v1Image, nil
 }
 
-func BuildImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time) error {
-	v1Image, err := buildImageFromLayer(layerTarGZ, ic, created)
+func BuildImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture) error {
+	v1Image, err := buildImageFromLayer(layerTarGZ, ic, created, arch)
 	if err != nil {
 		return err
 	}
@@ -119,7 +126,7 @@ func BuildImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ 
 	return nil
 }
 
-func publishTagFromImage(image v1.Image, imageRef string, hash v1.Hash, kc authn.Keychain) (name.Digest, error) {
+func publishTagFromImage(image v1.Image, imageRef string, hash v1.Hash) (name.Digest, error) {
 	imgRef, err := name.ParseReference(imageRef)
 	if err != nil {
 		return name.Digest{}, fmt.Errorf("unable to parse reference: %w", err)
@@ -131,33 +138,93 @@ func publishTagFromImage(image v1.Image, imageRef string, hash v1.Hash, kc authn
 	return imgRef.Context().Digest(hash.String()), nil
 }
 
-func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, tags ...string) (name.Digest, error) {
-	v1Image, err := buildImageFromLayer(layerTarGZ, ic, created)
+func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, tags ...string) (name.Digest, v1.Image, error) {
+	v1Image, err := buildImageFromLayer(layerTarGZ, ic, created, arch)
 	if err != nil {
-		return name.Digest{}, err
+		return name.Digest{}, nil, err
 	}
 
 	h, err := v1Image.Digest()
 	if err != nil {
-		return name.Digest{}, fmt.Errorf("failed to compute digest: %w", err)
+		return name.Digest{}, nil, fmt.Errorf("failed to compute digest: %w", err)
 	}
-
-	kc := authn.NewMultiKeychain(
-		authn.DefaultKeychain,
-		google.Keychain,
-		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogOutput(ioutil.Discard))),
-		authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
-		github.Keychain,
-	)
 
 	digest := name.Digest{}
 	for _, tag := range tags {
 		log.Printf("publishing tag %v", tag)
-		digest, err = publishTagFromImage(v1Image, tag, h, kc)
+		digest, err = publishTagFromImage(v1Image, tag, h)
+		if err != nil {
+			return name.Digest{}, nil, err
+		}
+	}
+
+	return digest, v1Image, nil
+}
+
+func PublishIndex(imgs []v1.Image, tags ...string) (name.Digest, error) {
+	var idx v1.ImageIndex = empty.Index
+	for _, img := range imgs {
+		mt, err := img.MediaType()
+		if err != nil {
+			return name.Digest{}, fmt.Errorf("failed to get mediatype: %w", err)
+		}
+
+		h, err := img.Digest()
+		if err != nil {
+			return name.Digest{}, fmt.Errorf("failed to compute digest: %w", err)
+		}
+
+		size, err := img.Size()
+		if err != nil {
+			return name.Digest{}, fmt.Errorf("failed to compute size: %w", err)
+		}
+
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			return name.Digest{}, fmt.Errorf("failed to get config file: %w", err)
+		}
+		plat := v1.Platform{
+			OS:           cfg.OS,
+			Architecture: cfg.Architecture,
+		}
+
+		idx = mutate.AppendManifests(idx, mutate.IndexAddendum{
+			Add: img,
+			Descriptor: v1.Descriptor{
+				MediaType: mt,
+				Digest:    h,
+				Size:      size,
+				Platform:  &plat,
+			},
+		})
+	}
+
+	h, err := idx.Digest()
+	if err != nil {
+		return name.Digest{}, err
+	}
+
+	digest := name.Digest{}
+	for _, tag := range tags {
+		log.Printf("publishing tag %v", tag)
+		digest, err = publishTagFromIndex(idx, tag, h)
 		if err != nil {
 			return name.Digest{}, err
 		}
 	}
 
 	return digest, nil
+}
+
+func publishTagFromIndex(index v1.ImageIndex, imageRef string, hash v1.Hash) (name.Digest, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return name.Digest{}, fmt.Errorf("unable to parse reference: %w", err)
+	}
+
+	err = remote.WriteIndex(ref, index, remote.WithAuthFromKeychain(keychain))
+	if err != nil {
+		return name.Digest{}, fmt.Errorf("failed to publish: %w", err)
+	}
+	return ref.Context().Digest(hash.String()), nil
 }

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -14,6 +14,8 @@
 
 package types
 
+import "sort"
+
 type User struct {
 	UserName string
 	UID      uint32
@@ -44,4 +46,56 @@ type ImageConfiguration struct {
 		Users  []User
 		Groups []Group
 	}
+	Archs []Architecture
+}
+
+type Architecture string
+
+const (
+	amd64   Architecture = "amd64"
+	arm64   Architecture = "arm64"
+	ppc64le Architecture = "ppc64le"
+	s390x   Architecture = "s390x"
+	_386    Architecture = "386"
+	riscv64 Architecture = "riscv64"
+	// TODO: armv7 and armhf (av6)
+)
+
+var AllArchs = []Architecture{amd64, arm64, ppc64le, s390x, _386, riscv64}
+
+func (a Architecture) ToAPK() string {
+	switch a {
+	case _386:
+		return "x86"
+	case amd64:
+		return "x86_64"
+	case arm64:
+		return "aarch64"
+	default:
+		return string(a)
+	}
+}
+
+func ParseArchitectures(in []string) []Architecture {
+	uniq := map[Architecture]struct{}{}
+	for _, s := range in {
+		a := Architecture(s)
+		switch s {
+		case "x86":
+			a = _386
+		case "x86_64":
+			a = amd64
+		case "aarch64":
+			a = arm64
+		}
+		uniq[a] = struct{}{}
+	}
+	archs := make([]Architecture, 0, len(uniq))
+	for k := range uniq {
+		archs = append(archs, k)
+	}
+	sort.Slice(archs, func(i, j int) bool {
+		return i < j
+	})
+	return archs
 }

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -49,6 +49,7 @@ type ImageConfiguration struct {
 	Archs []Architecture
 }
 
+// Architecture represents a CPU architecture for the container image.
 type Architecture string
 
 const (
@@ -61,8 +62,11 @@ const (
 	// TODO: armv7 and armhf (av6)
 )
 
+// AllArchs contains the standard set of supported architectures, which are
+// used by `apko publish` when no architectures are specified.
 var AllArchs = []Architecture{amd64, arm64, ppc64le, s390x, _386, riscv64}
 
+// ToAPK returns the apk-style equivalent string for the Architecture.
 func (a Architecture) ToAPK() string {
 	switch a {
 	case _386:
@@ -76,6 +80,12 @@ func (a Architecture) ToAPK() string {
 	}
 }
 
+// ParseArchitectures parses architecture values in string form, and returns
+// the equivalent slice of Architectures.
+//
+// apk-style arch strings (e.g., "x86_64") are converted to the OCI-style
+// equivalent ("amd64"). Values are deduped, and the resulting slice is sorted
+// for reproducibility.
 func ParseArchitectures(in []string) []Architecture {
 	uniq := map[Architecture]struct{}{}
 	for _, s := range in {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -105,7 +105,7 @@ func ParseArchitectures(in []string) []Architecture {
 		archs = append(archs, k)
 	}
 	sort.Slice(archs, func(i, j int) bool {
-		return i < j
+		return archs[i] < archs[j]
 	})
 	return archs
 }

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseArchitectures(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+		in   []string
+		want []Architecture
+	}{{
+		desc: "empty",
+		in:   []string{},
+		want: []Architecture{},
+	}, {
+		desc: "sort",
+		in:   []string{"riscv64", "amd64"},
+		want: []Architecture{amd64, riscv64},
+	}, {
+		desc: "dedupe",
+		in:   []string{"amd64", "amd64", "arm64"},
+		want: []Architecture{amd64, arm64},
+	}, {
+		desc: "dedupe w/ apk style",
+		in:   []string{"x86_64", "amd64", "arm64"},
+		want: []Architecture{amd64, arm64},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := ParseArchitectures(c.in)
+			if d := cmp.Diff(got, c.want); d != "" {
+				t.Fatal("Got diff (-got,+want):", d)
+			}
+		})
+	}
+}

--- a/pkg/cli/build-minirootfs.go
+++ b/pkg/cli/build-minirootfs.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 
 	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
 	"github.com/spf13/cobra"
 )
 
@@ -64,6 +66,12 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 	if err != nil {
 		return err
 	}
+
+	arch := types.Architecture(runtime.GOARCH)
+	if len(bc.ImageConfiguration.Archs) != 0 {
+		log.Printf("WARNING: ignoring archs in config, only building for current arch (%s)", arch)
+	}
+	bc.Arch = arch
 
 	log.Printf("building minirootfs '%s'", bc.TarballPath)
 

--- a/pkg/cli/publish.go
+++ b/pkg/cli/publish.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -93,7 +94,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	var digest name.Digest
 	switch len(bc.ImageConfiguration.Archs) {
 	case 0:
-		return fmt.Errorf("no archs requested: %w", err)
+		return errors.New("no archs requested")
 	case 1:
 		bc.Arch = bc.ImageConfiguration.Archs[0]
 		layerTarGZ, err := bc.BuildLayer()


### PR DESCRIPTION
`apko publish` produces a multiarch image index. By default, this includes six common archs, which can be overridden with `archs:` in the image config YAML, or values in the `--arch` flag (in increasing order of preference).

An attempt is made to accept both apk-style arch strings ("x86_86") and OCI-style arch strings ("amd64"), but more could probably be done. There's a TODO to support armv7 and armhf (arm/v7 and arm/v6 respectively, in OCI terms).

apk keys are extracted from arch-specific locations (e.g., `/usr/share/apk/keys/s390x/*`) and placed in the standard location (`/etc/apk/keys/*`).

`apko build` and `apko build-minirootfs` both only produce a single arch's tarball, for the current runtime arch. If the image config specifies archs in this case, a warning is logged to avoid confusion.