### PR TITLE
exec: check for debian qemu-user-static binaries as well as the alpine ones

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -59,13 +59,20 @@ func WithProot(proot bool) Option {
 
 func WithQemu(qemuArch string) Option {
 	return func(e *Executor) error {
-		emu, err := exec.LookPath(fmt.Sprintf("qemu-%s", qemuArch))
-		if err != nil {
-			return fmt.Errorf("unable to find qemu emulator for %s: %w", qemuArch, err)
+		paths := []string{
+			fmt.Sprintf("qemu-%s", qemuArch),
+			fmt.Sprintf("qemu-%s-static", qemuArch),
 		}
 
-		e.UseQemu = emu
-		return nil
+		for _, path := range paths {
+			emu, err := exec.LookPath(path)
+			if err == nil {
+				e.UseQemu = emu
+				return nil
+			}
+		}
+
+		return fmt.Errorf("unable to find qemu emulator for %s on $PATH, is qemu-user or qemu-user-static installed?", qemuArch)
 	}
 }
 


### PR DESCRIPTION
This makes the preflight check for building packages with Melange on Ubuntu hosts more clear.