### PR TITLE
Try again fixing the permissions on home directories.

### DIFF
--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -131,6 +131,8 @@ func (di *defaultBuildImplementation) MutateAccounts(
 				return fmt.Errorf("creating homedir: %w", err)
 			} else if err := os.Chown(targetHomedir, int(ue.UID), int(ue.GID)); err != nil {
 				return fmt.Errorf("chown(%d, %d) = %w", ue.UID, ue.GID, err)
+			} else if err := os.Chmod(targetHomedir, 0700); err != nil {
+				return fmt.Errorf("chmod %s %d = %w", ue.HomeDir, 0700, err)
 			}
 
 			// We have made sure that the directory exists, and if we created it


### PR DESCRIPTION
Previously we did a `MkdirAll` with `0700` as `root` and `Chown` the top directory to the appropriate `uid:gid`, but it turns out that this means `/home` is owned by `root` with 0700 which is insufficient for non-`root` users to list directories under `/home/...`

Instead, we lead the `MkdirAll` with 0755 that was our fallback, but in addition to the `Chown` we do a `Chmod` to reduce just the leaf directory's permissions to `0700`, which appears to work, and matches the `/home` permissions from the OG distroless images.