### PR TITLE
refactor: add build.New and proper documentation to build options

### DIFF
--- a/pkg/cli/build-minirootfs.go
+++ b/pkg/cli/build-minirootfs.go
@@ -57,14 +57,9 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 	}
 	defer os.RemoveAll(wd)
 
-	bc := build.Context{
-		WorkDir: wd,
-	}
-
-	for _, opt := range opts {
-		if err := opt(&bc); err != nil {
-			return err
-		}
+	bc, err := build.New(wd, opts...)
+	if err != nil {
+		return err
 	}
 
 	log.Printf("building minirootfs '%s'", bc.TarballPath)

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -62,14 +62,9 @@ func BuildCmd(ctx context.Context, imageRef string, outputTarGZ string, opts ...
 	}
 	defer os.RemoveAll(wd)
 
-	bc := build.Context{
-		WorkDir: wd,
-	}
-
-	for _, opt := range opts {
-		if err := opt(&bc); err != nil {
-			return err
-		}
+	bc, err := build.New(wd, opts...)
+	if err != nil {
+		return err
 	}
 
 	log.Printf("building image '%s'", imageRef)

--- a/pkg/cli/publish.go
+++ b/pkg/cli/publish.go
@@ -67,14 +67,9 @@ func PublishCmd(ctx context.Context, outputRefs string, opts ...build.Option) er
 	}
 	defer os.RemoveAll(wd)
 
-	bc := build.Context{
-		WorkDir: wd,
-	}
-
-	for _, opt := range opts {
-		if err := opt(&bc); err != nil {
-			return err
-		}
+	bc, err := build.New(wd, opts...)
+	if err != nil {
+		return err
 	}
 
 	log.Printf("building tags %v", bc.Tags)


### PR DESCRIPTION
comments are using the godoc convention so they should appear on https://pkg.go.dev/.

A new function (`New`) was added to provide a consistent way of creating a build contex (should help with https://github.com/chainguard-dev/apko/issues/46)

Finally, `SOURCE_DATE_EPOCH` is no longer ignored if you don't pass a `WithBuildDate` option (that should be consistent with the spec).