### PR TITLE
style: Prefer if-err style wherever possible

### DIFF
--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -69,8 +69,7 @@ func (bc *Context) MutateAccounts() error {
 			gf.Entries = appendGroup(gf.Entries, g)
 		}
 
-		err = gf.WriteFile(path)
-		if err != nil {
+		if err := gf.WriteFile(path); err != nil {
 			return err
 		}
 
@@ -90,8 +89,7 @@ func (bc *Context) MutateAccounts() error {
 			uf.Entries = appendUser(uf.Entries, u)
 		}
 
-		err = uf.WriteFile(path)
-		if err != nil {
+		if err := uf.WriteFile(path); err != nil {
 			return err
 		}
 

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -163,9 +163,8 @@ func (bc *Context) InitApkRepositories() error {
 	data := strings.Join(bc.ImageConfiguration.Contents.Repositories, "\n")
 
 	// #nosec G306 -- apk repositories must be publicly readable
-	err := os.WriteFile(filepath.Join(bc.WorkDir, "etc", "apk", "repositories"),
-		[]byte(data), 0644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(bc.WorkDir, "etc", "apk", "repositories"),
+		[]byte(data), 0644); err != nil {
 		return fmt.Errorf("failed to write apk repositories list: %w", err)
 	}
 
@@ -179,9 +178,8 @@ func (bc *Context) InitApkWorld() error {
 	data := strings.Join(bc.ImageConfiguration.Contents.Packages, "\n")
 
 	// #nosec G306 -- apk world must be publicly readable
-	err := os.WriteFile(filepath.Join(bc.WorkDir, "etc", "apk", "world"),
-		[]byte(data), 0644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(bc.WorkDir, "etc", "apk", "world"),
+		[]byte(data), 0644); err != nil {
 		return fmt.Errorf("failed to write apk world: %w", err)
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -57,8 +57,7 @@ func (bc *Context) BuildTarball() (string, error) {
 	}
 	defer outfile.Close()
 
-	err = tarball.WriteArchive(bc.WorkDir, outfile, bc.SourceDateEpoch)
-	if err != nil {
+	if err := tarball.WriteArchive(bc.WorkDir, outfile, bc.SourceDateEpoch); err != nil {
 		return "", fmt.Errorf("failed to generate tarball for image: %w", err)
 	}
 
@@ -70,8 +69,7 @@ func (bc *Context) BuildLayer() (string, error) {
 	bc.Summarize()
 
 	// build image filesystem
-	err := bc.BuildImage()
-	if err != nil {
+	if err := bc.BuildImage(); err != nil {
 		return "", err
 	}
 

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -27,40 +27,35 @@ import (
 // Builds the image in Context.WorkDir.
 func (bc *Context) BuildImage() error {
 	log.Printf("doing pre-flight checks")
-	err := bc.ImageConfiguration.Validate()
-	if err != nil {
+	if err := bc.ImageConfiguration.Validate(); err != nil {
 		return fmt.Errorf("failed to validate configuration: %w", err)
 	}
 
 	log.Printf("building image fileystem in %s", bc.WorkDir)
 
 	// initialize apk
-	err = bc.InitApkDB()
-	if err != nil {
+	if err := bc.InitApkDB(); err != nil {
 		return fmt.Errorf("failed to initialize apk database: %w", err)
 	}
 
 	var eg errgroup.Group
 
 	eg.Go(func() error {
-		err = bc.InitApkKeyring()
-		if err != nil {
+		if err := bc.InitApkKeyring(); err != nil {
 			return fmt.Errorf("failed to initialize apk keyring: %w", err)
 		}
 		return nil
 	})
 
 	eg.Go(func() error {
-		err = bc.InitApkRepositories()
-		if err != nil {
+		if err := bc.InitApkRepositories(); err != nil {
 			return fmt.Errorf("failed to initialize apk repositories: %w", err)
 		}
 		return nil
 	})
 
 	eg.Go(func() error {
-		err = bc.InitApkWorld()
-		if err != nil {
+		if err := bc.InitApkWorld(); err != nil {
 			return fmt.Errorf("failed to initialize apk world: %w", err)
 		}
 		return nil
@@ -71,8 +66,7 @@ func (bc *Context) BuildImage() error {
 	}
 
 	// sync reality with desired apk world
-	err = bc.FixateApkWorld()
-	if err != nil {
+	if err := bc.FixateApkWorld(); err != nil {
 		return fmt.Errorf("failed to fixate apk world: %w", err)
 	}
 
@@ -84,7 +78,7 @@ func (bc *Context) BuildImage() error {
 	})
 
 	eg.Go(func() error {
-		if err = bc.MutateAccounts(); err != nil {
+		if err := bc.MutateAccounts(); err != nil {
 			return fmt.Errorf("failed to mutate accounts: %w", err)
 		}
 		return nil
@@ -96,15 +90,13 @@ func (bc *Context) BuildImage() error {
 
 	// maybe install busybox symlinks
 	if bc.UseProot {
-		err = bc.InstallBusyboxSymlinks()
-		if err != nil {
+		if err := bc.InstallBusyboxSymlinks(); err != nil {
 			return fmt.Errorf("failed to install busybox symlinks: %w", err)
 		}
 	}
 
 	// write service supervision tree
-	err = bc.WriteSupervisionTree()
-	if err != nil {
+	if err := bc.WriteSupervisionTree(); err != nil {
 		return fmt.Errorf("failed to write supervision tree: %w", err)
 	}
 
@@ -126,8 +118,7 @@ func (bc *Context) InstallBusyboxSymlinks() error {
 	}
 
 	// use proot + qemu to run the installer
-	err = bc.ExecuteChroot("/bin/busybox", "--install", "-s")
-	if err != nil {
+	if err := bc.ExecuteChroot("/bin/busybox", "--install", "-s"); err != nil {
 		return fmt.Errorf("failed to install busybox symlinks: %w", err)
 	}
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -111,8 +111,7 @@ func BuildImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ 
 		return fmt.Errorf("unable to validate image reference tag: %w", err)
 	}
 
-	err = v1tar.WriteToFile(outputTarGZ, imgRefTag, v1Image)
-	if err != nil {
+	if err := v1tar.WriteToFile(outputTarGZ, imgRefTag, v1Image); err != nil {
 		return fmt.Errorf("unable to write OCI image to disk: %w", err)
 	}
 
@@ -126,8 +125,7 @@ func publishTagFromImage(image v1.Image, imageRef string, hash v1.Hash, kc authn
 		return name.Digest{}, fmt.Errorf("unable to parse reference: %w", err)
 	}
 
-	err = remote.Write(imgRef, image, remote.WithAuthFromKeychain(kc))
-	if err != nil {
+	if err := remote.Write(imgRef, image, remote.WithAuthFromKeychain(kc)); err != nil {
 		return name.Digest{}, fmt.Errorf("failed to publish: %w", err)
 	}
 	return imgRef.Context().Digest(hash.String()), nil

--- a/pkg/build/supervision_tree.go
+++ b/pkg/build/supervision_tree.go
@@ -26,8 +26,7 @@ func (bc *Context) CreateSupervisionDirectory(name string) (string, error) {
 	svcdir := filepath.Join(bc.WorkDir, "sv", name)
 	log.Printf("  supervision dir: %s", svcdir)
 
-	err := os.MkdirAll(svcdir, 0755)
-	if err != nil {
+	if err := os.MkdirAll(svcdir, 0755); err != nil {
 		return svcdir, fmt.Errorf("could not make supervision directory: %w", err)
 	}
 
@@ -41,8 +40,7 @@ func (bc *Context) WriteSupervisionTemplate(svcdir string, command string) error
 	}
 	defer file.Close()
 
-	err = os.Chmod(file.Name(), 0755)
-	if err != nil {
+	if err := os.Chmod(file.Name(), 0755); err != nil {
 		return fmt.Errorf("could not set permissions on runfile: %w", err)
 	}
 
@@ -59,8 +57,7 @@ func (bc *Context) WriteSupervisionServiceSimple(name string, command string) er
 		return err
 	}
 
-	err = bc.WriteSupervisionTemplate(svcdir, command)
-	if err != nil {
+	if err := bc.WriteSupervisionTemplate(svcdir, command); err != nil {
 		return err
 	}
 
@@ -78,8 +75,7 @@ func (bc *Context) WriteSupervisionTree() error {
 		}
 
 		if svccmd, ok := descriptor.(string); ok {
-			err := bc.WriteSupervisionServiceSimple(service, svccmd)
-			if err != nil {
+			if err := bc.WriteSupervisionServiceSimple(service, svccmd); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -29,8 +29,7 @@ func (ic *ImageConfiguration) Load(imageConfigPath string) error {
 		return fmt.Errorf("failed to read image configuration file: %w", err)
 	}
 
-	err = yaml.Unmarshal(data, ic)
-	if err != nil {
+	if err := yaml.Unmarshal(data, ic); err != nil {
 		return fmt.Errorf("failed to parse image configuration: %w", err)
 	}
 
@@ -40,8 +39,7 @@ func (ic *ImageConfiguration) Load(imageConfigPath string) error {
 // Do preflight checks and mutations on an image configuration.
 func (ic *ImageConfiguration) Validate() error {
 	if ic.Entrypoint.Type == "service-bundle" {
-		err := ic.ValidateServiceBundle()
-		if err != nil {
+		if err := ic.ValidateServiceBundle(); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -75,8 +75,7 @@ func BuildCmd(ctx context.Context, imageRef string, outputTarGZ string, opts ...
 	}
 	defer os.Remove(layerTarGZ)
 
-	err = oci.BuildImageTarballFromLayer(imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.SourceDateEpoch)
-	if err != nil {
+	if err := oci.BuildImageTarballFromLayer(imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.SourceDateEpoch); err != nil {
 		return fmt.Errorf("failed to build OCI image: %w", err)
 	}
 

--- a/pkg/cli/publish.go
+++ b/pkg/cli/publish.go
@@ -40,13 +40,12 @@ in a keychain.`,
 		Example: `  apko publish <config.yaml> <tag...>`,
 		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := PublishCmd(cmd.Context(), imageRefs,
+			if err := PublishCmd(cmd.Context(), imageRefs,
 				build.WithConfig(args[0]),
 				build.WithProot(useProot),
 				build.WithTags(args[1:]...),
 				build.WithBuildDate(buildDate),
-			)
-			if err != nil {
+			); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/passwd/group.go
+++ b/pkg/passwd/group.go
@@ -46,8 +46,7 @@ func ReadGroupFile(filePath string) (GroupFile, error) {
 	}
 	defer file.Close()
 
-	err = gf.Load(file)
-	if err != nil {
+	if err := gf.Load(file); err != nil {
 		return gf, err
 	}
 
@@ -60,8 +59,7 @@ func (gf *GroupFile) Load(r io.Reader) error {
 	for scanner.Scan() {
 		ge := GroupEntry{}
 
-		err := ge.Parse(scanner.Text())
-		if err != nil {
+		if err := ge.Parse(scanner.Text()); err != nil {
 			return fmt.Errorf("unable to parse: %w", err)
 		}
 
@@ -89,8 +87,7 @@ func (gf *GroupFile) WriteFile(filePath string) error {
 // Write an /etc/passwd file into an io.Writer.
 func (gf *GroupFile) Write(w io.Writer) error {
 	for _, ge := range gf.Entries {
-		err := ge.Write(w)
-		if err != nil {
+		if err := ge.Write(w); err != nil {
 			return fmt.Errorf("unable to write group entry: %w", err)
 		}
 	}

--- a/pkg/passwd/group_test.go
+++ b/pkg/passwd/group_test.go
@@ -43,8 +43,7 @@ func TestGroupWriter(t *testing.T) {
 	}
 
 	w := &bytes.Buffer{}
-	err = gf.Write(w)
-	if err != nil {
+	if err := gf.Write(w); err != nil {
 		t.Errorf("error while writing; %v", err)
 	}
 
@@ -53,8 +52,7 @@ func TestGroupWriter(t *testing.T) {
 	gf2.Load(r)
 
 	w2 := &bytes.Buffer{}
-	err = gf2.Write(w2)
-	if err != nil {
+	if err := gf2.Write(w2); err != nil {
 		t.Errorf("error while writing; %v", err)
 	}
 

--- a/pkg/passwd/passwd.go
+++ b/pkg/passwd/passwd.go
@@ -49,8 +49,7 @@ func ReadUserFile(filePath string) (UserFile, error) {
 	}
 	defer file.Close()
 
-	err = uf.Load(file)
-	if err != nil {
+	if err := uf.Load(file); err != nil {
 		return uf, err
 	}
 
@@ -63,8 +62,7 @@ func (uf *UserFile) Load(r io.Reader) error {
 	for scanner.Scan() {
 		ue := UserEntry{}
 
-		err := ue.Parse(scanner.Text())
-		if err != nil {
+		if err := ue.Parse(scanner.Text()); err != nil {
 			return fmt.Errorf("unable to parse: %w", err)
 		}
 
@@ -92,8 +90,7 @@ func (uf *UserFile) WriteFile(filePath string) error {
 // Write an /etc/passwd file into an io.Writer.
 func (uf *UserFile) Write(w io.Writer) error {
 	for _, ue := range uf.Entries {
-		err := ue.Write(w)
-		if err != nil {
+		if err := ue.Write(w); err != nil {
 			return fmt.Errorf("unable to write passwd entry: %w", err)
 		}
 	}

--- a/pkg/passwd/passwd_test.go
+++ b/pkg/passwd/passwd_test.go
@@ -43,8 +43,7 @@ func TestWriter(t *testing.T) {
 	}
 
 	w := &bytes.Buffer{}
-	err = uf.Write(w)
-	if err != nil {
+	if err := uf.Write(w); err != nil {
 		t.Errorf("error while writing; %v", err)
 	}
 
@@ -53,8 +52,7 @@ func TestWriter(t *testing.T) {
 	uf2.Load(r)
 
 	w2 := &bytes.Buffer{}
-	err = uf2.Write(w2)
-	if err != nil {
+	if err := uf2.Write(w2); err != nil {
 		t.Errorf("error while writing; %v", err)
 	}
 

--- a/pkg/tarball/tarball.go
+++ b/pkg/tarball/tarball.go
@@ -33,7 +33,7 @@ func WriteArchiveFromFS(base string, fsys fs.FS, out io.Writer, sourceDateEpoch 
 	tw := tar.NewWriter(gzw)
 	defer tw.Close()
 
-	err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -81,8 +81,7 @@ func WriteArchiveFromFS(base string, fsys fs.FS, out io.Writer, sourceDateEpoch 
 		}
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -93,8 +92,7 @@ func WriteArchiveFromFS(base string, fsys fs.FS, out io.Writer, sourceDateEpoch 
 // clean it up when it's done with it.
 func WriteArchive(src string, w io.Writer, sourceDateEpoch time.Time) error {
 	fs := os.DirFS(src)
-	err := WriteArchiveFromFS(src, fs, w, sourceDateEpoch)
-	if err != nil {
+	if err := WriteArchiveFromFS(src, fs, w, sourceDateEpoch); err != nil {
 		return fmt.Errorf("writing TAR archive failed: %w", err)
 	}
 


### PR DESCRIPTION
By keeping errs inside the scope of an if check, fewer errant errs end
up escaping to other calls, which reduces inadvertant shadowing, and
can make it clearer to readers that the err is only considerd during
that if check.

---

If y'all don't prefer this form, that's totally fine. I won't take it personally.