### PR TITLE
add support for uploading an IDB file as an SBOM

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -158,6 +158,7 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 	si := signed.Image(v1Image)
 
 	// Attach the SBOM, e.g.
+	// TODO(kaniini): Allow all SBOM types to be uploaded.
 	if len(sbomFormats) > 0 {
 		var mt ggcrtypes.MediaType
 		var path string
@@ -168,6 +169,9 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		case "cyclonedx":
 			mt = ctypes.CycloneDXJSONMediaType
 			path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.cdx", arch.ToAPK()))
+		case "idb":
+			mt = "application/vnd.apko.installed-db"
+			path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.idb", arch.ToAPK()))
 		default:
 			return nil, fmt.Errorf("unsupported SBOM format: %s", sbomFormats[0])
 		}

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -18,6 +18,7 @@ package generator
 
 import (
 	"chainguard.dev/apko/pkg/sbom/generator/cyclonedx"
+	"chainguard.dev/apko/pkg/sbom/generator/idb"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/apko/pkg/sbom/options"
 )
@@ -38,6 +39,9 @@ func Generators() map[string]Generator {
 
 	cdx := cyclonedx.New()
 	generators[cdx.Key()] = &cdx
+
+	idb := idb.New()
+	generators[idb.Key()] = &idb
 
 	return generators
 }

--- a/pkg/sbom/generator/idb/idb.go
+++ b/pkg/sbom/generator/idb/idb.go
@@ -48,7 +48,7 @@ func (i *IDB) Generate(opts *options.Options, path string) error {
 		return fmt.Errorf("reading installed db for copying: %w", err)
 	}
 
-	if err := os.WriteFile(path, idbData, 0o644); err != nil {
+	if err := os.WriteFile(path, idbData, 0o600); err != nil {
 		return fmt.Errorf("copying installed db: %w", err)
 	}
 

--- a/pkg/sbom/generator/idb/idb.go
+++ b/pkg/sbom/generator/idb/idb.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"chainguard.dev/apko/pkg/sbom/options"
+)
+
+// IDB treats the APK installed DB as an SBOM, which can be used with
+// `apk audit` to check an image for runtime deviations.
+type IDB struct{}
+
+func New() IDB {
+	return IDB{}
+}
+
+func (i *IDB) Key() string {
+	return "idb"
+}
+
+func (i *IDB) Ext() string {
+	return "idb"
+}
+
+// Generate copies the IDB from the work directory and saves it as
+// an SBOM.
+func (i *IDB) Generate(opts *options.Options, path string) error {
+	idbPath := filepath.Join(opts.WorkDir, "lib", "apk", "db", "installed")
+
+	idbData, err := os.ReadFile(idbPath)
+	if err != nil {
+		return fmt.Errorf("reading installed db for copying: %w", err)
+	}
+
+	if err := os.WriteFile(path, idbData, 0o644); err != nil {
+		return fmt.Errorf("copying installed db: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The apkdb can be used as an SBOM itself (in fact, our other SBOMs are just reinterpretations of this data anyway).  By doing so, we can enable use of the `apk audit` command to check for runtime deviations in a container.

Right now this is not terribly useful for :sparkles: political reasons :sparkles:.  We will need to adjust something related to OCI and SBOMs (I forget what) to allow for upload of multiple SBOM types to make the most of this capability.

Closes #187.