### PR TITLE
Fix image structure in apko SBOMs

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -125,6 +125,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, opts ...build.O
 	if err != nil {
 		return fmt.Errorf("failed to build layer image: %w", err)
 	}
+
 	defer os.Remove(layerTarGZ)
 
 	if err := bc.GenerateSBOM(); err != nil {
@@ -134,14 +135,14 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, opts ...build.O
 	if bc.Options.UseDockerMediaTypes {
 		if err := oci.BuildDockerImageTarballFromLayer(
 			imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch,
-			bc.Logger(),
+			bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats,
 		); err != nil {
 			return fmt.Errorf("failed to build Docker image: %w", err)
 		}
 	} else {
 		if err := oci.BuildImageTarballFromLayer(
 			imageRef, layerTarGZ, outputTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch,
-			bc.Logger(),
+			bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats,
 		); err != nil {
 			return fmt.Errorf("failed to build OCI image: %w", err)
 		}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -116,6 +116,9 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		return errors.New("no archs requested")
 	case 1:
 		bc.Options.Arch = bc.ImageConfiguration.Archs[0]
+		// We don't want to build the SBOM just now. We don't know
+		// the image digest.
+		bc.Options.WantSBOM = false
 
 		if err := bc.Refresh(); err != nil {
 			return fmt.Errorf("failed to update build context for %q: %w", bc.Options.Arch, err)
@@ -143,6 +146,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		var errg errgroup.Group
 		workDir := bc.Options.WorkDir
 		imgs := map[types.Architecture]coci.SignedImage{}
+		bc.Options.WantSBOM = false
 
 		for _, arch := range bc.ImageConfiguration.Archs {
 			arch := arch
@@ -175,6 +179,10 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 						return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
 					}
 				}
+
+				// Append the Image data to the SBOM options
+				// bc.Options.  = img ...
+				// Append SBOM
 				imgs[arch] = img
 				return nil
 			})

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -107,118 +106,99 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	if len(bc.ImageConfiguration.Archs) == 0 {
 		bc.ImageConfiguration.Archs = archs
 	}
+	bc.Logger().Infof(
+		"Publishing images for %d architectures: %+v",
+		len(bc.ImageConfiguration.Archs),
+		bc.ImageConfiguration.Archs,
+	)
+
+	// The build context options is sometimes copied in the next functions. Ensure
+	// we have the directory defined and created by invoking the function early.
+	bc.Options.TempDir()
+	defer os.RemoveAll(bc.Options.TempDir())
 
 	bc.Logger().Printf("building tags %v", bc.Options.Tags)
 
-	var digest name.Digest
-	switch len(bc.ImageConfiguration.Archs) {
-	case 0:
-		return errors.New("no archs requested")
-	case 1:
-		bc.Options.Arch = bc.ImageConfiguration.Archs[0]
+	var errg errgroup.Group
+	workDir := bc.Options.WorkDir
+	imgs := map[types.Architecture]coci.SignedImage{}
 
-		if err := bc.Refresh(); err != nil {
-			return fmt.Errorf("failed to update build context for %q: %w", bc.Options.Arch, err)
-		}
+	// This is a hack to skip the SBOM generation during
+	// image build. Will be removed when global options are a thing.
+	formats := bc.Options.SBOMFormats
+	wantSBOM := bc.Options.WantSBOM
+	bc.Options.SBOMFormats = []string{}
+	bc.Options.WantSBOM = false
 
-		layerTarGZ, err := bc.BuildLayer()
-		if err != nil {
-			return fmt.Errorf("failed to build layer image: %w", err)
-		}
-		defer os.Remove(layerTarGZ)
+	imageTags := []string{}
+	if len(bc.ImageConfiguration.Archs) == 1 {
+		imageTags = bc.Options.Tags
+	}
 
-		if bc.Options.UseDockerMediaTypes {
-			digest, _, err = oci.PublishDockerImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Tags...)
-			if err != nil {
-				return fmt.Errorf("failed to build Docker image: %w", err)
+	var finalDigest name.Digest
+	for _, arch := range bc.ImageConfiguration.Archs {
+		arch := arch
+		bc := *bc
+
+		errg.Go(func() error {
+			bc.Options.Arch = arch
+			bc.Options.WorkDir = filepath.Join(workDir, arch.ToAPK())
+
+			if err := bc.Refresh(); err != nil {
+				return fmt.Errorf("failed to update build context for %q: %w", arch, err)
 			}
-		} else {
-			digest, _, err = oci.PublishImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, bc.Options.Arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Tags...)
+
+			layerTarGZ, err := bc.BuildLayer()
 			if err != nil {
-				return fmt.Errorf("failed to build OCI image: %w", err)
+				return fmt.Errorf("failed to build layer image for %q: %w", arch, err)
 			}
-		}
+			// TODO(kaniini): clean up everything correctly for multitag scenario
+			// defer os.Remove(layerTarGZ)
 
-	default:
-		var errg errgroup.Group
-		workDir := bc.Options.WorkDir
-		imgs := map[types.Architecture]coci.SignedImage{}
-		bc.Options.WantSBOM = false
-
-		// This is a hack to skip the SBOM generation during
-		// image build. Will be removed when global options are a thing.
-		formats := bc.Options.SBOMFormats
-		bc.Options.SBOMFormats = []string{}
-
-		// The build context options is sometimes copied in the next
-		// functions. Ensure we have the directory defined and created
-		// by invoking the function early.
-		bc.Options.TempDir()
-		defer os.RemoveAll(bc.Options.TempDir())
-
-		for _, arch := range bc.ImageConfiguration.Archs {
-			arch := arch
-			bc := *bc
-
-			errg.Go(func() error {
-				bc.Options.Arch = arch
-				bc.Options.WorkDir = filepath.Join(workDir, arch.ToAPK())
-
-				if err := bc.Refresh(); err != nil {
-					return fmt.Errorf("failed to update build context for %q: %w", arch, err)
-				}
-
-				layerTarGZ, err := bc.BuildLayer()
+			var img coci.SignedImage
+			if bc.Options.UseDockerMediaTypes {
+				finalDigest, img, err = oci.PublishDockerImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats, imageTags...)
 				if err != nil {
-					return fmt.Errorf("failed to build layer image for %q: %w", arch, err)
+					return fmt.Errorf("failed to build Docker image for %q: %w", arch, err)
 				}
-				// TODO(kaniini): clean up everything correctly for multitag scenario
-				// defer os.Remove(layerTarGZ)
-
-				var img coci.SignedImage
-				if bc.Options.UseDockerMediaTypes {
-					_, img, err = oci.PublishDockerImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats)
-					if err != nil {
-						return fmt.Errorf("failed to build Docker image for %q: %w", arch, err)
-					}
-				} else {
-					_, img, err = oci.PublishImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats)
-					if err != nil {
-						return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
-					}
+			} else {
+				finalDigest, img, err = oci.PublishImageFromLayer(layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(), bc.Options.SBOMPath, bc.Options.SBOMFormats, imageTags...)
+				if err != nil {
+					return fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
 				}
+			}
 
-				// Append the Image data to the SBOM options
-				// bc.Options.  = img ...
-				// Append SBOM
-				imgs[arch] = img
-				return nil
-			})
-		}
+			imgs[arch] = img
+			return nil
+		})
+	}
 
-		if err := errg.Wait(); err != nil {
-			return err
-		}
+	if err := errg.Wait(); err != nil {
+		return err
+	}
 
+	if len(archs) > 1 {
 		if bc.Options.UseDockerMediaTypes {
-			digest, err = oci.PublishDockerIndex(imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Tags...)
+			finalDigest, err = oci.PublishDockerIndex(imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Tags...)
 			if err != nil {
 				return fmt.Errorf("failed to build Docker index: %w", err)
 			}
 		} else {
-			digest, err = oci.PublishIndex(imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Tags...)
+			finalDigest, err = oci.PublishIndex(imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Tags...)
 			if err != nil {
 				return fmt.Errorf("failed to build OCI index: %w", err)
 			}
 		}
+	}
 
-		bc.Options.SBOMFormats = formats
-		sbompath := bc.Options.SBOMPath
-		if bc.Options.SBOMPath == "" {
-			sbompath = bc.Options.TempDir()
-		}
+	bc.Options.SBOMFormats = formats
+	sbompath := bc.Options.SBOMPath
+	if bc.Options.SBOMPath == "" {
+		sbompath = bc.Options.TempDir()
+	}
 
-		logrus.Info("Generating Image SBOMs")
+	logrus.Info("Generating Image SBOMs")
+	if wantSBOM {
 		for arch, img := range imgs {
 			bc.Options.WantSBOM = true
 			bc.Options.Arch = arch
@@ -240,14 +220,14 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	// If provided, this is the name of the file to write digest referenced into
 	if outputRefs != "" {
 		//nolint:gosec // Make image ref file readable by non-root
-		if err := os.WriteFile(outputRefs, []byte(digest.String()), 0666); err != nil {
+		if err := os.WriteFile(outputRefs, []byte(finalDigest.String()), 0666); err != nil {
 			return fmt.Errorf("failed to write digest: %w", err)
 		}
 	}
 
 	// Write the image digest to STDOUT in order to enable command
 	// composition e.g. kn service create --image=$(apko publish ...)
-	fmt.Println(digest)
+	fmt.Println(finalDigest)
 
 	return nil
 }

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -136,7 +136,7 @@ func (di *defaultBuildImplementation) GenerateSBOM(o *options.Options) error {
 		return fmt.Errorf("getting installed packages from sbom: %w", err)
 	}
 	s.Options.ImageInfo.Arch = o.Arch
-	s.Options.ImageInfo.Digest = digest.String()
+	s.Options.ImageInfo.LayerDigest = digest.String()
 	s.Options.ImageInfo.SourceDateEpoch = o.SourceDateEpoch
 	s.Options.OutputDir = o.SBOMPath
 	s.Options.Packages = packages

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -17,8 +17,8 @@ package build
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1tar "github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -52,9 +52,7 @@ type buildImplementation interface {
 type defaultBuildImplementation struct{}
 
 func (di *defaultBuildImplementation) Refresh(o *options.Options) (*s6.Context, *exec.Executor, error) {
-	if strings.HasPrefix(o.TarballPath, "/tmp/apko") {
-		o.TarballPath = ""
-	}
+	o.TarballPath = ""
 
 	hostArch := types.ParseArchitecture(runtime.GOARCH)
 
@@ -79,7 +77,7 @@ func (di *defaultBuildImplementation) BuildTarball(o *options.Options) (string, 
 	if o.TarballPath != "" {
 		outfile, err = os.Create(o.TarballPath)
 	} else {
-		outfile, err = os.CreateTemp("", "apko-*.tar.gz")
+		outfile, err = os.Create(filepath.Join(o.TempDir(), o.TarballFileName()))
 	}
 	if err != nil {
 		return "", fmt.Errorf("opening the build context tarball path failed: %w", err)

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -129,6 +129,8 @@ func (di *defaultBuildImplementation) GenerateSBOM(o *options.Options) error {
 		s.Options.ImageInfo.Name = tag.String()
 	}
 
+	s.Options.ImageInfo.ImageDigest = o.ImageDigest
+
 	// Generate the packages externally as we may
 	// move the package reader somewhere else
 	packages, err := s.ReadPackageIndex()

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -140,9 +140,13 @@ func (di *defaultBuildImplementation) GenerateSBOM(o *options.Options) error {
 	s.Options.ImageInfo.Arch = o.Arch
 	s.Options.ImageInfo.LayerDigest = digest.String()
 	s.Options.ImageInfo.SourceDateEpoch = o.SourceDateEpoch
-	s.Options.OutputDir = o.SBOMPath
 	s.Options.Packages = packages
 	s.Options.Formats = o.SBOMFormats
+
+	s.Options.OutputDir = o.TempDir()
+	if o.SBOMPath != "" {
+		s.Options.OutputDir = o.SBOMPath
+	}
 
 	if _, err := s.Generate(); err != nil {
 		return fmt.Errorf("generating SBOMs: %w", err)

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -64,6 +64,7 @@ func TestBuildLayer(t *testing.T) {
 		mock := buildfakes.FakeBuildImplementation{}
 		tc.prepare(&mock)
 		sut, err := build.New("/mock")
+		sut.Options.WantSBOM = true
 		require.NoError(t, err)
 		sut.SetImplementation(&mock)
 		_, err = sut.BuildLayer()

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -157,45 +157,57 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 	}
 
 	si := signed.Image(v1Image)
-
-	// Attach the SBOM, e.g.
-	// TODO(kaniini): Allow all SBOM types to be uploaded.
-	if len(sbomFormats) > 0 {
-		var mt ggcrtypes.MediaType
-		var path string
-		switch sbomFormats[0] {
-		case "spdx":
-			mt = ctypes.SPDXJSONMediaType
-			path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.spdx.json", arch.ToAPK()))
-		case "cyclonedx":
-			mt = ctypes.CycloneDXJSONMediaType
-			path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.cdx", arch.ToAPK()))
-		case "idb":
-			mt = "application/vnd.apko.installed-db"
-			path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.idb", arch.ToAPK()))
-		default:
-			return nil, fmt.Errorf("unsupported SBOM format: %s", sbomFormats[0])
-		}
-		if len(sbomFormats) > 1 {
-			// When we have multiple formats, warn that we're picking the first.
-			logger.Warnf("multiple SBOM formats requested, uploading SBOM with media type: %s", mt)
-		}
-
-		sbom, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("reading sbom: %w", err)
-		}
-
-		f, err := static.NewFile(sbom, static.WithLayerMediaType(mt))
-		if err != nil {
-			return nil, err
-		}
-		si, err = ocimutate.AttachFileToImage(si, "sbom", f)
-		if err != nil {
-			return nil, err
-		}
+	var err2 error
+	if si, err2 = attachSBOM(si, sbomPath, sbomFormats, arch, logger); err2 != nil {
+		return nil, fmt.Errorf("attaching SBOM to image: %w", err2)
 	}
 
+	return si, nil
+}
+
+func attachSBOM(
+	si oci.SignedImage, sbomPath string, sbomFormats []string,
+	arch types.Architecture, logger *logrus.Entry,
+) (oci.SignedImage, error) {
+	// Attach the SBOM, e.g.
+	// TODO(kaniini): Allow all SBOM types to be uploaded.
+	if len(sbomFormats) == 0 {
+		return nil, nil
+	}
+
+	var mt ggcrtypes.MediaType
+	var path string
+	switch sbomFormats[0] {
+	case "spdx":
+		mt = ctypes.SPDXJSONMediaType
+		path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.spdx.json", arch.ToAPK()))
+	case "cyclonedx":
+		mt = ctypes.CycloneDXJSONMediaType
+		path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.cdx", arch.ToAPK()))
+	case "idb":
+		mt = "application/vnd.apko.installed-db"
+		path = filepath.Join(sbomPath, fmt.Sprintf("sbom-%s.idb", arch.ToAPK()))
+	default:
+		return nil, fmt.Errorf("unsupported SBOM format: %s", sbomFormats[0])
+	}
+	if len(sbomFormats) > 1 {
+		// When we have multiple formats, warn that we're picking the first.
+		logger.Warnf("multiple SBOM formats requested, uploading SBOM with media type: %s", mt)
+	}
+
+	sbom, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading sbom: %w", err)
+	}
+
+	f, err := static.NewFile(sbom, static.WithLayerMediaType(mt))
+	if err != nil {
+		return nil, err
+	}
+	si, err = ocimutate.AttachFileToImage(si, "sbom", f)
+	if err != nil {
+		return nil, err
+	}
 	return si, nil
 }
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -195,6 +195,7 @@ func attachSBOM(
 	// Attach the SBOM, e.g.
 	// TODO(kaniini): Allow all SBOM types to be uploaded.
 	if len(sbomFormats) == 0 {
+		logrus.Debug("Not building sboms, no formats requested")
 		return si, nil
 	}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -87,7 +87,7 @@ func (o *Options) TempDir() string {
 func (o Options) TarballFileName() string {
 	tarName := "apko.tar.gz"
 	if o.Arch.String() != "" {
-		tarName = fmt.Sprintf("apko-%s.tar.gz", o.Arch.String())
+		tarName = fmt.Sprintf("apko-%s.tar.gz", o.Arch.ToAPK())
 	}
 	return tarName
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -38,6 +39,7 @@ type Options struct {
 	ExtraRepos          []string
 	Arch                types.Architecture
 	Log                 *logrus.Logger
+	TempDirPath         string
 }
 
 var Default = Options{
@@ -63,4 +65,19 @@ func (o *Options) Summarize(logger *logrus.Entry) {
 
 func (o *Options) Logger() *logrus.Entry {
 	return o.Log.WithFields(logrus.Fields{"arch": o.Arch.ToAPK()})
+}
+
+// Tempdir returns the temporary directory where apko will create
+// the layer blobs
+func (o *Options) TempDir() string {
+	if o.TempDirPath != "" {
+		return o.TempDirPath
+	}
+
+	path, err := os.MkdirTemp(os.TempDir(), "apko-temp-*")
+	if err != nil {
+		o.Logger().Fatalf(fmt.Errorf("creating tempdir: %w", err).Error())
+	}
+	o.TempDirPath = path
+	return o.TempDirPath
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	ExtraKeyFiles       []string
 	ExtraRepos          []string
 	Arch                types.Architecture
+	ImageDigest         string
 	Log                 *logrus.Logger
 	TempDirPath         string
 }
@@ -80,4 +81,13 @@ func (o *Options) TempDir() string {
 	}
 	o.TempDirPath = path
 	return o.TempDirPath
+}
+
+// TarballFileName returns a deterministic filename for the layer taball
+func (o Options) TarballFileName() string {
+	tarName := "apko.tar.gz"
+	if o.Arch.String() != "" {
+		tarName = fmt.Sprintf("apko-%s.tar.gz", o.Arch.String())
+	}
+	return tarName
 }

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -111,7 +111,7 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 	}
 	rootComponent := Component{
 		BOMRef: purl.NewPackageURL(
-			purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.Digest,
+			purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.LayerDigest,
 			purl.QualifiersFromMap(mmMain), "",
 		).String(),
 		Name:       opts.OS.Name,

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -109,23 +109,52 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 	if opts.ImageInfo.Arch.String() != "" {
 		mmMain["arch"] = opts.ImageInfo.Arch.ToOCIPlatform().Architecture
 	}
-	rootComponent := Component{
+	var imageComponent Component
+	layerComponent := Component{
 		BOMRef: purl.NewPackageURL(
 			purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.LayerDigest,
 			purl.QualifiersFromMap(mmMain), "",
 		).String(),
-		Name:       opts.OS.Name,
+		Name:        opts.OS.Name,
+		Description: "apko OS layer",
+		PUrl: purl.NewPackageURL(
+			purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.LayerDigest,
+			purl.QualifiersFromMap(mmMain), "",
+		).String(),
 		Version:    opts.OS.Version,
 		Type:       "operating-system",
 		Components: pkgComponents,
+	}
+
+	if opts.ImageInfo.ImageDigest != "" {
+		imageComponent = Component{
+			BOMRef: purl.NewPackageURL(
+				purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.ImageDigest,
+				purl.QualifiersFromMap(mmMain), "",
+			).String(),
+			Type: "container",
+			Name: "",
+			// Version:            "",
+			Description: "apko container image",
+			PUrl: purl.NewPackageURL(
+				purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.ImageDigest,
+				purl.QualifiersFromMap(mmMain), "",
+			).String(),
+			Components: []Component{layerComponent},
+		}
 	}
 
 	bom := Document{
 		BOMFormat:    "CycloneDX",
 		SpecVersion:  "1.4",
 		Version:      1,
-		Components:   []Component{rootComponent},
 		Dependencies: pkgDependencies,
+	}
+
+	if opts.ImageInfo.ImageDigest != "" {
+		bom.Components = []Component{imageComponent}
+	} else {
+		bom.Components = []Component{layerComponent}
 	}
 
 	out, err := os.Create(path)

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -66,8 +66,8 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 	// The default document name makes no attempt to avoid
 	// clashes. Ensuring a unique name requires a digest
 	documentName := "sbom"
-	if opts.ImageInfo.Digest != "" {
-		documentName += "-" + opts.ImageInfo.Digest
+	if opts.ImageInfo.LayerDigest != "" {
+		documentName += "-" + opts.ImageInfo.LayerDigest
 	}
 	doc := &Document{
 		ID:      "SPDXRef-DOCUMENT",
@@ -213,7 +213,7 @@ func (sx *SPDX) layerPackage(opts *options.Options) (p *Package, err error) {
 				Category: "PACKAGE_MANAGER",
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
-					purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.Digest,
+					purl.TypeOCI, "", opts.ImageInfo.Name, opts.ImageInfo.LayerDigest,
 					purl.QualifiersFromMap(mmMain), "",
 				).String(),
 			},

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -227,7 +227,11 @@ func (sx *SPDX) apkPackage(opts *options.Options, pkg *repository.Package) (p Pa
 
 // LayerPackage returns a package describing the layer
 func (sx *SPDX) layerPackage(opts *options.Options) (p *Package, err error) {
-	layerPackageName := "apko-os-layer"
+	layerPackageName := opts.ImageInfo.LayerDigest
+	if opts.ImageInfo.Name != "" {
+		layerPackageName = opts.ImageInfo.Name + "@" + opts.ImageInfo.LayerDigest
+	}
+
 	if opts.ImageInfo.Reference != "" {
 		x := ""
 		if !strings.Contains(opts.ImageInfo.Reference, "/") {
@@ -256,10 +260,9 @@ func (sx *SPDX) layerPackage(opts *options.Options) (p *Package, err error) {
 		FilesAnalyzed:    false,
 		LicenseConcluded: NOASSERTION,
 		LicenseDeclared:  NOASSERTION,
-		Description:      "",
+		Description:      "apko operating system layer",
 		DownloadLocation: NOASSERTION,
 		Originator:       "",
-		SourceInfo:       "",
 		CopyrightText:    NOASSERTION,
 		Checksums:        []Checksum{},
 		ExternalRefs: []ExternalRef{

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -58,6 +58,7 @@ type ImageInfo struct {
 	Name            string
 	Repository      string
 	LayerDigest     string
+	ImageDigest     string
 	Arch            types.Architecture
 	SourceDateEpoch time.Time
 }

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -57,7 +57,7 @@ type ImageInfo struct {
 	Tag             string
 	Name            string
 	Repository      string
-	Digest          string
+	LayerDigest     string
 	Arch            types.Architecture
 	SourceDateEpoch time.Time
 }


### PR DESCRIPTION
This PR implements proper image structure in the individual apko images. Both CycloneDX and SPDX have been updated to capture the structure of the images. The biggest change is when running `apko publish`:

* When running apko publish and generating a Cyclonedx SBOM, the layer is now a subcomponent of a new image component.
* When requesting an SPDX SBOM the image now has its own top level package and is related to the layer package.

It is a big refactor as the SBOM generation is now done after publishing the images and the SBOM is now attached at the end of the publish function.

Easiest to visualize it by looking at the sboms. This is before the change:

![image](https://user-images.githubusercontent.com/3935899/176394336-5eb06f88-8eec-4a97-ba2f-3f62d80cac23.png)

This is after the change:

![image](https://user-images.githubusercontent.com/3935899/176394382-f0e23eab-2f37-4327-b6d2-eb81b553d5ea.png)

There are other minor changes, each commit captures the changes as atomic as I could.

Fixes https://github.com/chainguard-dev/apko/issues/225