### PR TITLE
feat: Add apko login

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,11 +56,9 @@ jobs:
       with:
         version: v0.10.0
     - uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.0.1
-    - uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.13.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ github.token }}
+    - name: Login to registry
+      run: |
+        echo ${{ github.token }} | go run ./ login ghcr.io --username=${{ github.repository_owner }} --password-stdin
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v2.4.0
     - name: Publish/Sign apko image
       run: |

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	cranecmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/version"
 )
@@ -26,6 +27,7 @@ func New() *cobra.Command {
 		SilenceUsage:      true,
 	}
 
+	cmd.AddCommand(cranecmd.NewCmdAuthLogin("apko")) // apko login
 	cmd.AddCommand(Build())
 	cmd.AddCommand(BuildMinirootFS())
 	cmd.AddCommand(Publish())


### PR DESCRIPTION
This uses code exported from `crane auth login`, also used by `ko
login`, to simulate `docker login`, without requiring Docker to be
installed.