### PR TITLE
chore: bump cosign-installer to v2.3.0, which installs cosign 1.8.0

### DIFF
--- a/.github/workflows/mink-e2e.yaml
+++ b/.github/workflows/mink-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
       with:
         version: v0.11.1
     - uses: imjasonh/setup-crane@v0.1
-    - uses: sigstore/cosign-installer@main
+    - uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730 # v2.3.0
 
     - uses: chainguard-dev/actions/setup-kind@main
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
-    - uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.0.1
+    - uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730 # v2.3.0
     - uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # v2.8.1
       with:
         version: v1.7.0
@@ -60,7 +60,7 @@ jobs:
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
       with:
         version: v0.11.1
-    - uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.0.1
+    - uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730 # v2.3.0
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
     - name: Login to registry
       run: |
@@ -93,7 +93,7 @@ jobs:
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
       with:
         version: v0.11.1
-    - uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.0.1
+    - uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730 # v2.3.0
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
     - name: Login to registry
       run: |


### PR DESCRIPTION
This should hopefully fix our Fulcio issue e.g., https://github.com/chainguard-dev/apko/runs/6710222241?check_suite_focus=true#step:7:112