### PR TITLE
test: use testify consistently

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,15 @@ linters-settings:
     include-go-root: true
     packages:
       - io/ioutil
+      - github.com/google/go-cmp/cmp
     packages-with-error-message:
       - io/ioutil: 'ioutil was deprecated in 1.16 (https://go.dev/doc/go1.16#ioutil)'
+      - github.com/google/go-cmp/cmp: 'forbid go-cmp in favor of using testify'
+  forbidigo:
+    forbid:
+      - ^print.*$
+      - '^t\.Error.*$(# forbid t\.Error in favor of using testify\.)?'
+      - '^t\.Fatal.*$(# forbid t\.Fatal in favor of using testify\.)?'
   goheader:
     template-path: header.tmpl
 
@@ -15,6 +22,7 @@ linters:
   - depguard
   - errcheck
   - errorlint
+  - forbidigo
   - gofmt
   - goheader
   - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,8 @@ linters-settings:
     include-go-root: true
     packages:
       - io/ioutil
-      - github.com/google/go-cmp/cmp
     packages-with-error-message:
       - io/ioutil: 'ioutil was deprecated in 1.16 (https://go.dev/doc/go1.16#ioutil)'
-      - github.com/google/go-cmp/cmp: 'forbid go-cmp in favor of using testify'
   forbidigo:
     forbid:
       - ^print.*$

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220216180153-3d7835abdf40
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
-	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.1-0.20220223122423-dd8d514a9b24
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220216180153-3d7835abdf40
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.1-0.20220223122423-dd8d514a9b24
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -17,7 +17,7 @@ package types
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseArchitectures(t *testing.T) {
@@ -44,9 +44,7 @@ func TestParseArchitectures(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := ParseArchitectures(c.in)
-			if d := cmp.Diff(got, c.want); d != "" {
-				t.Fatal("Got diff (-got,+want):", d)
-			}
+			require.Equal(t, c.want, got)
 		})
 	}
 }

--- a/pkg/passwd/group_test.go
+++ b/pkg/passwd/group_test.go
@@ -17,46 +17,38 @@ package passwd
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGroupParser(t *testing.T) {
 	gf, err := ReadOrCreateGroupFile("testdata/group")
-	if err != nil {
-		t.Errorf("error while parsing; %v", err)
-	}
+	require.NoError(t, err)
 
 	for _, ge := range gf.Entries {
-		if ge.GID == 0 && ge.GroupName != "root" {
-			t.Errorf("gid 0 is not root")
+		if ge.GID == 0 {
+			require.Equal(t, "root", ge.GroupName, "gid 0 is not root")
 		}
 
-		if ge.GID == 65534 && ge.GroupName != "nobody" {
-			t.Errorf("gid 65534 is not nobody")
+		if ge.GID == 65534 {
+			require.Equal(t, "nobody", ge.GroupName, "gid 65534 is not nobody")
 		}
 	}
 }
 
 func TestGroupWriter(t *testing.T) {
 	gf, err := ReadOrCreateGroupFile("testdata/group")
-	if err != nil {
-		t.Errorf("error while parsing; %v", err)
-	}
+	require.NoError(t, err)
 
 	w := &bytes.Buffer{}
-	if err := gf.Write(w); err != nil {
-		t.Errorf("error while writing; %v", err)
-	}
+	require.NoError(t, gf.Write(w))
 
 	r := bytes.NewReader(w.Bytes())
 	gf2 := &GroupFile{}
-	gf2.Load(r)
+	require.NoError(t, gf2.Load(r))
 
 	w2 := &bytes.Buffer{}
-	if err := gf2.Write(w2); err != nil {
-		t.Errorf("error while writing; %v", err)
-	}
+	require.NoError(t, gf2.Write(w2))
 
-	if !bytes.Equal(w.Bytes(), w2.Bytes()) {
-		t.Errorf("bytes are not equal %v %v", w.Bytes(), w2.Bytes())
-	}
+	require.Equal(t, w.Bytes(), w2.Bytes())
 }

--- a/pkg/passwd/passwd_test.go
+++ b/pkg/passwd/passwd_test.go
@@ -17,46 +17,38 @@ package passwd
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser(t *testing.T) {
 	uf, err := ReadOrCreateUserFile("testdata/passwd")
-	if err != nil {
-		t.Errorf("error while parsing; %v", err)
-	}
+	require.NoError(t, err)
 
 	for _, ue := range uf.Entries {
-		if ue.UID == 0 && ue.UserName != "root" {
-			t.Errorf("uid 0 is not root")
+		if ue.UID == 0 {
+			require.Equal(t, "root", ue.UserName, "uid 0 is not root")
 		}
 
-		if ue.UID == 65534 && ue.UserName != "nobody" {
-			t.Errorf("uid 65534 is not nobody")
+		if ue.UID == 65534 {
+			require.Equal(t, "nobody", ue.UserName, "uid 65534 is not nobody")
 		}
 	}
 }
 
 func TestWriter(t *testing.T) {
 	uf, err := ReadOrCreateUserFile("testdata/passwd")
-	if err != nil {
-		t.Errorf("error while parsing; %v", err)
-	}
+	require.NoError(t, err)
 
 	w := &bytes.Buffer{}
-	if err := uf.Write(w); err != nil {
-		t.Errorf("error while writing; %v", err)
-	}
+	require.NoError(t, uf.Write(w))
 
 	r := bytes.NewReader(w.Bytes())
 	uf2 := &UserFile{}
-	uf2.Load(r)
+	require.NoError(t, uf2.Load(r))
 
 	w2 := &bytes.Buffer{}
-	if err := uf2.Write(w2); err != nil {
-		t.Errorf("error while writing; %v", err)
-	}
+	require.NoError(t, uf2.Write(w2))
 
-	if !bytes.Equal(w.Bytes(), w2.Bytes()) {
-		t.Errorf("bytes are not equal %v %v", w.Bytes(), w2.Bytes())
-	}
+	require.Equal(t, w.Bytes(), w2.Bytes())
 }

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"chainguard.dev/apko/pkg/sbom/options"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 	"sigs.k8s.io/release-utils/command"
@@ -78,7 +79,8 @@ func TestReproducible(t *testing.T) {
 		require.NoError(t, err)
 		d = append(d, data)
 	}
-	require.Equal(t, d[0], d[1])
+	diff := cmp.Diff(d[0], d[1])
+	require.Empty(t, diff, fmt.Sprintf("difference in expected output %s", diff))
 }
 
 // To run TestValidateSPDX, point SPDX_TOOLS_JAR to the SPDX tools

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"chainguard.dev/apko/pkg/sbom/options"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 	"sigs.k8s.io/release-utils/command"
@@ -79,8 +78,7 @@ func TestReproducible(t *testing.T) {
 		require.NoError(t, err)
 		d = append(d, data)
 	}
-	diff := cmp.Diff(d[0], d[1])
-	require.Empty(t, diff)
+	require.Equal(t, d[0], d[1])
 }
 
 // To run TestValidateSPDX, point SPDX_TOOLS_JAR to the SPDX tools


### PR DESCRIPTION
tests are using `go-cmp`, `testify` and `t.Error`.

This standardize the assertions to use testify and forbids the other two

```release-note
-Test assertions are now standardized the to use testify
```