### PR TITLE
Split out types.ParseArchitecture and use it in build code

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -155,12 +155,13 @@ func New(workDir string, opts ...Option) (*Context, error) {
 	}
 
 	// if arch is missing default to the running program's arch
-	if bc.Arch == "" {
-		bc.Arch = types.Architecture(runtime.GOARCH)
+	zeroArch := types.Architecture{}
+	if bc.Arch == zeroArch {
+		bc.Arch = types.ParseArchitecture(runtime.GOARCH)
 	}
 
 	execOpts := []exec.Option{exec.WithProot(bc.UseProot)}
-	if bc.UseProot && bc.Arch != types.Architecture(runtime.GOARCH) {
+	if bc.UseProot && bc.Arch != types.ParseArchitecture(runtime.GOARCH) {
 		execOpts = append(execOpts, exec.WithQemu(bc.Arch.ToAPK()))
 	}
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -88,7 +88,7 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 
 	cfg = cfg.DeepCopy()
 	cfg.Author = "github.com/chainguard-dev/apko"
-	cfg.Architecture = string(arch)
+	cfg.Architecture = arch.String()
 	cfg.OS = "linux"
 
 	if ic.Entrypoint.Command != "" {
@@ -170,7 +170,7 @@ func PublishIndex(imgs map[types.Architecture]v1.Image, tags ...string) (name.Di
 		archs = append(archs, arch)
 	}
 	sort.Slice(archs, func(i, j int) bool {
-		return archs[i] < archs[j]
+		return archs[i].String() < archs[j].String()
 	})
 	for _, arch := range archs {
 		img := imgs[arch]

--- a/pkg/cli/build-minirootfs.go
+++ b/pkg/cli/build-minirootfs.go
@@ -46,7 +46,7 @@ func BuildMinirootFS() *cobra.Command {
 				build.WithProot(useProot),
 				build.WithBuildDate(buildDate),
 				build.WithSBOM(sbomPath),
-				build.WithArch(types.Architecture(buildArch)),
+				build.WithArch(types.ParseArchitecture(buildArch)),
 			)
 		},
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -69,7 +69,7 @@ bill of materials) describing the image contents.
 				build.WithExtraKeys(extraKeys),
 				build.WithTags(args[1]),
 				build.WithExtraRepos(extraRepos),
-				build.WithArch(types.Architecture(buildArch)),
+				build.WithArch(types.ParseArchitecture(buildArch)),
 			)
 		},
 	}

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -106,7 +106,7 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 	if opts.ImageInfo.Repository != "" {
 		mmMain["repository_url"] = opts.ImageInfo.Repository
 	}
-	if opts.ImageInfo.Arch != "" {
+	if opts.ImageInfo.Arch.String() != "" {
 		mmMain["arch"] = opts.ImageInfo.Arch.ToOCIPlatform().Architecture
 	}
 	rootComponent := Component{

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -103,7 +103,7 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 	if opts.ImageInfo.Repository != "" {
 		mmMain["repository_url"] = opts.ImageInfo.Repository
 	}
-	if opts.ImageInfo.Arch != "" {
+	if opts.ImageInfo.Arch.String() != "" {
 		mmMain["arch"] = opts.ImageInfo.Arch.ToOCIPlatform().Architecture
 	}
 


### PR DESCRIPTION
Followup from https://github.com/chainguard-dev/apko/pull/118#discussion_r829500559

cc @kaniini 

Changing `type Architecture string` -> `type Architecture struct { s string }` should prevent folks from naively trying to cast a `string` to an `Architecture`, and funnel folks toward `types.ParseArchitecture`.