### PR TITLE
fix up early logging and build context for early builds

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -133,6 +133,7 @@ func (bc *Context) runAssertions() error {
 func New(workDir string, opts ...Option) (*Context, error) {
 	bc := Context{
 		WorkDir: workDir,
+		Log:     log.New(log.Writer(), "apko (early): ", log.LstdFlags|log.Lmsgprefix),
 	}
 
 	for _, opt := range opts {
@@ -192,7 +193,7 @@ func (bc *Context) Refresh() error {
 }
 
 func (bc *Context) UpdatePrefix() {
-	bc.Log = log.New(log.Writer(), fmt.Sprintf("%s: ", bc.Arch.ToAPK()), log.LstdFlags|log.Lmsgprefix)
+	bc.Log = log.New(log.Writer(), fmt.Sprintf("apko (%s): ", bc.Arch.ToAPK()), log.LstdFlags|log.Lmsgprefix)
 }
 
 // Option is an option for the build context.

--- a/pkg/cli/build-minirootfs.go
+++ b/pkg/cli/build-minirootfs.go
@@ -71,6 +71,10 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 		return err
 	}
 
+	if err := bc.Refresh(); err != nil {
+		return err
+	}
+
 	if len(bc.ImageConfiguration.Archs) != 0 {
 		log.Printf("WARNING: ignoring archs in config, only building for current arch (%s)", bc.Arch)
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -98,6 +98,10 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, opts ...build.O
 		return err
 	}
 
+	if err := bc.Refresh(); err != nil {
+		return err
+	}
+
 	if bc.SBOMPath == "" {
 		dir, err := filepath.Abs(outputTarGZ)
 		if err != nil {


### PR DESCRIPTION
Needed to fix `apko build` command when no explicit `--build-arch` is requested.

Closes #126.