### PR TITLE
Review nits from #257

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -126,7 +126,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	// The build context options is sometimes copied in the next functions. Ensure
 	// we have the directory defined and created by invoking the function early.
 	bc.Options.TempDir()
-	// defer os.RemoveAll(bc.Options.TempDir())
+	defer os.RemoveAll(bc.Options.TempDir())
 
 	bc.Logger().Printf("building tags %v", bc.Options.Tags)
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -352,17 +352,17 @@ func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, imgs map[types.Arc
 		img := imgs[arch]
 		mt, err := img.MediaType()
 		if err != nil {
-			return name.Digest{}, idx, fmt.Errorf("failed to get mediatype: %w", err)
+			return name.Digest{}, nil, fmt.Errorf("failed to get mediatype: %w", err)
 		}
 
 		h, err := img.Digest()
 		if err != nil {
-			return name.Digest{}, idx, fmt.Errorf("failed to compute digest: %w", err)
+			return name.Digest{}, nil, fmt.Errorf("failed to compute digest: %w", err)
 		}
 
 		size, err := img.Size()
 		if err != nil {
-			return name.Digest{}, idx, fmt.Errorf("failed to compute size: %w", err)
+			return name.Digest{}, nil, fmt.Errorf("failed to compute size: %w", err)
 		}
 
 		idx = ocimutate.AppendManifests(idx, ocimutate.IndexAddendum{
@@ -378,7 +378,7 @@ func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, imgs map[types.Arc
 
 	h, err := idx.Digest()
 	if err != nil {
-		return name.Digest{}, idx, err
+		return name.Digest{}, nil, err
 	}
 
 	digest := name.Digest{}
@@ -386,7 +386,7 @@ func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, imgs map[types.Arc
 		logger.Printf("publishing tag %v", tag)
 		digest, err = publishTagFromIndex(idx, tag, h, logger)
 		if err != nil {
-			return name.Digest{}, idx, err
+			return name.Digest{}, nil, err
 		}
 	}
 


### PR DESCRIPTION
This PR fixes two nits leftover from the review of https://github.com/chainguard-dev/apko/pull/257

* Removes a comment to reenable the clean-up of the tmpdir in `apko publish`
* Avoids returning a partially formed index when an error happens in `oci.publishTagFromIndex()`

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
