### PR TITLE
Generate and attach multiarch index SBOMs (only SPDX for now)

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/hashicorp/go-multierror"
 	coci "github.com/sigstore/cosign/pkg/oci"
 	"github.com/sirupsen/logrus"
@@ -64,6 +65,10 @@ func (bc *Context) GenerateImageSBOM(arch types.Architecture, img coci.SignedIma
 	opts.ImageDigest = h.String()
 
 	return bc.impl.GenerateSBOM(&opts)
+}
+
+func (bc *Context) GenerateIndexSBOM(indexDigest name.Digest, imgs map[types.Architecture]coci.SignedImage) error {
+	return bc.impl.GenerateIndexSBOM(&bc.Options, indexDigest, imgs)
 }
 
 func (bc *Context) GenerateSBOM() error {

--- a/pkg/build/buildfakes/fake_build_implementation.go
+++ b/pkg/build/buildfakes/fake_build_implementation.go
@@ -8,6 +8,8 @@ import (
 	"chainguard.dev/apko/pkg/exec"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/s6"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sigstore/cosign/pkg/oci"
 )
 
 type FakeBuildImplementation struct {
@@ -37,6 +39,19 @@ type FakeBuildImplementation struct {
 	buildTarballReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
+	}
+	GenerateIndexSBOMStub        func(*options.Options, name.Digest, map[types.Architecture]oci.SignedImage) error
+	generateIndexSBOMMutex       sync.RWMutex
+	generateIndexSBOMArgsForCall []struct {
+		arg1 *options.Options
+		arg2 name.Digest
+		arg3 map[types.Architecture]oci.SignedImage
+	}
+	generateIndexSBOMReturns struct {
+		result1 error
+	}
+	generateIndexSBOMReturnsOnCall map[int]struct {
+		result1 error
 	}
 	GenerateOSReleaseStub        func(*options.Options, *types.ImageConfiguration) error
 	generateOSReleaseMutex       sync.RWMutex
@@ -277,6 +292,69 @@ func (fake *FakeBuildImplementation) BuildTarballReturnsOnCall(i int, result1 st
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOM(arg1 *options.Options, arg2 name.Digest, arg3 map[types.Architecture]oci.SignedImage) error {
+	fake.generateIndexSBOMMutex.Lock()
+	ret, specificReturn := fake.generateIndexSBOMReturnsOnCall[len(fake.generateIndexSBOMArgsForCall)]
+	fake.generateIndexSBOMArgsForCall = append(fake.generateIndexSBOMArgsForCall, struct {
+		arg1 *options.Options
+		arg2 name.Digest
+		arg3 map[types.Architecture]oci.SignedImage
+	}{arg1, arg2, arg3})
+	stub := fake.GenerateIndexSBOMStub
+	fakeReturns := fake.generateIndexSBOMReturns
+	fake.recordInvocation("GenerateIndexSBOM", []interface{}{arg1, arg2, arg3})
+	fake.generateIndexSBOMMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOMCallCount() int {
+	fake.generateIndexSBOMMutex.RLock()
+	defer fake.generateIndexSBOMMutex.RUnlock()
+	return len(fake.generateIndexSBOMArgsForCall)
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOMCalls(stub func(*options.Options, name.Digest, map[types.Architecture]oci.SignedImage) error) {
+	fake.generateIndexSBOMMutex.Lock()
+	defer fake.generateIndexSBOMMutex.Unlock()
+	fake.GenerateIndexSBOMStub = stub
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOMArgsForCall(i int) (*options.Options, name.Digest, map[types.Architecture]oci.SignedImage) {
+	fake.generateIndexSBOMMutex.RLock()
+	defer fake.generateIndexSBOMMutex.RUnlock()
+	argsForCall := fake.generateIndexSBOMArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOMReturns(result1 error) {
+	fake.generateIndexSBOMMutex.Lock()
+	defer fake.generateIndexSBOMMutex.Unlock()
+	fake.GenerateIndexSBOMStub = nil
+	fake.generateIndexSBOMReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBuildImplementation) GenerateIndexSBOMReturnsOnCall(i int, result1 error) {
+	fake.generateIndexSBOMMutex.Lock()
+	defer fake.generateIndexSBOMMutex.Unlock()
+	fake.GenerateIndexSBOMStub = nil
+	if fake.generateIndexSBOMReturnsOnCall == nil {
+		fake.generateIndexSBOMReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateIndexSBOMReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeBuildImplementation) GenerateOSRelease(arg1 *options.Options, arg2 *types.ImageConfiguration) error {
@@ -847,6 +925,8 @@ func (fake *FakeBuildImplementation) Invocations() map[string][][]interface{} {
 	defer fake.buildImageMutex.RUnlock()
 	fake.buildTarballMutex.RLock()
 	defer fake.buildTarballMutex.RUnlock()
+	fake.generateIndexSBOMMutex.RLock()
+	defer fake.generateIndexSBOMMutex.RUnlock()
 	fake.generateOSReleaseMutex.RLock()
 	defer fake.generateOSReleaseMutex.RUnlock()
 	fake.generateSBOMMutex.RLock()

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -206,3 +206,7 @@ type Dependency struct {
 	Ref       string   `json:"ref"`
 	DependsOn []string `json:"dependsOn"`
 }
+
+func (cdx *CycloneDX) GenerateIndex(opts *options.Options, path string) error {
+	return nil
+}

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -85,7 +85,7 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 				continue
 			}
 
-			depRefs = append(depRefs, purl.NewPackageURL("apk", opts.OS.ID, pkg.Name, "",
+			depRefs = append(depRefs, purl.NewPackageURL("apk", opts.OS.ID, dep, "",
 				purl.QualifiersFromMap(mm), "").String())
 		}
 

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -29,6 +29,7 @@ type Generator interface {
 	Key() string
 	Ext() string
 	Generate(*options.Options, string) error
+	GenerateIndex(*options.Options, string) error
 }
 
 func Generators() map[string]Generator {

--- a/pkg/sbom/generator/generatorfakes/fake_generator.go
+++ b/pkg/sbom/generator/generatorfakes/fake_generator.go
@@ -31,6 +31,18 @@ type FakeGenerator struct {
 	generateReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GenerateIndexStub        func(*options.Options, string) error
+	generateIndexMutex       sync.RWMutex
+	generateIndexArgsForCall []struct {
+		arg1 *options.Options
+		arg2 string
+	}
+	generateIndexReturns struct {
+		result1 error
+	}
+	generateIndexReturnsOnCall map[int]struct {
+		result1 error
+	}
 	KeyStub        func() string
 	keyMutex       sync.RWMutex
 	keyArgsForCall []struct {
@@ -160,6 +172,68 @@ func (fake *FakeGenerator) GenerateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeGenerator) GenerateIndex(arg1 *options.Options, arg2 string) error {
+	fake.generateIndexMutex.Lock()
+	ret, specificReturn := fake.generateIndexReturnsOnCall[len(fake.generateIndexArgsForCall)]
+	fake.generateIndexArgsForCall = append(fake.generateIndexArgsForCall, struct {
+		arg1 *options.Options
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GenerateIndexStub
+	fakeReturns := fake.generateIndexReturns
+	fake.recordInvocation("GenerateIndex", []interface{}{arg1, arg2})
+	fake.generateIndexMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeGenerator) GenerateIndexCallCount() int {
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
+	return len(fake.generateIndexArgsForCall)
+}
+
+func (fake *FakeGenerator) GenerateIndexCalls(stub func(*options.Options, string) error) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = stub
+}
+
+func (fake *FakeGenerator) GenerateIndexArgsForCall(i int) (*options.Options, string) {
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
+	argsForCall := fake.generateIndexArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeGenerator) GenerateIndexReturns(result1 error) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = nil
+	fake.generateIndexReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeGenerator) GenerateIndexReturnsOnCall(i int, result1 error) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = nil
+	if fake.generateIndexReturnsOnCall == nil {
+		fake.generateIndexReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateIndexReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeGenerator) Key() string {
 	fake.keyMutex.Lock()
 	ret, specificReturn := fake.keyReturnsOnCall[len(fake.keyArgsForCall)]
@@ -220,6 +294,8 @@ func (fake *FakeGenerator) Invocations() map[string][][]interface{} {
 	defer fake.extMutex.RUnlock()
 	fake.generateMutex.RLock()
 	defer fake.generateMutex.RUnlock()
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
 	fake.keyMutex.RLock()
 	defer fake.keyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/sbom/generator/idb/idb.go
+++ b/pkg/sbom/generator/idb/idb.go
@@ -54,3 +54,7 @@ func (i *IDB) Generate(opts *options.Options, path string) error {
 
 	return nil
 }
+
+func (i *IDB) GenerateIndex(opts *options.Options, path string) error {
+	return nil
+}

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -17,6 +17,8 @@ package options
 import (
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 
 	"chainguard.dev/apko/pkg/build/types"
@@ -59,6 +61,15 @@ type ImageInfo struct {
 	Repository      string
 	LayerDigest     string
 	ImageDigest     string
+	IndexMediaType  ggcrtypes.MediaType
+	IndexDigest     v1.Hash
+	Images          []ArchImageInfo
 	Arch            types.Architecture
 	SourceDateEpoch time.Time
+}
+
+type ArchImageInfo struct {
+	Digest     v1.Hash
+	Arch       types.Architecture
+	SBOMDigest string
 }

--- a/pkg/sbom/sbomfakes/fake_sbom_implementation.go
+++ b/pkg/sbom/sbomfakes/fake_sbom_implementation.go
@@ -36,6 +36,20 @@ type FakeSbomImplementation struct {
 		result1 []string
 		result2 error
 	}
+	GenerateIndexStub        func(*options.Options, map[string]generator.Generator) ([]string, error)
+	generateIndexMutex       sync.RWMutex
+	generateIndexArgsForCall []struct {
+		arg1 *options.Options
+		arg2 map[string]generator.Generator
+	}
+	generateIndexReturns struct {
+		result1 []string
+		result2 error
+	}
+	generateIndexReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	ReadPackageIndexStub        func(*options.Options, string) ([]*repository.Package, error)
 	readPackageIndexMutex       sync.RWMutex
 	readPackageIndexArgsForCall []struct {
@@ -193,6 +207,71 @@ func (fake *FakeSbomImplementation) GenerateReturnsOnCall(i int, result1 []strin
 	}{result1, result2}
 }
 
+func (fake *FakeSbomImplementation) GenerateIndex(arg1 *options.Options, arg2 map[string]generator.Generator) ([]string, error) {
+	fake.generateIndexMutex.Lock()
+	ret, specificReturn := fake.generateIndexReturnsOnCall[len(fake.generateIndexArgsForCall)]
+	fake.generateIndexArgsForCall = append(fake.generateIndexArgsForCall, struct {
+		arg1 *options.Options
+		arg2 map[string]generator.Generator
+	}{arg1, arg2})
+	stub := fake.GenerateIndexStub
+	fakeReturns := fake.generateIndexReturns
+	fake.recordInvocation("GenerateIndex", []interface{}{arg1, arg2})
+	fake.generateIndexMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSbomImplementation) GenerateIndexCallCount() int {
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
+	return len(fake.generateIndexArgsForCall)
+}
+
+func (fake *FakeSbomImplementation) GenerateIndexCalls(stub func(*options.Options, map[string]generator.Generator) ([]string, error)) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = stub
+}
+
+func (fake *FakeSbomImplementation) GenerateIndexArgsForCall(i int) (*options.Options, map[string]generator.Generator) {
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
+	argsForCall := fake.generateIndexArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSbomImplementation) GenerateIndexReturns(result1 []string, result2 error) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = nil
+	fake.generateIndexReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSbomImplementation) GenerateIndexReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.generateIndexMutex.Lock()
+	defer fake.generateIndexMutex.Unlock()
+	fake.GenerateIndexStub = nil
+	if fake.generateIndexReturnsOnCall == nil {
+		fake.generateIndexReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.generateIndexReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeSbomImplementation) ReadPackageIndex(arg1 *options.Options, arg2 string) ([]*repository.Package, error) {
 	fake.readPackageIndexMutex.Lock()
 	ret, specificReturn := fake.readPackageIndexReturnsOnCall[len(fake.readPackageIndexArgsForCall)]
@@ -327,6 +406,8 @@ func (fake *FakeSbomImplementation) Invocations() map[string][][]interface{} {
 	defer fake.checkGeneratorsMutex.RUnlock()
 	fake.generateMutex.RLock()
 	defer fake.generateMutex.RUnlock()
+	fake.generateIndexMutex.RLock()
+	defer fake.generateIndexMutex.RUnlock()
 	fake.readPackageIndexMutex.RLock()
 	defer fake.readPackageIndexMutex.RUnlock()
 	fake.readReleaseDataMutex.RLock()


### PR DESCRIPTION
This PR introduces the index SBOMs for `apko publish`. When publishing more than one image, apko will now attach an SBOM to the image index describing it and linking to the individual arch images.

The index SBOM contains one package which ties the images by adding external refs to image packages in the single image SBOMs. 

For now, only the SPDX driver generates the index SBOMs. I'll add CycloneDX support in a follow-up. 


#### Example Index SBOM:

```json
{
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "sbom-sha256:af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58",
  "spdxVersion": "SPDX-2.2",
  "creationInfo": {
    "created": "1970-01-01T00:00:00Z",
    "creators": [
      "Tool: apko (devel)",
      "Organization: Chainguard, Inc"
    ],
    "licenseListVersion": "3.16"
  },
  "dataLicense": "CC0-1.0",
  "documentNamespace": "https://spdx.org/spdxdocs/apko/",
  "documentDescribes": [
    "SPDXRef-Package-sha256-af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58"
  ],
  "packages": [
    {
      "SPDXID": "SPDXRef-Package-sha256-af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58",
      "name": "172.19.0.1:5000/test-nosbom3@sha256:af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58",
      "filesAnalyzed": false,
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "NOASSERTION",
      "description": "Multi-arch image index",
      "sourceInfo": "Generated at image build time by apko",
      "copyrightText": "NOASSERTION",
      "checksums": [
        {
          "algorithm": "SHA256",
          "checksumValue": "af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58"
        }
      ],
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:oci/172.19.0.1:5000%2Ftest-nosbom3?mediaType=application%2Fvnd.oci.image.index.v1+json\u0026tag=latest",
          "referenceType": "purl"
        }
      ]
    }
  ],
  "relationships": [
    {
      "spdxElementId": "DocumentRef-386-image-sbom:SPDXRef-Package-sha256-d0370905ad41c4eb2b1a56f3139fd6a9acfcef203c27e2a9e1655eab28351fd6",
      "relationshipType": "VARIANT_OF",
      "relatedSpdxElement": "SPDXRef-Package-sha256-af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58"
    },
    {
      "spdxElementId": "DocumentRef-amd64-image-sbom:SPDXRef-Package-sha256-b09ddd04b47e07919402c15ea21bf839a95f6bf38ec0df1594c296425010cf1a",
      "relationshipType": "VARIANT_OF",
      "relatedSpdxElement": "SPDXRef-Package-sha256-af1c5f9673f78aa7a575d627cd8a210bf6a895b0065f719a098dc035eee55a58"
    }
  ],
  "externalDocumentRefs": [
    {
      "checksum": {
        "algorithm": "SHA256",
        "checksumValue": "89ddcc4bd6e2b110aef37f0ba7ae5a638bf8c221a9ba8b618bba908c10324d1c"
      },
      "externalDocumentId": "DocumentRef-386-image-sbom",
      "spdxDocument": "https://172.19.0.1:5000/v2/test-nosbom3/blobs/sha256:89ddcc4bd6e2b110aef37f0ba7ae5a638bf8c221a9ba8b618bba908c10324d1c"
    },
    {
      "checksum": {
        "algorithm": "SHA256",
        "checksumValue": "ff76954b0ade75e2b0c450696c73cc521ef94c94785d30c03c5d624217d2797c"
      },
      "externalDocumentId": "DocumentRef-amd64-image-sbom",
      "spdxDocument": "https://172.19.0.1:5000/v2/test-nosbom3/blobs/sha256:ff76954b0ade75e2b0c450696c73cc521ef94c94785d30c03c5d624217d2797c"
    }
  ]
}

```