### PR TITLE
feat: introduce build assertions and validate passwd and group files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220216180153-3d7835abdf40
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
 	github.com/google/go-containerregistry v0.8.1-0.20220223122423-dd8d514a9b24
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	go.lsp.dev/uri v0.3.0
@@ -46,6 +47,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.14.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -616,6 +616,7 @@ github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -628,6 +629,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -158,6 +158,10 @@ func WithTarball(path string) Option {
 	}
 }
 
+// WithAssertions adds assertions to validate the result
+// of this build context.
+// Assertions are checked in parallel at the end of the
+// build process.
 func WithAssertions(a ...Assertion) Option {
 	return func(bc *Context) error {
 		bc.Assertions = append(bc.Assertions, a...)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -32,6 +32,7 @@ type Context struct {
 	UseProot           bool
 	Tags               []string
 	SourceDateEpoch    time.Time
+	Assertions         []Assertion
 }
 
 func (bc *Context) Summarize() {
@@ -153,6 +154,13 @@ func WithTags(tags ...string) Option {
 func WithTarball(path string) Option {
 	return func(bc *Context) error {
 		bc.TarballPath = path
+		return nil
+	}
+}
+
+func WithAssertions(a ...Assertion) Option {
+	return func(bc *Context) error {
+		bc.Assertions = append(bc.Assertions, a...)
 		return nil
 	}
 }

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -20,7 +20,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -88,14 +90,7 @@ func (bc *Context) BuildImage() error {
 		return err
 	}
 
-	for _, a := range bc.Assertions {
-		a := a
-		eg.Go(func() error {
-			return a(bc)
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
+	if err := bc.runAssertions(); err != nil {
 		return err
 	}
 
@@ -113,6 +108,33 @@ func (bc *Context) BuildImage() error {
 
 	log.Printf("finished building filesystem in %s", bc.WorkDir)
 	return nil
+}
+
+func (bc *Context) runAssertions() error {
+	var wg sync.WaitGroup
+	var result error
+	errCh := make(chan error, len(bc.Assertions))
+
+	for _, a := range bc.Assertions {
+		a := a
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := a(bc); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		result = multierror.Append(result, err)
+	}
+
+	return result
 }
 
 // Installs the BusyBox symlinks, if appropriate.

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -88,6 +88,17 @@ func (bc *Context) BuildImage() error {
 		return err
 	}
 
+	for _, a := range bc.Assertions {
+		a := a
+		eg.Go(func() error {
+			return a(bc)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
 	// maybe install busybox symlinks
 	if bc.UseProot {
 		if err := bc.InstallBusyboxSymlinks(); err != nil {

--- a/pkg/build/validate.go
+++ b/pkg/build/validate.go
@@ -1,0 +1,38 @@
+package build
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type Assertion func(*Context) error
+
+func RequirePasswdFile(optional bool) Assertion {
+	return func(bc *Context) error {
+		path := filepath.Join(bc.WorkDir, "etc", "passwd")
+
+		_, err := os.Stat(path)
+		if err != nil && optional {
+			log.Printf("warning: %s is missing", path)
+			return nil
+		}
+
+		return fmt.Errorf("/etc/passwd file is missing: %w", err)
+	}
+}
+
+func RequireGroupFile(optional bool) Assertion {
+	return func(bc *Context) error {
+		path := filepath.Join(bc.WorkDir, "etc", "group")
+
+		_, err := os.Stat(path)
+		if err != nil && optional {
+			log.Printf("warning: %s is missing", path)
+			return nil
+		}
+
+		return fmt.Errorf("/etc/group file is missing: %w", err)
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -45,6 +45,7 @@ command, e.g.
 				build.WithConfig(args[0]),
 				build.WithProot(useProot),
 				build.WithBuildDate(buildDate),
+				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 			)
 		},
 	}


### PR DESCRIPTION
Add support for assertions to check the result of the build context.  

As an example, two assertions are added to check whether `/etc/passwd` and `/etc/group` are (optionally) present.