### PR TITLE
oci: set created field correctly in config

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -96,6 +96,7 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 	cfg = cfg.DeepCopy()
 	cfg.Author = "github.com/chainguard-dev/apko"
 	cfg.Architecture = arch.String()
+	cfg.Created = v1.Time{Time: created}
 	cfg.OS = "linux"
 
 	if ic.Entrypoint.Command != "" {


### PR DESCRIPTION
Closes: #128
Signed-off-by: Ariadne Conill <ariadne@chainguard.dev>