### PR TITLE
Fix development environment apko example

### DIFF
--- a/examples/apko-devenv.yaml
+++ b/examples/apko-devenv.yaml
@@ -31,4 +31,4 @@ contents:
     - make
     - docker-cli
 entrypoint:
-  command: /bin/sh -l
+  shell-fragment: /bin/sh -l


### PR DESCRIPTION
Requires `shell-fragment` syntax.