### PR TITLE
build: add bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 /apko
 dist/
+bin/
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
`make golangci-lint` installs golangci in the bin/ directory. This should avoid adding noise to the git status/diff