### PR TITLE
Add license details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Chainguard Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add license details to Apache 2.0 license. I think this is necessary, but if it's not, just close this PR.

Sorry I didn't fork first. I thought GitHub was going to fork for me when I clicked a UI button earlier. I can re-open this via my own fork if necessary.