### PR TITLE
Allow entrypoint to be blank.

### DIFF
--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -109,13 +109,20 @@ There are several child elements:
  - `type`: if this is set to `service-bundle`, the s6 supervisor will be used to start commands
    listed in `services`
  - `command`: if the type is not `service-bundle`, this can be set to specify a command to run when the
-   container starts.
+   container starts. Note that this sets the "entrypoint" value on OCI images (contrast with the
+   `cmd` top level element).
  - `shell-fragment`: if the type is not `service-bundle`, this behaves like `command`, except that the
    command is a shell fragment.
  - `services`: a map of service names to commands to run by the s6 supervisor. `type` should be set
    to `service-bundle` when specifying services.
 
 Services are monitored with the [s6 supervisor](https://skarnet.org/software/s6/index.html).
+
+### Cmd top level element
+
+`cmd` defines a command to run when the container starts up. If `entrypoint.command` is not set, it
+will be executed with `/bin/sh -c`. If `entrypoint.command` is set, `cmd` will be passed as arguments to
+`entrypoint.command`. This sets the "cmd" value on OCI images.
 
 ### Accounts top level element
 

--- a/examples/alpine-386_amd64.yaml
+++ b/examples/alpine-386_amd64.yaml
@@ -4,6 +4,8 @@ contents:
   packages:
     - alpine-base
 
+cmd: /bin/sh -l
+
 archs:
   - amd64
   - 386

--- a/examples/alpine-386_amd64.yaml
+++ b/examples/alpine-386_amd64.yaml
@@ -4,9 +4,6 @@ contents:
   packages:
     - alpine-base
 
-entrypoint:
-  command: /bin/sh -l
-
 archs:
   - amd64
   - 386

--- a/examples/alpine-amd64.yaml
+++ b/examples/alpine-amd64.yaml
@@ -4,5 +4,7 @@ contents:
   packages:
     - alpine-base
 
+cmd: /bin/sh -l
+
 archs:
   - amd64

--- a/examples/alpine-amd64.yaml
+++ b/examples/alpine-amd64.yaml
@@ -4,8 +4,5 @@ contents:
   packages:
     - alpine-base
 
-entrypoint:
-  command: /bin/sh -l
-
 archs:
   - amd64

--- a/examples/alpine-base-rootless.yaml
+++ b/examples/alpine-base-rootless.yaml
@@ -13,6 +13,8 @@ accounts:
       uid: 10000
   run-as: nonroot
 
+cmd: /bin/sh -l
+
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/alpine-base-rootless.yaml
+++ b/examples/alpine-base-rootless.yaml
@@ -4,9 +4,6 @@ contents:
   packages:
     - alpine-base
 
-entrypoint:
-  command: /bin/sh -l
-
 accounts:
   groups:
     - groupname: nonroot

--- a/examples/alpine-base.yaml
+++ b/examples/alpine-base.yaml
@@ -4,6 +4,8 @@ contents:
   packages:
     - alpine-base
 
+cmd: /bin/sh -l
+  
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/alpine-base.yaml
+++ b/examples/alpine-base.yaml
@@ -4,9 +4,6 @@ contents:
   packages:
     - alpine-base
 
-entrypoint:
-  command: /bin/sh -l
-
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/alpine-slim.yaml
+++ b/examples/alpine-slim.yaml
@@ -6,9 +6,6 @@ contents:
     - apk-tools
     - busybox
 
-entrypoint:
-  command: /bin/sh -l
-
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/examples/alpine-slim.yaml
+++ b/examples/alpine-slim.yaml
@@ -10,6 +10,8 @@ contents:
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 
+cmd: /bin/sh -l
+
 # data for /etc/os-release if it does not already exist
 # in the image
 os-release:

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -112,20 +112,16 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 		splitcmd, err := shlex.Split(ic.Entrypoint.Command)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse entrypoint command: %w", err)
-		} else {
-			cfg.Config.Entrypoint = splitcmd
 		}
+		cfg.Config.Entrypoint = splitcmd
 	}
 
 	if ic.Cmd != "" {
-		logger.Print("ENTERING CMD STUFF")
-
 		splitcmd, err := shlex.Split(string(ic.Cmd))
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse cmd: %w", err)
-		} else {
-			cfg.Config.Cmd = splitcmd
 		}
+		cfg.Config.Cmd = splitcmd
 	}
 
 	if len(ic.Environment) > 0 {

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -114,8 +114,7 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 		}
 
 		cfg.Config.Entrypoint = splitcmd
-	default:
-		cfg.Config.Entrypoint = []string{"/bin/sh", "-l"}
+		// NOTE: allow empty Entrypoint which runtime will override to `/bin/sh -c` and handle quoting
 	}
 
 	if len(ic.Environment) > 0 {

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -117,7 +117,7 @@ func buildImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created
 	}
 
 	if ic.Cmd != "" {
-		splitcmd, err := shlex.Split(string(ic.Cmd))
+		splitcmd, err := shlex.Split(ic.Cmd)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse cmd: %w", err)
 		}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -105,8 +105,12 @@ func (ic *ImageConfiguration) Summarize(logger *log.Logger) {
 	if ic.Entrypoint.Type != "" || ic.Entrypoint.Command != "" || len(ic.Entrypoint.Services) != 0 {
 		logger.Printf("  entrypoint:")
 		logger.Printf("    type:    %s", ic.Entrypoint.Type)
-		logger.Printf("    cmd:     %s", ic.Entrypoint.Command)
+		logger.Printf("    command:     %s", ic.Entrypoint.Command)
 		logger.Printf("    service: %v", ic.Entrypoint.Services)
+		logger.Printf("    shell fragment: %v", ic.Entrypoint.ShellFragment)
+	}
+	if ic.Cmd != "" {
+		logger.Printf("  cmd: %s", ic.Cmd)
 	}
 	if ic.Accounts.RunAs != "" || len(ic.Accounts.Users) != 0 || len(ic.Accounts.Groups) != 0 {
 		logger.Printf("  accounts:")

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -64,6 +64,7 @@ type ImageConfiguration struct {
 		// TBD: presently a map of service names and the command to run
 		Services map[interface{}]interface{}
 	}
+	Cmd      Cmd
 	Accounts struct {
 		RunAs  string `yaml:"run-as"`
 		Users  []User
@@ -74,6 +75,8 @@ type ImageConfiguration struct {
 	Paths       []PathMutation
 	OSRelease   OSRelease `yaml:"os-release"`
 }
+
+type Cmd string
 
 // Architecture represents a CPU architecture for the container image.
 type Architecture struct{ s string }

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -64,7 +64,7 @@ type ImageConfiguration struct {
 		// TBD: presently a map of service names and the command to run
 		Services map[interface{}]interface{}
 	}
-	Cmd      Cmd
+	Cmd      string
 	Accounts struct {
 		RunAs  string `yaml:"run-as"`
 		Users  []User
@@ -75,8 +75,6 @@ type ImageConfiguration struct {
 	Paths       []PathMutation
 	OSRelease   OSRelease `yaml:"os-release"`
 }
-
-type Cmd string
 
 // Architecture represents a CPU architecture for the container image.
 type Architecture struct{ s string }


### PR DESCRIPTION
Allowing entrypoint to be blank can be used to force default docker behaviour of running cmd in shell. Also updated examples.

Closes #177.

We could also create a PR to set CMD to `/bin/sh -l` which would be keep previous behaviour when no command is specified.

