### PR TITLE
Script to run apko commands via docker.

### DIFF
--- a/hack/run-devenv.sh
+++ b/hack/run-devenv.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+function run() {
+
+    if [[ ! -f "./apko" ]]; then
+	echo "Building apko"
+	make apko
+    fi
+
+    ./apko "$@"
+}
+
+function docker_run() {
+    docker run --rm -w /apko -v $(pwd):/apko --entrypoint /apko/hack/run-devenv.sh apko-inception:latest run $@
+}
+
+case "$1" in
+    "run")
+        run ${@:4};;
+    *)
+	docker_run $@;;
+esac
+


### PR DESCRIPTION
This isn't quite ready yet, but I wanted to get some feedback.

Basically, if the dev-env has been built, you can run the script like this:

```
hack/run-devenv.sh build examples/nginx.yaml apko/test test.tar
```

This should work on platform with docker. It will also run `make` if the binary isn't there.

I'm not really sure what the best way to do this. We could merge with the other script, but note that it is really for hacking on apko, whilst this is more for being able to run the commands without a VM.

The script needs some improvement e.g. pulling out the image name. 

