### PR TITLE
Add Lima config and instructions for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ with apko, due to apk-tools' use of chroot(2).
 Some example configurations are available in the examples
 directory.
 
+Want to run `apko` on a mac? See [here](./mac/README.md).
+
 ## Features
 
 ### Sub-second image build times

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,0 +1,63 @@
+# apko on mac
+
+Currently `apko` relies on `apk`, which is currently
+not available for mac.
+
+This page documents workarounds to run
+`apko` on a mac.
+
+## Lima
+
+We maintain an example configuration file for
+[Lima](https://github.com/lima-vm/lima)
+(see [`lima/ako-playground.yaml`](./lima/apko-playground.yaml)).
+
+This provides a VM with the following:
+
+- 1 CPU, 2GiB memory, 10GiB disk
+- Latest release of `apko` (from Alpine edge repo)
+- Useful tools such as `vim`
+- Latest releases of various Docker credential helpers (ECR, GCR)
+- Dummy version of `docker-credential-osxkeychain`
+- Example config files from the repo at `/examples`
+
+Your `$HOME` directory will be mounted into the VM (read-only), in
+order to have access to things such as `~/.docker/config.json`,
+cloud registry credentials, etc.
+
+Root shell is needed for `apko build`. We also override `$HOME` with
+your mac's `$HOME` (mounted into the VM) so that Docker credential
+helpers work properly with `apko publish`.
+
+The commands below assume to be run in this
+directory of the repository, and require `limactl`.
+
+### Start environment
+
+```
+limactl start --tty=false apko-playground.yaml
+```
+
+### Obtain a shell
+
+```
+limactl shell apko-playground sudo su -c "HOME=\"${HOME}\" ash"
+```
+
+### Build an example image
+
+```
+apko build /examples/nginx.yaml tag /tmp/output.tar
+```
+
+### Publish an example image
+
+```
+apko publish /examples/nginx.yaml <registry_ref>
+```
+
+### Delete environment
+
+```
+limactl delete -f apko-playground
+```

--- a/mac/lima/apko-playground.yaml
+++ b/mac/lima/apko-playground.yaml
@@ -1,0 +1,110 @@
+# apko lima configuration file
+#
+#   To start environment:
+#     limactl start --tty=false apko-playground.yaml
+#
+#   To obtain root shell (needed for apko build):
+#     limactl shell apko-playground sudo su -c "HOME=\"${HOME}\" ash"
+#
+#   Build an example image:
+#     apko build /examples/nginx.yaml tag /tmp/output.tar
+#
+#   Publish an example image:
+#      apko publish /examples/nginx.yaml <registry_ref>
+#   
+#   To delete environment:
+#     limactl delete -f apko-playground
+#
+images:
+- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.9/alpine-lima-std-3.14.3-x86_64.iso
+  arch: "x86_64"
+  digest: "sha512:fb51cbfe7e6779324adfd835d55a4fa0b702ed66529fe218eb3a9595df8cb31d60d20f8e440674b5dba0f3e43c639a0078828afe36060d245d74ab16f9ce3485"
+- location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.9/alpine-lima-std-3.14.3-aarch64.iso
+  arch: "aarch64"
+  digest: "sha512:58ebe295031d7f0010500bde6d9c47b5a3affe6a76ce5a42f400346e954fbb24bdb35ede5e0998e1f9491273821fcc734ba0d50de830c0264e1ba997c245e1e5"
+cpus: 1
+memory: 2GiB
+disk: 10GiB
+firmware:
+  legacyBIOS: true
+containerd:
+  system: false
+  user: false
+mounts:
+# Allow access to things like ~/.docker/config.json and cloud credentials etc.
+- location: "~"
+
+provision:
+- mode: system
+  script: |
+    #!/bin/ash
+    set -eux -o pipefail
+
+    # Install apko from Alpine edge repo
+    apk add apko -X https://dl-cdn.alpinelinux.org/alpine/edge/testing/
+
+    # Add useful tools like vim
+    apk update
+    apk add vim
+
+    # Add Docker credential helpers needed for pushing to various cloud registries
+    arch="$(uname -m)"
+    if [[ "${arch}" != "x86_64" ]] && [[ "${arch}" != "aarch64" ]]; then
+      echo "Unsupported arch: ${arch}. Exiting."
+      exit 1
+    fi
+
+    # 1. docker-credential-gcr (Google)
+    # https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases
+    if [[ "${arch}" == "x86_64" ]]; then
+      wget -O tmp.tar.gz https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.0/docker-credential-gcr_linux_amd64-2.1.0.tar.gz
+      sha256sum tmp.tar.gz | grep '^91cca7b5ca33133bcd217982be31d670efe7f1a33eb5be72e014f74feecac00f '
+    else
+      wget -O tmp.tar.gz https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.0/docker-credential-gcr_linux_arm64-2.1.0.tar.gz
+      sha256sum tmp.tar.gz | grep '^0fcde1af46a4ddc3135a673b61707a4e241b5fc994d493c6c0c03e9ebcf5eee4 '
+    fi
+    tar -xvf tmp.tar.gz docker-credential-gcr
+    chmod +x docker-credential-gcr
+    mv docker-credential-gcr /usr/bin
+    rm -f tmp.tar.gz
+
+    # 2. docker-credential-ecr-login (Amazon)
+    # https://github.com/awslabs/amazon-ecr-credential-helper/releases
+    if [[ "${arch}" == "x86_64" ]]; then
+      wget -O docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login
+      sha256sum docker-credential-ecr-login | grep '^af805202cb5d627dde2e6d4be1f519b195fd5a3a35ddc88d5010b4a4e5a98dd8 '
+    else
+      wget -O docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-arm64/docker-credential-ecr-login
+      sha256sum docker-credential-ecr-login | grep '^760ecd36acf720cfe6a6ddb6fb20a32845e8886ea2e5333441c4bcca0a1d9620 '
+    fi
+    chmod +x docker-credential-ecr-login
+    mv docker-credential-ecr-login /usr/bin
+
+    # 3. docker-credential-acr-env (Microsoft)
+    # https://github.com/chrismellard/docker-credential-acr-env/releases
+    # No version yet available for aarch64, skipping.
+    # See: https://github.com/chrismellard/docker-credential-acr-env/issues/6
+
+    # 4. docker-credential-osxkeychain (mac system)
+    # Add a dummy version of docker-credential-osxkeychain typically found
+    # in mac ~/.docker/config.json
+    echo '#!/bin/ash' > /usr/bin/docker-credential-osxkeychain
+    echo 'echo "{\"ServerURL\":\"${1}\",\"Username\":\"\",\"Secret\":\"\"}"' \
+      >> /usr/bin/docker-credential-osxkeychain
+    chmod +x /usr/bin/docker-credential-osxkeychain
+
+    # Get the examples/ dir from GitHub release, place at /examples
+    wget https://github.com/chainguard-dev/apko/archive/refs/heads/main.zip
+    unzip main.zip "apko-main/examples/*" -d /examples -j
+    rm -f main.zip
+message: |-
+  ---
+  Run the following to get a root shell (needed to run apko build):
+    limactl shell apko-playground sudo su -c "HOME=\"${HOME}\" ash"
+  
+  Try building an image:
+    apko build /examples/nginx.yaml tag /tmp/output.tar
+
+  Try publishing an image:
+    apko publish /examples/nginx.yaml <registry_ref>
+  ---


### PR DESCRIPTION
Add a new mac/ directory containing instructions for how to get up-and-running with apko on a mac, considering it is not directly supported yet.

This includes a configuration file for Lima, which creates a QEMU-based VM with the latest version of apko installed from the Alpine edge repo.

Resolves #111