### PR TITLE
apko development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin/
 .vscode
 .idea
 tmp/
+_output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+### Thank you for you interest in apko!  You are welcome here.
+
+apko and [melange](https://github.com/chainguard-dev/melange) are open
+source projects, always open for outside contributors.
+
+If you are looking for a place to start take a look at the 
+[open issues](https://github.com/chainguard-dev/apko/issues), 
+especially those marked with
+[good-first-issue](https://github.com/chainguard-dev/apko/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+
+## Setting Up a Develpment Environment
+
+Running apko requires an environment with apk available. To make development 
+easier under any platform, we have created a script that uses apko itself to
+bootstrap a development environment under any platform with docker installed.
+
+To run it, simply execute the following script from the top of the apko
+repository:
+
+```bash
+./hack/make-devenv.sh
+```
+
+That command should use apko to create a development image with some 
+useful tools. It will load the devel image into your local docker daemon and
+drop you into a shell. The apko repository in your local machine will be 
+mounted in the current working directory.
+
+You can use your editor to change the apko code and execute apko in the
+development shell to test it out:
+
+```
+go run ./main.go
+
+e5cf7d79f68b:/apko# go run ./main.go version
+     _      ____    _  __   ___
+    / \    |  _ \  | |/ /  / _ \
+   / _ \   | |_) | | ' /  | | | |
+  / ___ \  |  __/  | . \  | |_| |
+ /_/   \_\ |_|     |_|\_\  \___/
+apko
+
+GitVersion:    
+GitCommit:     unknown
+GitTreeState:  unknown
+BuildDate:     unknown
+GoVersion:     go1.18
+Compiler:      gc
+Platform:      linux/amd64
+
+
+```
+
+When done developing, simply exit the development shell. We would love to hear
+about your experience in the development shell and any ideas you may have!
+
+## Linting and Tests
+
+Before submitting a pull request, make sure tests and lints do not complain. 
+Make sure you have go 1.18 and
+[golangci-lint](https://golangci-lint.run/usage/install/) installed and try
+running the linter and tests:
+
+```
+go test ./...
+golangci-lint run
+```

--- a/examples/apko-devenv.yaml
+++ b/examples/apko-devenv.yaml
@@ -1,0 +1,12 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+  packages:
+    - alpine-base
+    - go
+    #- git
+    #- jq
+
+entrypoint:
+  command: /bin/sh -l

--- a/examples/apko-devenv.yaml
+++ b/examples/apko-devenv.yaml
@@ -1,3 +1,23 @@
+# Copyright 2022 Chainguard, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# APKO DEVELOPMENT ENVIRONMENT
+#
+# This image configuration is used by the apko development environment 
+# shell script. It preconfigures some tools to make them available in 
+# the dev shell.
+#
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
@@ -5,8 +25,7 @@ contents:
   packages:
     - alpine-base
     - go
-    #- git
-    #- jq
-
+    - git
+    - jq
 entrypoint:
   command: /bin/sh -l

--- a/examples/apko-devenv.yaml
+++ b/examples/apko-devenv.yaml
@@ -27,5 +27,6 @@ contents:
     - go
     - git
     - jq
+    - tree
 entrypoint:
   command: /bin/sh -l

--- a/hack/make-devenv.sh
+++ b/hack/make-devenv.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+BUILDER_ALPINE_TAG="3.15.0@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
+DEVENV_IMAGE_TARBALL="apko-inception.tar.gz"
+IMAGE_TAG="apko-inception"
+
+function checkrepo() {
+    grep "module chainguard.dev/apko" go.mod &> /dev/null && return
+    echo;
+    echo "Please run me from the apko repository root. Thank you!";
+    echo
+    exit 1;
+}
+
+function run_builder() {
+    set -e
+    mkdir _output > /dev/null 2>&1 || : 
+    docker run --rm -v $(pwd):/apko -w /apko -ti \
+        -e BUILD_UID=$(id -u) -e BUILD_GID=$(id -g) \
+        alpine:${BUILDER_ALPINE_TAG} \
+        /bin/sh hack/make-devenv.sh build_image
+    load_image
+    run
+}
+
+function build_image() {
+    set -e
+    cat /etc/os-release
+    apk add go
+    go run main.go build ./examples/apko-devenv.yaml ${IMAGE_TAG} ./_output/${DEVENV_IMAGE_TARBALL}
+    chown ${BUILD_UID}:${BUILD_GID} _output/${DEVENV_IMAGE_TARBALL}
+}
+
+function load_image() {
+    set -e
+    docker rmi ${IMAGE_TAG}:latest || :
+    docker load < _output/${DEVENV_IMAGE_TARBALL}
+}
+
+function run() {
+    docker run --rm -w /apko -v $(pwd):/apko -ti ${IMAGE_TAG}:latest /bin/sh -l hack/make-devenv.sh setup
+}
+
+function setup() {
+    echo
+    echo "Welcome to the apko development environment!\n\n"
+    echo
+    echo
+    alias ll="ls -l"
+    export PS1="[apko] ❯ "
+}
+
+checkrepo
+case "$1" in
+    "")
+        run_builder;;
+    "build_image")
+        build_image;;
+    "run")
+        run;;
+    "setup")
+        setup;;
+esac


### PR DESCRIPTION
This PR adds a shell script that allows a one-command way to start an apko development environment. 

Running the following script from the top of the apko repo launches a series of steps that use apko itself to build an image and drop the user into a development shell:

```
./hack/make-devenv.sh 
```

The environment is pre loaded with some tools (currently go, git and jq) and the user shell is opened with the apko repository mounted, ready to run any changes you make in your editor. I've also added a first draft of a CONTRIBUTING.md doc with instructions to launch the shell and basic info for contributors.

The image is `apko-inception` because apko is building the apko environment with a script that calls itself multiple times :)