### PR TITLE
Fix Tekton Task release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,10 @@ jobs:
         make sign-image
 
   tekton-task:
-    # Only release Task for tagged releases
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    # Only release the Tekton Task after a CLI release has been created, since
+    # goreleaser creates a GitHub Release which the Tekton Task will be
+    # attached to.
+    needs: cli
 
     name: Release the Tekton Task
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow failed when releases were created by first creating a tag,
and the goreleaser workflow would create a Release. This caused a race
(that the Tekton Task workflow would always lose) resulting in the
task.yaml being unable to be attached to the (non-existent-at-the-time)
release.

This changes the Task generation workflow to depend on the CLI (and
release-creating) workflow, so the release is guaranteed to exist at the
time we attach to it.