### PR TITLE
Add --use-oci-mediatypes option to use OCI mediatypes

### DIFF
--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -167,3 +167,11 @@ func WithArch(arch types.Architecture) Option {
 		return nil
 	}
 }
+
+// WithOCIMediatypes determine whether to use OCI mediatypes for the build context.
+func WithOCIMediatypes(useOCIMediaTypes bool) Option {
+	return func(bc *Context) error {
+		bc.Options.UseOCIMediaTypes = useOCIMediaTypes
+		return nil
+	}
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -22,18 +22,19 @@ import (
 )
 
 type Options struct {
-	WantSBOM        bool
-	UseProot        bool
-	WorkDir         string
-	TarballPath     string
-	Tags            []string
-	SourceDateEpoch time.Time
-	SBOMPath        string
-	SBOMFormats     []string
-	ExtraKeyFiles   []string
-	ExtraRepos      []string
-	Arch            types.Architecture
-	Log             *log.Logger
+	UseOCIMediaTypes bool
+	WantSBOM         bool
+	UseProot         bool
+	WorkDir          string
+	TarballPath      string
+	Tags             []string
+	SourceDateEpoch  time.Time
+	SBOMPath         string
+	SBOMFormats      []string
+	ExtraKeyFiles    []string
+	ExtraRepos       []string
+	Arch             types.Architecture
+	Log              *log.Logger
 }
 
 var Default = Options{
@@ -45,6 +46,7 @@ func (o *Options) Summarize() {
 	o.Log.Printf("  tarball path: %s", o.TarballPath)
 	o.Log.Printf("  use proot: %t", o.UseProot)
 	o.Log.Printf("  source date: %s", o.SourceDateEpoch)
+	o.Log.Printf("  OCI mediatypes: %t", o.UseOCIMediaTypes)
 	o.Log.Printf("  SBOM output path: %s", o.SBOMPath)
 	o.Log.Printf("  arch: %v", o.Arch.ToAPK())
 }


### PR DESCRIPTION
Resolves #209

It works! After running:
```
$ apko publish --use-oci-mediatypes examples/alpine-base.yaml ghcr.io/jdolitsky/apko-oci-test:testing1234
```

Here is the results:
```
$ crane manifest ghcr.io/jdolitsky/apko-oci-test:testing1234 | jq
```

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:ac9c79faea9a6d47ef0e81fd69769ac8c9627fa5d0fcf41bdd42d004c16128f8",
      "platform": {
        "architecture": "386",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:4adff1fc78d9a05767aa15b8e3f67b1eccb965af9c38662e5b1d4d3ff909803d",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:5e5d4e890e3f804e420e33e98995f3d504a72faaba151caa0f64ae4e60df386e",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v6"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:df11bf88fea5250c7d7caeb89e1e8713e74154b297b007076279032008249de8",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v7"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:0bb77502b9eb42e9b9b553900a6a5d0f1d41790fced8744c1ef038f11e5283d2",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:b951563ab431ea51f7d3a7d7c46f730a87ba272c04515221836bd7be579a09d8",
      "platform": {
        "architecture": "ppc64le",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:45d4fdc15d7ee304fba5e88dc26eb71d3fcc97c29f5f437fa01c905dd647aa45",
      "platform": {
        "architecture": "riscv64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 405,
      "digest": "sha256:d7e8170e6aabe7b475b2260cf3bc24c1a85a74499694f063bdbecfa90be6ec23",
      "platform": {
        "architecture": "s390x",
        "os": "linux"
      }
    }
  ]
}
```

Single manifest:
```
$ crane manifest ghcr.io/jdolitsky/apko-oci-test@sha256:ac9c79faea9a6d47ef0e81fd69769ac8c9627fa5d0fcf41bdd42d004c16128f8 | jq
```

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "size": 433,
    "digest": "sha256:9f04c6fe9163a6f8028a0a731964445c03b5270aeccf38d461d57cc73327fd22"
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "size": 3228010,
      "digest": "sha256:4bca50d285fc75b06f8fe97e2301dedb293dc34c168df07bbbf8718bf549586b"
    }
  ]
}
```

and it runs!
```
$ docker run --rm -it --entrypoint sh ghcr.io/jdolitsky/apko-oci-test:testing1234 -c 'echo $PATH && whoami'
/usr/sbin:/sbin:/usr/bin:/bin
root
```
