### PR TITLE
Add --keyring-append option

### DIFF
--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -101,6 +101,11 @@ func (bc *Context) InitApkKeyring() (err error) {
 		}
 	}
 
+	if len(bc.ExtraKeyFiles) > 0 {
+		log.Printf("appending %d extra keys to keyring", len(bc.ExtraKeyFiles))
+		keyFiles = append(keyFiles, bc.ExtraKeyFiles...)
+	}
+
 	var eg errgroup.Group
 
 	for _, element := range keyFiles {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -36,6 +36,7 @@ type Context struct {
 	WantSBOM           bool
 	SBOMPath           string
 	SBOMFormats        []string
+	ExtraKeyFiles      []string
 	Arch               types.Architecture
 }
 
@@ -219,6 +220,13 @@ func WithSBOM(path string) Option {
 func WithSBOMFormats(formats []string) Option {
 	return func(bc *Context) error {
 		bc.SBOMFormats = formats
+		return nil
+	}
+}
+
+func WithExtraKeys(keys []string) Option {
+	return func(bc *Context) error {
+		bc.ExtraKeyFiles = keys
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -35,6 +35,7 @@ func Build() *cobra.Command {
 	var writeSBOM bool
 	var sbomPath string
 	var sbomFormats []string
+	var extraKeys []string
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -62,6 +63,7 @@ bill of materials) describing the image contents.
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithSBOM(sbomPath),
 				build.WithSBOMFormats(sbomFormats),
+				build.WithExtraKeys(sbomFormats),
 				build.WithTags(args[1]),
 			)
 		},
@@ -71,6 +73,7 @@ bill of materials) describing the image contents.
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate SBOMs")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate SBOMs in dir (defaults to image directory)")
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 
 	return cmd


### PR DESCRIPTION
This PR introduces the `--keyring-append` flag (shorthand -k).
Using this option, new keys can be passed to apko to include in the
image keyring in addition to the keys read in the config file or from the
system keys.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>