### PR TITLE
Fix dependency refs in CycloneDX sboms

### DIFF
--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -85,7 +85,7 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 				continue
 			}
 
-			depRefs = append(depRefs, purl.NewPackageURL("apk", opts.OS.ID, pkg.Name, "",
+			depRefs = append(depRefs, purl.NewPackageURL("apk", opts.OS.ID, dep, "",
 				purl.QualifiersFromMap(mm), "").String())
 		}
 


### PR DESCRIPTION
Package references in the CycloneDX SBOMs are wrong and dependecies of one package are pointing to itself. This PR fixes it.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>