### PR TITLE
WIP support for multi-layered images.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -38,6 +38,7 @@ type Context struct {
 	SBOMFormats        []string
 	ExtraKeyFiles      []string
 	Arch               types.Architecture
+	Multilayer         bool
 }
 
 func (bc *Context) Summarize() {
@@ -48,6 +49,7 @@ func (bc *Context) Summarize() {
 	log.Printf("  source date: %s", bc.SourceDateEpoch)
 	log.Printf("  SBOM output path: %s", bc.SBOMPath)
 	log.Printf("  arch: %v", bc.Arch.ToAPK())
+	log.Printf("  multilayer: %t", bc.Multilayer)
 	bc.ImageConfiguration.Summarize()
 }
 
@@ -99,6 +101,21 @@ func (bc *Context) BuildLayer() (string, error) {
 	}
 
 	return layerTarGZ, nil
+}
+
+// TODO: integrate with BuildLayer
+func (bc *Context) BuildMultilayer() ([]string, error) {
+	bc.Summarize()
+
+	// build image filesystem
+	layers, err := bc.BuildMultilayerImage()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: support SBOM
+
+	return layers, nil
 }
 
 // New creates a build context.
@@ -244,6 +261,13 @@ func WithImageConfiguration(ic types.ImageConfiguration) Option {
 func WithArch(arch types.Architecture) Option {
 	return func(bc *Context) error {
 		bc.Arch = arch
+		return nil
+	}
+}
+
+func WithMultilayer(multilayer bool) Option {
+	return func(bc *Context) error {
+		bc.Multilayer = multilayer
 		return nil
 	}
 }

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -17,11 +17,17 @@ package build
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -107,6 +113,34 @@ func (bc *Context) BuildImage() error {
 	return nil
 }
 
+// TODO: integrate this with BuildImage
+func (bc *Context) BuildMultilayerImage() ([]string, error) {
+	sortedPkgs, err := bc.GetSortedPkgs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sorted packages: %w", err)
+	}
+	// TODO: remove debug logs
+	log.Print("sorted packages:")
+	for _, pkg := range sortedPkgs {
+		log.Print(pkg.Name)
+	}
+
+	// TODO: parallelize this, just be careful to retain the same order
+	var layerTarGZs []string
+	for _, pkg := range sortedPkgs {
+		layerTarGZ, err := bc.FetchPkg(pkg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch package %s: %w", pkg.Filename(), err)
+		}
+		layerTarGZs = append(layerTarGZs, layerTarGZ)
+	}
+
+	// TODO: assertions, mutate accounts, supervision tree, SBOM, busybox symlinks, etc.
+
+	log.Printf("finished fetching packages in %s", bc.WorkDir)
+	return layerTarGZs, nil
+}
+
 func (bc *Context) runAssertions() error {
 	var eg multierror.Group
 
@@ -137,4 +171,197 @@ func (bc *Context) InstallBusyboxSymlinks() error {
 	}
 
 	return nil
+}
+
+// TODO: remove .PKGINFO and .SIGN* keyfiles from the tarball
+// TODO: how do we use the keyfiles here?
+func (bc *Context) FetchPkg(pkg *repository.RepositoryPackage) (string, error) {
+	destPath := filepath.Join(bc.WorkDir, pkg.Filename())
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s: %w", destPath, err)
+	}
+	defer f.Close()
+
+	pkgURL, err := url.Parse(pkg.Url())
+	if err != nil {
+		return "", fmt.Errorf("failed to parse package URL: %w", err)
+	}
+	resp, err := http.Get(pkgURL.String())
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch package: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		resp.Body.Close()
+		return "", fmt.Errorf("failed to fetch package %s: %s", pkgURL, resp.Status)
+	}
+
+	// TODO: consider CopyBuffer instead
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", destPath, err)
+	}
+	return destPath, nil
+}
+
+// TODO: make this work when user requests pinned version of package
+// TODO: What is supposed to happen when there are multiple alternatives for a package (i.e. libudev).
+// TODO: Is checking each repository in the order provided and using the first one the package is found in correct?
+// TODO: this probably uses a ton of memory holding all packages for each repo in memory, see if there's a way to lazy load info from disk/remote
+func (bc *Context) GetSortedPkgs() ([]*repository.RepositoryPackage, error) {
+	pkgs := make(map[string][]*repository.RepositoryPackage)
+	for _, repoUri := range bc.ImageConfiguration.Contents.Repositories {
+		// TODO: this seems hacky?
+		repoUri = repoUri + "/" + bc.Arch.ToAPK()
+		repo := &repository.Repository{
+			Uri: repoUri,
+		}
+
+		// TODO: handle non-http[s] uris?
+		indexUri := repo.IndexUri()
+		asURL, err := url.Parse(indexUri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse repository index uri: %w", err)
+		}
+		resp, err := http.Get(asURL.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch repository index %q: %w", asURL.String(), err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("failed to fetch repository index: %q %s", asURL.String(), resp.Status)
+		}
+		apkIndex, err := repository.IndexFromArchive(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse repository index: %w", err)
+		}
+
+		for _, pkg := range repo.WithIndex(apkIndex).Packages() {
+			pkgs[pkg.Name] = append(pkgs[pkg.Name], pkg)
+			// TODO: this is all really really hacky...
+			versioned := fmt.Sprintf("%s=%s", pkg.Name, pkg.Version)
+			pkgs[versioned] = append(pkgs[versioned], pkg)
+			for _, provided := range pkg.Provides {
+				pkgs[provided] = append(pkgs[provided], pkg)
+				unversioned := strings.Split(provided, "=")[0]
+				pkgs[unversioned] = append(pkgs[unversioned], pkg)
+			}
+		}
+	}
+
+	getPkg := func(name string) (*repository.RepositoryPackage, error) {
+		pkgs := pkgs[name]
+		if len(pkgs) == 0 {
+			return nil, fmt.Errorf("failed to find package %s", name)
+		}
+		return pkgs[0], nil
+	}
+
+	var targetPkgs []*repository.RepositoryPackage
+	for _, name := range bc.ImageConfiguration.Contents.Packages {
+		pkg, err := getPkg(name)
+		if err != nil {
+			return nil, err
+		}
+		targetPkgs = append(targetPkgs, pkg)
+	}
+
+	return tsort(targetPkgs, func(pkg *repository.RepositoryPackage) ([]*repository.RepositoryPackage, error) {
+		// TODO: not sure what's going on here.. alpine-baselayout-data has a dep on itself... hacky workaround for now
+		if strings.HasPrefix(pkg.Name, "alpine-baselayout-data") {
+			return nil, nil
+		}
+
+		var deps []*repository.RepositoryPackage
+		for _, depName := range pkg.Dependencies {
+			depPkg, err := getPkg(depName)
+			if err != nil {
+				return nil, err
+			}
+			deps = append(deps, depPkg)
+		}
+		return deps, nil
+	})
+}
+
+func tsort(targetPkgs []*repository.RepositoryPackage, getDeps func(pkg *repository.RepositoryPackage) ([]*repository.RepositoryPackage, error)) ([]*repository.RepositoryPackage, error) {
+	type pkgVtx struct {
+		pkg     *repository.RepositoryPackage
+		deps    map[*pkgVtx]struct{}
+		revdeps map[*pkgVtx]struct{}
+		added   bool
+	}
+
+	pkgs := make(map[string]*pkgVtx)
+	var ready []*pkgVtx
+	var add func(*repository.RepositoryPackage, *repository.RepositoryPackage) error
+	add = func(pkg, rdep *repository.RepositoryPackage) error {
+		vtx, ok := pkgs[pkg.Name]
+		if !ok {
+			vtx = &pkgVtx{
+				pkg:     pkg,
+				deps:    make(map[*pkgVtx]struct{}),
+				revdeps: make(map[*pkgVtx]struct{}),
+			}
+			pkgs[pkg.Name] = vtx
+		}
+		if rdep != nil {
+			if rvtx, ok := pkgs[rdep.Name]; ok {
+				vtx.revdeps[rvtx] = struct{}{}
+				rvtx.deps[vtx] = struct{}{}
+			}
+		}
+
+		if vtx.added {
+			return nil
+		}
+		vtx.added = true
+		deps, err := getDeps(pkg)
+		if err != nil {
+			return err
+		}
+
+		if len(deps) == 0 {
+			ready = append(ready, vtx)
+		}
+		for _, dep := range deps {
+			if err := add(dep, pkg); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, pkg := range targetPkgs {
+		if err := add(pkg, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	var sorted []*repository.RepositoryPackage
+	for len(ready) > 0 {
+		// make the order within a topological level deterministic, helps container runtimes
+		// deduplicate when unpacking snapshots
+		// TODO: double check the above actually is true
+		sort.Slice(ready, func(i, j int) bool {
+			return ready[i].pkg.Name < ready[j].pkg.Name
+		})
+		var next []*pkgVtx
+		for _, vtx := range ready {
+			sorted = append(sorted, vtx.pkg)
+			for dep := range vtx.revdeps {
+				delete(dep.deps, vtx)
+				if len(dep.deps) == 0 {
+					next = append(next, dep)
+				}
+			}
+			delete(pkgs, vtx.pkg.Name)
+		}
+		ready = next
+	}
+	if len(pkgs) > 0 {
+		return nil, fmt.Errorf("cycle detected") // TODO: more helpful error
+	}
+	return sorted, nil
 }


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

WIP fix to #66

The code already technically works when using the `build` command for simple cases, try it out with `apko build --multilayer test.yaml test output.tar` using this test.yaml for instance:
```
contents:
  repositories:
    - https://dl-cdn.alpinelinux.org/alpine/edge/main
  packages:
    - alpine-baselayout
    - curl
    - rsync
    - coreutils
```

On running `docker load <output.tar` you'll see multiple layers loaded, 1 for each package in the DAG.

However, still big caveats:
1. Walking the package DAG has some hacks which probably don't always work, need guidance on how to deal with corner cases there
1. Doesn't support supervision tree, custom keyfiles, sboms, etc. 
1. Just uses downloaded apks directly as layer tar.gzs, which does work but results in `.PKGINFO` and `.SIGN.RSA*` files sticking around in the exported image
1. Doesn't support `publish` yet (this is probably easy though)
1. Various other issues marked with `TODO` comments in the code

---

@kaniini  Opening as a draft so I can get guidance on some questions related to apk before cleaning up the rest. A few big ones:
1. When there are multiple alternatives for a package, how do we disambiguate? i.e. I running `apk info so:libudev.so.1` shows multiple implementations. Right now the code just picks the first package it finds, which feels likely to not always be correct? Obviously if the user specifically requests one version of the package, choose that one, but what about when the user doesn't request any one in particular? Is the default choice in the apk metadata somewhere?
2. If the user provides multiple repositories, is it right to check each one for a requested package in order and use the package from the first repository its found in? Or is there some other logic that should be followed.
3. Is there anything special about the apk keyring that would require special logic to use the keys to download the packages? Or is it just a matter of telling the Go http client to use them. I haven't actually looked into this yet, so apologies if it's a dumb question.

There are some other TODOs in the apk DAG code too and I'm sure there's plenty of "unknown unknowns" I've overlooked too...

Also, let me know if the package DAG parsing code would fit better upsteam in the the `alpine/go` package. Happy to put stuff there if you think it fits better.