### PR TITLE
Accept --arch=all only if it's the only element

### DIFF
--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -210,11 +210,12 @@ func ParseArchitecture(s string) Architecture {
 // equivalent ("amd64"). Values are deduped, and the resulting slice is sorted
 // for reproducibility.
 func ParseArchitectures(in []string) []Architecture {
+	if len(in) == 1 && in[0] == "all" {
+		return AllArchs
+	}
+
 	uniq := map[Architecture]struct{}{}
 	for _, s := range in {
-		if s == "all" {
-			return AllArchs
-		}
 		a := ParseArchitecture(s)
 		uniq[a] = struct{}{}
 	}

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -45,7 +45,7 @@ func TestParseArchitectures(t *testing.T) {
 		// Unknown arch strings are accepted.
 		desc: "unknown arch",
 		in:   []string{"apples", "bananas"},
-		want: []Architecture{Architecture{"apples"}, Architecture{"bananas"}},
+		want: []Architecture{{"apples"}, {"bananas"}},
 	}, {
 		desc: "all",
 		in:   []string{"all"},
@@ -54,7 +54,7 @@ func TestParseArchitectures(t *testing.T) {
 		// If 'all' is present and isn't the only element, it will be interpreted as an architecture.
 		desc: "uh oh all",
 		in:   []string{"all", "riscv64"},
-		want: []Architecture{Architecture{"all"}, riscv64},
+		want: []Architecture{{"all"}, riscv64},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := ParseArchitectures(c.in)

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -41,6 +41,20 @@ func TestParseArchitectures(t *testing.T) {
 		desc: "dedupe w/ apk style",
 		in:   []string{"x86_64", "amd64", "arm64", "arm/v6", "armhf"},
 		want: []Architecture{amd64, armv6, arm64},
+	}, {
+		// Unknown arch strings are accepted.
+		desc: "unknown arch",
+		in:   []string{"apples", "bananas"},
+		want: []Architecture{Architecture{"apples"}, Architecture{"bananas"}},
+	}, {
+		desc: "all",
+		in:   []string{"all"},
+		want: AllArchs,
+	}, {
+		// If 'all' is present and isn't the only element, it will be interpreted as an architecture.
+		desc: "uh oh all",
+		in:   []string{"all", "riscv64"},
+		want: []Architecture{Architecture{"all"}, riscv64},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := ParseArchitectures(c.in)


### PR DESCRIPTION
Followup from https://github.com/chainguard-dev/apko/pull/249

I'm not totally happy with this either, tbh. With this, `--arch=arm64,all` will just fail mysteriously later when there aren't apks for the `"all"` arch.

Maybe we should just fail if `all` is found outside of the only element, but that means letting `ParseArchitectures` return an err, which makes this change a lot bigger.

I'd also be okay just closing this and allowing `--arch=foo,bar,all`