### PR TITLE
Fix validate passwd/group logic.

### DIFF
--- a/pkg/build/validate.go
+++ b/pkg/build/validate.go
@@ -28,12 +28,14 @@ func RequirePasswdFile(optional bool) Assertion {
 		path := filepath.Join(bc.WorkDir, "etc", "passwd")
 
 		_, err := os.Stat(path)
-		if err != nil && optional {
-			log.Printf("warning: %s is missing", path)
-			return nil
+		if err != nil {
+			if optional {
+				log.Printf("warning: %s is missing", path)
+				return nil
+			}
+			return fmt.Errorf("/etc/passwd file is missing: %w", err)
 		}
-
-		return fmt.Errorf("/etc/passwd file is missing: %w", err)
+		return nil
 	}
 }
 
@@ -42,11 +44,13 @@ func RequireGroupFile(optional bool) Assertion {
 		path := filepath.Join(bc.WorkDir, "etc", "group")
 
 		_, err := os.Stat(path)
-		if err != nil && optional {
-			log.Printf("warning: %s is missing", path)
-			return nil
+		if err != nil {
+			if optional {
+				log.Printf("warning: %s is missing", path)
+				return nil
+			}
+			return fmt.Errorf("/etc/group file is missing: %w", err)
 		}
-
-		return fmt.Errorf("/etc/group file is missing: %w", err)
+		return nil
 	}
 }


### PR DESCRIPTION
Before this change, whenever I ran "apko build" I got this error:

Error: failed to build layer image: 2 errors occurred:
        * /etc/passwd file is missing: %!w(<nil>)
        * /etc/group file is missing: %!w(<nil>)

The problem is that "optional" was not true, so the code branch that
returned the wrapped error would always be followed even when err == nil.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>