### PR TITLE
Set the `mediaType` on the index.

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	v1tar "github.com/google/go-containerregistry/pkg/v1/tarball"
+	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 
 	"chainguard.dev/apko/pkg/build/types"
 )
@@ -164,7 +165,7 @@ func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, creat
 }
 
 func PublishIndex(imgs map[types.Architecture]v1.Image, logger *log.Logger, tags ...string) (name.Digest, error) {
-	var idx v1.ImageIndex = empty.Index
+	idx := mutate.IndexMediaType(empty.Index, ggcrtypes.DockerManifestList)
 	archs := make([]types.Architecture, 0, len(imgs))
 	for arch := range imgs {
 		archs = append(archs, arch)


### PR DESCRIPTION
Unfortunately `empty.Image` defaults to setting the Docker "schema2" media type, but `empty.Index` defaults to no media type.  This is unfortunate because Docker requires media types, so the absence of a media type is interpreted as OCI, and gcr.io doesn't allow mixing OCI index types with Docker image types.

When using `ghcr.io/distroless/static` with `ko` multi-arch I see:
```
MANIFEST_INVALID: Failed to parse manifest for request "/v2/.../manifests/latest": Image index child manifest not supported: application/vnd.docker.distribution.manifest.v2+json.
```