### PR TITLE
Github action to automatically add apko issues to project board.

### DIFF
--- a/.github/workflows/add-issues.yml
+++ b/.github/workflows/add-issues.yml
@@ -1,0 +1,20 @@
+name: Add apko repo issues to Images project board
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write 
+
+jobs:
+  add-to-project:
+    name: Add issue to project board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/chainguard-dev/projects/12
+          github-token: ${{ secrets.PROJECT_WRITER }}


### PR DESCRIPTION
Adding Github action to automatically add apko issues to Github Projects Beta board.

https://github.com/orgs/chainguard-dev/projects/12