### PR TITLE
Include arm v6 and v7 in multiarch support

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"sort"
 	"time"
 
 	"chainguard.dev/apko/pkg/build/types"
@@ -161,9 +162,17 @@ func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, creat
 	return digest, v1Image, nil
 }
 
-func PublishIndex(imgs []v1.Image, tags ...string) (name.Digest, error) {
+func PublishIndex(imgs map[types.Architecture]v1.Image, tags ...string) (name.Digest, error) {
 	var idx v1.ImageIndex = empty.Index
-	for _, img := range imgs {
+	var archs []types.Architecture
+	for arch := range imgs {
+		archs = append(archs, arch)
+	}
+	sort.Slice(archs, func(i, j int) bool {
+		return archs[i] < archs[j]
+	})
+	for _, arch := range archs {
+		img := imgs[arch]
 		mt, err := img.MediaType()
 		if err != nil {
 			return name.Digest{}, fmt.Errorf("failed to get mediatype: %w", err)
@@ -179,22 +188,13 @@ func PublishIndex(imgs []v1.Image, tags ...string) (name.Digest, error) {
 			return name.Digest{}, fmt.Errorf("failed to compute size: %w", err)
 		}
 
-		cfg, err := img.ConfigFile()
-		if err != nil {
-			return name.Digest{}, fmt.Errorf("failed to get config file: %w", err)
-		}
-		plat := v1.Platform{
-			OS:           cfg.OS,
-			Architecture: cfg.Architecture,
-		}
-
 		idx = mutate.AppendManifests(idx, mutate.IndexAddendum{
 			Add: img,
 			Descriptor: v1.Descriptor{
 				MediaType: mt,
 				Digest:    h,
 				Size:      size,
-				Platform:  &plat,
+				Platform:  arch.ToOCIPlatform(),
 			},
 		})
 	}

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -164,7 +164,7 @@ func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, creat
 
 func PublishIndex(imgs map[types.Architecture]v1.Image, tags ...string) (name.Digest, error) {
 	var idx v1.ImageIndex = empty.Index
-	var archs []types.Architecture
+	archs := make([]types.Architecture, 0, len(imgs))
 	for arch := range imgs {
 		archs = append(archs, arch)
 	}

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -31,16 +31,16 @@ func TestParseArchitectures(t *testing.T) {
 		want: []Architecture{},
 	}, {
 		desc: "sort",
-		in:   []string{"riscv64", "amd64"},
-		want: []Architecture{amd64, riscv64},
+		in:   []string{"riscv64", "amd64", "arm/v6"},
+		want: []Architecture{amd64, armv6, riscv64},
 	}, {
 		desc: "dedupe",
 		in:   []string{"amd64", "amd64", "arm64"},
 		want: []Architecture{amd64, arm64},
 	}, {
 		desc: "dedupe w/ apk style",
-		in:   []string{"x86_64", "amd64", "arm64"},
-		want: []Architecture{amd64, arm64},
+		in:   []string{"x86_64", "amd64", "arm64", "arm/v6", "armhf"},
+		want: []Architecture{amd64, armv6, arm64},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := ParseArchitectures(c.in)

--- a/pkg/cli/publish.go
+++ b/pkg/cli/publish.go
@@ -108,7 +108,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			return fmt.Errorf("failed to build OCI image: %w", err)
 		}
 	default:
-		var imgs []v1.Image
+		imgs := map[types.Architecture]v1.Image{}
 		workDir := bc.WorkDir
 		for _, arch := range archs {
 			bc.Arch = arch
@@ -123,7 +123,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			if err != nil {
 				return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
 			}
-			imgs = append(imgs, img)
+			imgs[arch] = img
 		}
 		digest, err = oci.PublishIndex(imgs, bc.Tags...)
 		if err != nil {


### PR DESCRIPTION
This turned out to be a little more complicated than I wanted, since the image's config doesn't include the CPU variant. So instead, I just pass through a `map[types.Architecture]v1.Image` to `PublishIndex` (which I also don't super love).

Ideas welcome. I'm also fine just punting on this if we think we'll come up with a better idea later. I don't really think it needs to block anything.

edit: An example image built with this change:
```
index.docker.io/imjasonh/alpine-multi@sha256:735bfedcd7f5e4c7a4655a7d8d23c218e837aa0290c045019270a61fcc0e184a
```