### PR TITLE
Fix config `archs` support

### DIFF
--- a/examples/alpine-386_amd64.yaml
+++ b/examples/alpine-386_amd64.yaml
@@ -1,0 +1,12 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - alpine-base
+
+entrypoint:
+  command: /bin/sh -l
+
+archs:
+  - amd64
+  - 386

--- a/examples/alpine-amd64.yaml
+++ b/examples/alpine-amd64.yaml
@@ -1,0 +1,11 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - alpine-base
+
+entrypoint:
+  command: /bin/sh -l
+
+archs:
+  - amd64

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -72,7 +72,7 @@ func (a Architecture) String() string { return a.s }
 func (a *Architecture) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var buf string
 	if err := unmarshal(&buf); err != nil {
-		return nil
+		return err
 	}
 
 	a.s = ParseArchitecture(buf).s

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -69,6 +69,16 @@ type Architecture struct{ s string }
 
 func (a Architecture) String() string { return a.s }
 
+func (a *Architecture) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var buf string
+	if err := unmarshal(&buf); err != nil {
+		return nil
+	}
+
+	a.s = ParseArchitecture(buf).s
+	return nil
+}
+
 var (
 	_386    = Architecture{"386"}
 	amd64   = Architecture{"amd64"}

--- a/pkg/cli/publish.go
+++ b/pkg/cli/publish.go
@@ -130,7 +130,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		workDir := bc.Options.WorkDir
 		imgs := map[types.Architecture]coci.SignedImage{}
 
-		for _, arch := range archs {
+		for _, arch := range bc.ImageConfiguration.Archs {
 			arch := arch
 			bc := *bc
 


### PR DESCRIPTION
There appears to be 2 issues with the current `archs` support from the config file.

1.

Currently if you try and specify the `archs` option in the config file,
the publish command fails along the lines of
```
  line 7: cannot unmarshal !!int `386` into types.Architecture
  line 7: cannot unmarshal !!str `amd64` into types.Architecture
```

Add a custom `UnmarshalYAML` function to `Architecture`, supporting
decoding the string values into the correct `Architecture` object.

2.

Currently if we specify 1 arch under `bc.ImageConfiguration.Archs`, the
publish command will handle it, however if we have more than 1 the
default case uses `archs`, which is defaulted to all entries (cli
options).

Swap out the default range case to use `bc.ImageConfiguration.Archs`,
which will be set to `archs` in the default case (no config specified).