### PR TITLE
Fix buf cli passing correct extrakeys

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -63,7 +63,7 @@ bill of materials) describing the image contents.
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithSBOM(sbomPath),
 				build.WithSBOMFormats(sbomFormats),
-				build.WithExtraKeys(sbomFormats),
+				build.WithExtraKeys(extraKeys),
 				build.WithTags(args[1]),
 			)
 		},


### PR DESCRIPTION
Fix a bug introduced in #97 where the cli is passing the wrong var to the keyring

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>