### PR TITLE
make install: skip rebuilding apko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ apko: $(SRCS) ## Builds apko
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./
 
 .PHONY: install
-install: $(SRCS) apko ## Builds and moves apko into BINDIR (default /usr/bin)
+install: $(SRCS) ## Builds and moves apko into BINDIR (default /usr/bin)
 	install -Dm755 apko ${DESTDIR}${BINDIR}/apko
 
 #####################


### PR DESCRIPTION
CVE-2022-24765 makes it difficult to rebuild from a git
repository as another user, therefore do not bother trying
to do it.