### PR TITLE
s6: change supervision tree permission to 0777 from 0755

### DIFF
--- a/pkg/s6/supervision_tree.go
+++ b/pkg/s6/supervision_tree.go
@@ -22,11 +22,20 @@ import (
 )
 
 func (sc *Context) CreateSupervisionDirectory(name string) (string, error) {
-	svcdir := filepath.Join(sc.WorkDir, "sv", name)
+	svbase := filepath.Join(sc.WorkDir, "sv")
+	svcdir := filepath.Join(svbase, name)
 	sc.Log.Printf("  supervision dir: %s", svcdir)
 
 	if err := os.MkdirAll(svcdir, 0755); err != nil {
 		return svcdir, fmt.Errorf("could not make supervision directory: %w", err)
+	}
+
+	if err := os.Chmod(svcdir, 0777); err != nil { // nolint:gosec
+		return svcdir, fmt.Errorf("could not set permissions on supervision dir: %w", err)
+	}
+
+	if err := os.Chmod(svbase, 0777); err != nil { // nolint:gosec
+		return svcdir, fmt.Errorf("could not set permissions on base supervision dir: %w", err)
 	}
 
 	return svcdir, nil

--- a/pkg/s6/supervision_tree.go
+++ b/pkg/s6/supervision_tree.go
@@ -22,11 +22,9 @@ import (
 )
 
 func (sc *Context) CreateSupervisionDirectory(name string) (string, error) {
-
 	svbase := filepath.Join(sc.WorkDir, "sv")
 	svcdir := filepath.Join(svbase, name)
 	sc.Log.Debugf("  supervision dir: %s", svcdir)
-
 
 	if err := os.MkdirAll(svcdir, 0755); err != nil {
 		return svcdir, fmt.Errorf("could not make supervision directory: %w", err)


### PR DESCRIPTION
this allows rootless images to make use of the supervisor

closes #240