### PR TITLE
fix creation dates on SPDX SBOMs

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -139,6 +139,7 @@ func (di *defaultBuildImplementation) GenerateSBOM(o *options.Options) error {
 	}
 	s.Options.ImageInfo.Arch = o.Arch
 	s.Options.ImageInfo.Digest = digest.String()
+	s.Options.ImageInfo.SourceDateEpoch = o.SourceDateEpoch
 	s.Options.OutputDir = o.SBOMPath
 	s.Options.Packages = packages
 	s.Options.Formats = o.SBOMFormats

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"sigs.k8s.io/release-utils/version"
@@ -72,7 +73,7 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 		Name:    documentName,
 		Version: "SPDX-2.2",
 		CreationInfo: CreationInfo{
-			Created: "1970-01-01T00:00:00Z",
+			Created: opts.ImageInfo.SourceDateEpoch.Format(time.RFC3339),
 			Creators: []string{
 				fmt.Sprintf("Tool: apko (%s)", version.GetVersionInfo().GitVersion),
 				"Organization: Chainguard, Inc",

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -15,6 +15,8 @@
 package options
 
 import (
+	"time"
+
 	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 
 	"chainguard.dev/apko/pkg/build/types"
@@ -51,10 +53,11 @@ type OSInfo struct {
 }
 
 type ImageInfo struct {
-	Reference  string
-	Tag        string
-	Name       string
-	Repository string
-	Digest     string
-	Arch       types.Architecture
+	Reference       string
+	Tag             string
+	Name            string
+	Repository      string
+	Digest          string
+	Arch            types.Architecture
+	SourceDateEpoch time.Time
 }


### PR DESCRIPTION
This ensures the SPDX SBOM `creationInfo` is consistent with the `SourceDateEpoch` setting.

Closes #208.