### PR TITLE
apko: never run scripts, ever

### DIFF
--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -195,10 +195,7 @@ func (bc *Context) InitApkWorld() error {
 func (bc *Context) FixateApkWorld() error {
 	log.Printf("synchronizing with desired apk world")
 
-	args := []string{"fix", "--root", bc.WorkDir, "--no-cache", "--update-cache", "--arch", bc.Arch.ToAPK()}
-	if bc.UseProot {
-		args = append(args, "--no-scripts")
-	}
+	args := []string{"fix", "--root", bc.WorkDir, "--no-scripts", "--no-cache", "--update-cache", "--arch", bc.Arch.ToAPK()}
 
 	return bc.Execute("apk", args...)
 }

--- a/pkg/build/executor.go
+++ b/pkg/build/executor.go
@@ -36,8 +36,16 @@ func runCommand(cmd *exec.Cmd, logname string) error {
 
 // TODO(kaniini): Add support for using qemu-binfmt here for multiarch.
 func (bc *Context) ExecuteChroot(name string, arg ...string) error {
-	arg = append([]string{"-S", bc.WorkDir, name}, arg...)
-	cmd := exec.Command("proot", arg...)
+	var cmd *exec.Cmd
+
+	if bc.UseProot {
+		arg = append([]string{"-S", bc.WorkDir, name}, arg...)
+		cmd = exec.Command("proot", arg...)
+	} else {
+		arg = append([]string{bc.WorkDir, name}, arg...)
+		cmd = exec.Command("chroot", arg...)
+	}
+
 	return runCommand(cmd, name)
 }
 

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -94,10 +94,8 @@ func (bc *Context) BuildImage() error {
 	}
 
 	// maybe install busybox symlinks
-	if bc.UseProot {
-		if err := bc.InstallBusyboxSymlinks(); err != nil {
-			return fmt.Errorf("failed to install busybox symlinks: %w", err)
-		}
+	if err := bc.InstallBusyboxSymlinks(); err != nil {
+		return fmt.Errorf("failed to install busybox symlinks: %w", err)
 	}
 
 	// write service supervision tree


### PR DESCRIPTION
Previously we just never ran scripts if we were using proot.  Instead, just never run scripts.

Also allow ExecuteChroot() to work if proot is not requested, by using `chroot` instead.  In this scenario, we assume that the build is privileged.