### PR TITLE
Change the default config name in the Tekton task

### DIFF
--- a/config/task.yaml
+++ b/config/task.yaml
@@ -25,7 +25,7 @@ spec:
       description: Where to publish an image.
     - name: path
       description: The bundle-relative path to the config file to build.
-      default: ./config.yaml
+      default: .apko.yaml
 
   results:
     - name: IMAGES


### PR DESCRIPTION
This matches what we have been using in `github.com/distroless`