### PR TITLE
/etc/os-release generator

### DIFF
--- a/examples/alpine-slim.yaml
+++ b/examples/alpine-slim.yaml
@@ -1,0 +1,23 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - alpine-baselayout-data
+    - apk-tools
+    - busybox
+
+entrypoint:
+  command: /bin/sh -l
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin
+
+# data for /etc/os-release if it does not already exist
+# in the image
+os-release:
+  id: alpine
+  version-id: '3.16.0'
+  name: 'Alpine Slim'
+  pretty-name: 'Alpine Slim (apko)'
+

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -43,6 +43,7 @@ type buildImplementation interface {
 	InitializeApk(*options.Options, *types.ImageConfiguration) error
 	MutateAccounts(*options.Options, *types.ImageConfiguration) error
 	MutatePaths(*options.Options, *types.ImageConfiguration) error
+	GenerateOSRelease(*options.Options, *types.ImageConfiguration) error
 	ValidateImageConfiguration(*types.ImageConfiguration) error
 	BuildImage(*options.Options, *types.ImageConfiguration, *exec.Executor, *s6.Context) error
 	WriteSupervisionTree(*s6.Context, *types.ImageConfiguration) error
@@ -189,6 +190,10 @@ func buildImage(
 	// maybe install busybox symlinks
 	if err := di.InstallBusyboxSymlinks(o, e); err != nil {
 		return fmt.Errorf("failed to install busybox symlinks: %w", err)
+	}
+
+	if err := di.GenerateOSRelease(o, ic); err != nil {
+		return fmt.Errorf("failed to generate /etc/os-release: %w", err)
 	}
 
 	if err := di.WriteSupervisionTree(s6context, ic); err != nil {

--- a/pkg/build/buildfakes/fake_build_implementation.go
+++ b/pkg/build/buildfakes/fake_build_implementation.go
@@ -38,6 +38,18 @@ type FakeBuildImplementation struct {
 		result1 string
 		result2 error
 	}
+	GenerateOSReleaseStub        func(*options.Options, *types.ImageConfiguration) error
+	generateOSReleaseMutex       sync.RWMutex
+	generateOSReleaseArgsForCall []struct {
+		arg1 *options.Options
+		arg2 *types.ImageConfiguration
+	}
+	generateOSReleaseReturns struct {
+		result1 error
+	}
+	generateOSReleaseReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GenerateSBOMStub        func(*options.Options) error
 	generateSBOMMutex       sync.RWMutex
 	generateSBOMArgsForCall []struct {
@@ -265,6 +277,68 @@ func (fake *FakeBuildImplementation) BuildTarballReturnsOnCall(i int, result1 st
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeBuildImplementation) GenerateOSRelease(arg1 *options.Options, arg2 *types.ImageConfiguration) error {
+	fake.generateOSReleaseMutex.Lock()
+	ret, specificReturn := fake.generateOSReleaseReturnsOnCall[len(fake.generateOSReleaseArgsForCall)]
+	fake.generateOSReleaseArgsForCall = append(fake.generateOSReleaseArgsForCall, struct {
+		arg1 *options.Options
+		arg2 *types.ImageConfiguration
+	}{arg1, arg2})
+	stub := fake.GenerateOSReleaseStub
+	fakeReturns := fake.generateOSReleaseReturns
+	fake.recordInvocation("GenerateOSRelease", []interface{}{arg1, arg2})
+	fake.generateOSReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuildImplementation) GenerateOSReleaseCallCount() int {
+	fake.generateOSReleaseMutex.RLock()
+	defer fake.generateOSReleaseMutex.RUnlock()
+	return len(fake.generateOSReleaseArgsForCall)
+}
+
+func (fake *FakeBuildImplementation) GenerateOSReleaseCalls(stub func(*options.Options, *types.ImageConfiguration) error) {
+	fake.generateOSReleaseMutex.Lock()
+	defer fake.generateOSReleaseMutex.Unlock()
+	fake.GenerateOSReleaseStub = stub
+}
+
+func (fake *FakeBuildImplementation) GenerateOSReleaseArgsForCall(i int) (*options.Options, *types.ImageConfiguration) {
+	fake.generateOSReleaseMutex.RLock()
+	defer fake.generateOSReleaseMutex.RUnlock()
+	argsForCall := fake.generateOSReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBuildImplementation) GenerateOSReleaseReturns(result1 error) {
+	fake.generateOSReleaseMutex.Lock()
+	defer fake.generateOSReleaseMutex.Unlock()
+	fake.GenerateOSReleaseStub = nil
+	fake.generateOSReleaseReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBuildImplementation) GenerateOSReleaseReturnsOnCall(i int, result1 error) {
+	fake.generateOSReleaseMutex.Lock()
+	defer fake.generateOSReleaseMutex.Unlock()
+	fake.GenerateOSReleaseStub = nil
+	if fake.generateOSReleaseReturnsOnCall == nil {
+		fake.generateOSReleaseReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateOSReleaseReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeBuildImplementation) GenerateSBOM(arg1 *options.Options) error {
@@ -773,6 +847,8 @@ func (fake *FakeBuildImplementation) Invocations() map[string][][]interface{} {
 	defer fake.buildImageMutex.RUnlock()
 	fake.buildTarballMutex.RLock()
 	defer fake.buildTarballMutex.RUnlock()
+	fake.generateOSReleaseMutex.RLock()
+	defer fake.generateOSReleaseMutex.RUnlock()
 	fake.generateSBOMMutex.RLock()
 	defer fake.generateSBOMMutex.RUnlock()
 	fake.initializeApkMutex.RLock()

--- a/pkg/build/os-release.go
+++ b/pkg/build/os-release.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
+)
+
+func (di *defaultBuildImplementation) GenerateOSRelease(
+	o *options.Options, ic *types.ImageConfiguration,
+) error {
+	path := filepath.Join(o.WorkDir, "etc", "os-release")
+
+	_, err := os.Stat(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	w, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if ic.OSRelease.ID != "" {
+		_, err := fmt.Fprintf(w, "ID=%s\n", ic.OSRelease.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ic.OSRelease.Name != "" {
+		_, err := fmt.Fprintf(w, "NAME=\"%s\"\n", ic.OSRelease.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ic.OSRelease.PrettyName != "" {
+		_, err := fmt.Fprintf(w, "PRETTY_NAME=\"%s\"\n", ic.OSRelease.PrettyName)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ic.OSRelease.VersionID != "" {
+		_, err := fmt.Fprintf(w, "VERSION_ID=%s\n", ic.OSRelease.VersionID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ic.OSRelease.HomeURL != "" {
+		_, err := fmt.Fprintf(w, "HOME_URL=\"%s\"\n", ic.OSRelease.HomeURL)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ic.OSRelease.BugReportURL != "" {
+		_, err := fmt.Fprintf(w, "BUG_REPORT_URL=\"%s\"\n", ic.OSRelease.BugReportURL)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -64,6 +64,23 @@ func (ic *ImageConfiguration) Validate() error {
 		}
 	}
 
+	if ic.OSRelease.ID == "" {
+		ic.OSRelease.ID = "alpine"
+	}
+
+	if ic.OSRelease.Name == "" {
+		ic.OSRelease.Name = "apko-generated image"
+		ic.OSRelease.PrettyName = "apko-generated image"
+	}
+
+	if ic.OSRelease.VersionID == "" {
+		ic.OSRelease.VersionID = "3.999"
+	}
+
+	if ic.OSRelease.HomeURL == "" {
+		ic.OSRelease.HomeURL = "https://github.com/chainguard-dev/apko"
+	}
+
 	return nil
 }
 

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -74,7 +74,7 @@ func (ic *ImageConfiguration) Validate() error {
 	}
 
 	if ic.OSRelease.VersionID == "" {
-		ic.OSRelease.VersionID = "3.999"
+		ic.OSRelease.VersionID = "3.16"
 	}
 
 	if ic.OSRelease.HomeURL == "" {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -41,6 +41,15 @@ type PathMutation struct {
 	Source      string
 }
 
+type OSRelease struct {
+	Name         string
+	ID           string
+	VersionID    string `yaml:"version-id"`
+	PrettyName   string `yaml:"pretty-name"`
+	HomeURL      string `yaml:"home-url"`
+	BugReportURL string `yaml:"bug-report-url"`
+}
+
 type ImageConfiguration struct {
 	Contents struct {
 		Repositories []string
@@ -62,6 +71,7 @@ type ImageConfiguration struct {
 	Archs       []Architecture
 	Environment map[string]string
 	Paths       []PathMutation
+	OSRelease   OSRelease `yaml:"os-release"`
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
Generate `/etc/os-release` if it does not already exist.

Closes #165.