### PR TITLE
fix: readd skipclose option

### DIFF
--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -32,7 +32,11 @@ func (ctx *Context) writeArchiveFromFS(dst io.Writer, fsys fs.FS) error {
 	defer gzw.Close()
 
 	tw := tar.NewWriter(gzw)
-	defer tw.Close()
+	if !ctx.SkipClose {
+		defer tw.Close()
+	} else {
+		defer tw.Flush()
+	}
 
 	return ctx.writeTar(tw, fsys)
 }


### PR DESCRIPTION
got lost in the previous PR, my apologies.

On a side note: should this and other APK specific code be moved to melange ? Right now the tarball package serves two different purposes: generating OCI layer tarball and generating APK packages.