### PR TITLE
configurable image environment

### DIFF
--- a/examples/alpine-base-rootless.yaml
+++ b/examples/alpine-base-rootless.yaml
@@ -15,3 +15,7 @@ accounts:
     - username: nonroot
       uid: 10000
   run-as: nonroot
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/alpine-base.yaml
+++ b/examples/alpine-base.yaml
@@ -6,3 +6,7 @@ contents:
 
 entrypoint:
   command: /bin/sh -l
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/nginx-rootless.yaml
+++ b/examples/nginx-rootless.yaml
@@ -18,3 +18,7 @@ accounts:
     - username: nginx
       uid: 10000
   run-as: nginx
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -9,3 +9,7 @@ entrypoint:
   type: service-bundle
   services:
     nginx: /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -98,6 +98,21 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 		cfg.Config.Entrypoint = []string{"/bin/sh", "-l"}
 	}
 
+	if len(ic.Environment) > 0 {
+		envs := []string{}
+
+		for k, v := range ic.Environment {
+			envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		cfg.Config.Env = envs
+	} else {
+		cfg.Config.Env = []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt",
+		}
+	}
+
 	if ic.Accounts.RunAs != "" {
 		cfg.Config.User = ic.Accounts.RunAs
 	}

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -50,7 +50,8 @@ type ImageConfiguration struct {
 		Users  []User
 		Groups []Group
 	}
-	Archs []Architecture
+	Archs       []Architecture
+	Environment map[string]string
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
Adds environment stanza to image configuration:

```yaml
environment:
  PATH: ...
```

A default environment is provided for images which do not have one.

Closes #136.