### PR TITLE
refactor: decouple executor from build context

### DIFF
--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -40,7 +40,7 @@ import (
 func (bc *Context) InitApkDB() error {
 	log.Printf("initializing apk database")
 
-	return bc.Execute("apk", "add", "--initdb", "--arch", bc.Arch.ToAPK(), "--root", bc.WorkDir)
+	return bc.executor.Execute("apk", "add", "--initdb", "--arch", bc.Arch.ToAPK(), "--root", bc.WorkDir)
 }
 
 // loadSystemKeyring returns the keys found in the system keyring
@@ -202,7 +202,7 @@ func (bc *Context) FixateApkWorld() error {
 
 	args := []string{"fix", "--root", bc.WorkDir, "--no-scripts", "--no-cache", "--update-cache", "--arch", bc.Arch.ToAPK()}
 
-	return bc.Execute("apk", args...)
+	return bc.executor.Execute("apk", args...)
 }
 
 func (bc *Context) normalizeApkScriptsTar() error {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/exec"
 	apkofs "chainguard.dev/apko/pkg/fs"
 	"chainguard.dev/apko/pkg/tarball"
 )
@@ -39,6 +40,7 @@ type Context struct {
 	SBOMFormats        []string
 	ExtraKeyFiles      []string
 	Arch               types.Architecture
+	executor           *exec.Executor
 }
 
 func (bc *Context) Summarize() {
@@ -130,6 +132,8 @@ func New(workDir string, opts ...Option) (*Context, error) {
 
 		bc.SourceDateEpoch = time.Unix(sec, 0)
 	}
+
+	bc.executor = exec.New(bc.WorkDir, exec.WithProot(bc.UseProot))
 
 	return &bc, nil
 }

--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -132,7 +132,7 @@ func (bc *Context) InstallBusyboxSymlinks() error {
 	}
 
 	// use proot + qemu to run the installer
-	if err := bc.ExecuteChroot("/bin/busybox", "--install", "-s"); err != nil {
+	if err := bc.executor.ExecuteChroot("/bin/busybox", "--install", "-s"); err != nil {
 		return fmt.Errorf("failed to install busybox symlinks: %w", err)
 	}
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+type Executor struct {
+	WorkDir  string
+	UseProot bool
+}
+
+type Option func(*Executor)
+
+func New(workDir string, opts ...Option) *Executor {
+	e := &Executor{
+		WorkDir: workDir,
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+func WithProot(proot bool) Option {
+	return func(e *Executor) {
+		e.UseProot = proot
+	}
+}


### PR DESCRIPTION
executor and `build.Context` are tightly coupled. This PR should make it easier to run a command (just create an executor and you're good) without changing api/behaviour of `build.Context`