### PR TITLE
Use OCI mediatypes by default

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -32,7 +32,7 @@ import (
 
 func buildCmd() *cobra.Command {
 	var useProot bool
-	var useOCIMediaTypes bool
+	var useDockerMediaTypes bool
 	var buildDate string
 	var buildArch string
 	var writeSBOM bool
@@ -63,7 +63,7 @@ bill of materials) describing the image contents.
 			return BuildCmd(cmd.Context(), args[1], args[2],
 				build.WithConfig(args[0]),
 				build.WithProot(useProot),
-				build.WithOCIMediatypes(useOCIMediaTypes),
+				build.WithDockerMediatypes(useDockerMediaTypes),
 				build.WithBuildDate(buildDate),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithSBOM(sbomPath),
@@ -77,7 +77,7 @@ bill of materials) describing the image contents.
 	}
 
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
-	cmd.Flags().BoolVar(&useOCIMediaTypes, "use-oci-mediatypes", false, "use OCI mediatypes for image layers/manifest")
+	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image in RFC3339 format")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate SBOMs")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate SBOMs in dir (defaults to image directory)")
@@ -129,19 +129,19 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, opts ...build.O
 		return fmt.Errorf("generating SBOMs: %w", err)
 	}
 
-	if bc.Options.UseOCIMediaTypes {
-		if err := oci.BuildOCIImageTarballFromLayer(
+	if bc.Options.UseDockerMediaTypes {
+		if err := oci.BuildDockerImageTarballFromLayer(
 			imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch,
 			log.Default(),
 		); err != nil {
-			return fmt.Errorf("failed to build OCI image: %w", err)
+			return fmt.Errorf("failed to build Docker image: %w", err)
 		}
 	} else {
 		if err := oci.BuildImageTarballFromLayer(
 			imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch,
 			log.Default(),
 		); err != nil {
-			return fmt.Errorf("failed to build Docker image: %w", err)
+			return fmt.Errorf("failed to build OCI image: %w", err)
 		}
 	}
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -36,7 +36,7 @@ import (
 func publish() *cobra.Command {
 	var imageRefs string
 	var useProot bool
-	var useOCIMediaTypes bool
+	var useDockerMediaTypes bool
 	var buildDate string
 	var sbomPath string
 	var sbomFormats []string
@@ -58,7 +58,7 @@ in a keychain.`,
 			if err := PublishCmd(cmd.Context(), imageRefs, archs,
 				build.WithConfig(args[0]),
 				build.WithProot(useProot),
-				build.WithOCIMediatypes(useOCIMediaTypes),
+				build.WithDockerMediatypes(useDockerMediaTypes),
 				build.WithTags(args[1:]...),
 				build.WithBuildDate(buildDate),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
@@ -75,7 +75,7 @@ in a keychain.`,
 
 	cmd.Flags().StringVar(&imageRefs, "image-refs", "", "path to file where a list of the published image references will be written")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
-	cmd.Flags().BoolVar(&useOCIMediaTypes, "use-oci-mediatypes", false, "use OCI mediatypes for image layers/manifest")
+	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate an SBOM")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
@@ -124,15 +124,15 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		}
 		defer os.Remove(layerTarGZ)
 
-		if bc.Options.UseOCIMediaTypes {
-			digest, _, err = oci.PublishOCIImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Tags...)
+		if bc.Options.UseDockerMediaTypes {
+			digest, _, err = oci.PublishDockerImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Tags...)
 			if err != nil {
-				return fmt.Errorf("failed to build OCI image: %w", err)
+				return fmt.Errorf("failed to build Docker image: %w", err)
 			}
 		} else {
 			digest, _, err = oci.PublishImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Tags...)
 			if err != nil {
-				return fmt.Errorf("failed to build Docker image: %w", err)
+				return fmt.Errorf("failed to build OCI image: %w", err)
 			}
 		}
 
@@ -161,15 +161,15 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 				// defer os.Remove(layerTarGZ)
 
 				var img coci.SignedImage
-				if bc.Options.UseOCIMediaTypes {
-					_, img, err = oci.PublishOCIImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats)
+				if bc.Options.UseDockerMediaTypes {
+					_, img, err = oci.PublishDockerImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats)
 					if err != nil {
-						return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
+						return fmt.Errorf("failed to build Docker image for %q: %w", arch, err)
 					}
 				} else {
 					_, img, err = oci.PublishImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Options.Log, bc.Options.SBOMPath, bc.Options.SBOMFormats)
 					if err != nil {
-						return fmt.Errorf("failed to build Docker image for %q: %w", arch, err)
+						return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
 					}
 				}
 				imgs[arch] = img
@@ -181,15 +181,15 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			return err
 		}
 
-		if bc.Options.UseOCIMediaTypes {
-			digest, err = oci.PublishOCIIndex(imgs, log.Default(), bc.Options.Tags...)
+		if bc.Options.UseDockerMediaTypes {
+			digest, err = oci.PublishDockerIndex(imgs, log.Default(), bc.Options.Tags...)
 			if err != nil {
-				return fmt.Errorf("failed to build OCI index: %w", err)
+				return fmt.Errorf("failed to build Docker index: %w", err)
 			}
 		} else {
 			digest, err = oci.PublishIndex(imgs, log.Default(), bc.Options.Tags...)
 			if err != nil {
-				return fmt.Errorf("failed to build Docker index: %w", err)
+				return fmt.Errorf("failed to build OCI index: %w", err)
 			}
 		}
 	}

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -195,11 +195,11 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 }
 
 func BuildImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger) error {
-	return buildImageTarballFromLayerWithMediaType(ggcrtypes.DockerLayer, imageRef, layerTarGZ, outputTarGZ, ic, created, arch, logger)
+	return buildImageTarballFromLayerWithMediaType(ggcrtypes.OCILayer, imageRef, layerTarGZ, outputTarGZ, ic, created, arch, logger)
 }
 
-func BuildOCIImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger) error {
-	return buildImageTarballFromLayerWithMediaType(ggcrtypes.OCILayer, imageRef, layerTarGZ, outputTarGZ, ic, created, arch, logger)
+func BuildDockerImageTarballFromLayer(imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger) error {
+	return buildImageTarballFromLayerWithMediaType(ggcrtypes.DockerLayer, imageRef, layerTarGZ, outputTarGZ, ic, created, arch, logger)
 }
 
 func buildImageTarballFromLayerWithMediaType(mediaType ggcrtypes.MediaType, imageRef string, layerTarGZ string, outputTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger) error {
@@ -241,11 +241,11 @@ func publishTagFromImage(image oci.SignedImage, imageRef string, hash v1.Hash) (
 }
 
 func PublishImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger, sbomPath string, sbomFormats []string, tags ...string) (name.Digest, oci.SignedImage, error) {
-	return publishImageFromLayerWithMediaType(ggcrtypes.DockerLayer, layerTarGZ, ic, created, arch, logger, sbomPath, sbomFormats, tags...)
+	return publishImageFromLayerWithMediaType(ggcrtypes.OCILayer, layerTarGZ, ic, created, arch, logger, sbomPath, sbomFormats, tags...)
 }
 
-func PublishOCIImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger, sbomPath string, sbomFormats []string, tags ...string) (name.Digest, oci.SignedImage, error) {
-	return publishImageFromLayerWithMediaType(ggcrtypes.OCILayer, layerTarGZ, ic, created, arch, logger, sbomPath, sbomFormats, tags...)
+func PublishDockerImageFromLayer(layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger, sbomPath string, sbomFormats []string, tags ...string) (name.Digest, oci.SignedImage, error) {
+	return publishImageFromLayerWithMediaType(ggcrtypes.DockerLayer, layerTarGZ, ic, created, arch, logger, sbomPath, sbomFormats, tags...)
 }
 
 func publishImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ string, ic types.ImageConfiguration, created time.Time, arch types.Architecture, logger *log.Logger, sbomPath string, sbomFormats []string, tags ...string) (name.Digest, oci.SignedImage, error) {
@@ -272,11 +272,11 @@ func publishImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarG
 }
 
 func PublishIndex(imgs map[types.Architecture]oci.SignedImage, logger *log.Logger, tags ...string) (name.Digest, error) {
-	return publishIndexWithMediaType(ggcrtypes.DockerManifestList, imgs, logger, tags...)
+	return publishIndexWithMediaType(ggcrtypes.OCIImageIndex, imgs, logger, tags...)
 }
 
-func PublishOCIIndex(imgs map[types.Architecture]oci.SignedImage, logger *log.Logger, tags ...string) (name.Digest, error) {
-	return publishIndexWithMediaType(ggcrtypes.OCIImageIndex, imgs, logger, tags...)
+func PublishDockerIndex(imgs map[types.Architecture]oci.SignedImage, logger *log.Logger, tags ...string) (name.Digest, error) {
+	return publishIndexWithMediaType(ggcrtypes.DockerManifestList, imgs, logger, tags...)
 }
 
 func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, imgs map[types.Architecture]oci.SignedImage, logger *log.Logger, tags ...string) (name.Digest, error) {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -168,10 +168,10 @@ func WithArch(arch types.Architecture) Option {
 	}
 }
 
-// WithOCIMediatypes determine whether to use OCI mediatypes for the build context.
-func WithOCIMediatypes(useOCIMediaTypes bool) Option {
+// WithDockerMediatypes determine whether to use Docker mediatypes for the build context.
+func WithDockerMediatypes(useDockerMediaTypes bool) Option {
 	return func(bc *Context) error {
-		bc.Options.UseOCIMediaTypes = useOCIMediaTypes
+		bc.Options.UseDockerMediaTypes = useDockerMediaTypes
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -22,19 +22,19 @@ import (
 )
 
 type Options struct {
-	UseOCIMediaTypes bool
-	WantSBOM         bool
-	UseProot         bool
-	WorkDir          string
-	TarballPath      string
-	Tags             []string
-	SourceDateEpoch  time.Time
-	SBOMPath         string
-	SBOMFormats      []string
-	ExtraKeyFiles    []string
-	ExtraRepos       []string
-	Arch             types.Architecture
-	Log              *log.Logger
+	UseDockerMediaTypes bool
+	WantSBOM            bool
+	UseProot            bool
+	WorkDir             string
+	TarballPath         string
+	Tags                []string
+	SourceDateEpoch     time.Time
+	SBOMPath            string
+	SBOMFormats         []string
+	ExtraKeyFiles       []string
+	ExtraRepos          []string
+	Arch                types.Architecture
+	Log                 *log.Logger
 }
 
 var Default = Options{
@@ -46,7 +46,7 @@ func (o *Options) Summarize() {
 	o.Log.Printf("  tarball path: %s", o.TarballPath)
 	o.Log.Printf("  use proot: %t", o.UseProot)
 	o.Log.Printf("  source date: %s", o.SourceDateEpoch)
-	o.Log.Printf("  OCI mediatypes: %t", o.UseOCIMediaTypes)
+	o.Log.Printf("  Docker mediatypes: %t", o.UseDockerMediaTypes)
 	o.Log.Printf("  SBOM output path: %s", o.SBOMPath)
 	o.Log.Printf("  arch: %v", o.Arch.ToAPK())
 }


### PR DESCRIPTION
Resolves #211

This reverses the unreleased `--use-oci-mediatypes` option and replaces it with `--use-docker-mediatypes`