### PR TITLE
Makefile - correct indentation in checkfmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ fmt: ## Format all go files
 checkfmt: SHELL := /usr/bin/env bash
 checkfmt: ## Check formatting of all go files
 	@ $(MAKE) --no-print-directory log-$@
- 	$(shell test -z "$(shell gofmt -l $(GOFILES) | tee /dev/stderr)")
- 	$(shell test -z "$(shell goimports -l $(GOFILES) | tee /dev/stderr)")
+	$(shell test -z "$(shell gofmt -l $(GOFILES) | tee /dev/stderr)")
+	$(shell test -z "$(shell goimports -l $(GOFILES) | tee /dev/stderr)")
 
 log-%:
 	@grep -h -E '^$*:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
Currently the first line in checkfmt is tab indented, however the second
and third lines are space indented, this causes the commands to not be
scoped under `checkfmt`.

Running make with any (or indeed no) target, causes the shell/sub-shell
commands to execute e.g.

```
$ make
/bin/sh: goimports: command not found
apko                            Builds apko
checkfmt                        Check formatting of all go files
clean                           Clean the workspace
fmt                             Format all go files
help                            Display help
install                         Builds and moves apko into BINDIR (default /usr/bin)
ko                              Build images using ko
ko-apply                        Build the image and apply the manifests
ko-local                        Build images locally using ko
lint                            Run linters and checks like golangci-lint
release                         Run Goreleaser in release mode
sign-image                      Sign images built using ko
snapshot                        Run Goreleaser in snapshot mode
test                            Run go test
```