### PR TITLE
Add recursive option to PathMutation to traverse directory and modify perms

### DIFF
--- a/pkg/build/paths.go
+++ b/pkg/build/paths.go
@@ -42,6 +42,10 @@ func mutatePermissions(o *options.Options, mut types.PathMutation) error {
 		return err
 	}
 
+	if err := os.Chown(target, int(mut.UID), int(mut.GID)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -50,6 +54,23 @@ func mutateDirectory(o *options.Options, mut types.PathMutation) error {
 
 	if err := os.MkdirAll(filepath.Join(o.WorkDir, mut.Path), perms); err != nil {
 		return err
+	}
+
+	if mut.WalkDir {
+		if err := filepath.WalkDir(filepath.Join(o.WorkDir, mut.Path), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if err := os.Chmod(path, perms); err != nil {
+				return err
+			}
+			if err := os.Chown(path, int(mut.UID), int(mut.GID)); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/build/paths.go
+++ b/pkg/build/paths.go
@@ -56,7 +56,7 @@ func mutateDirectory(o *options.Options, mut types.PathMutation) error {
 		return err
 	}
 
-	if mut.WalkDir {
+	if mut.Recursive {
 		if err := filepath.WalkDir(filepath.Join(o.WorkDir, mut.Path), func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -39,6 +39,7 @@ type PathMutation struct {
 	GID         uint32
 	Permissions uint32
 	Source      string
+	WalkDir     bool `yaml:"walk-dir"`
 }
 
 type OSRelease struct {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -39,7 +39,7 @@ type PathMutation struct {
 	GID         uint32
 	Permissions uint32
 	Source      string
-	WalkDir     bool `yaml:"walk-dir"`
+	Recursive   bool
 }
 
 type OSRelease struct {


### PR DESCRIPTION
For distroless.dev/nginx, the `/var/lib/nginx` and `/run/nginx` directories need to be writable by the nginx process.
Right now, there are at least 6 subdirectories/files that also need updated permissions.

We could write each one out explicitly in apko.yaml, but I think it would be easier to give people the option
to change permissions on a directory and all subdirectories/files.
This way we just have to explicitly call out the two dirs mentions above and set `recursive: true` e.g.

```yaml
  - path: /var/lib/nginx
    uid: 10000
    gid: 10000
    type: directory
    permissions: 0o755
    recursive: true
  - path: /run/nginx
    uid: 10000
    gid: 10000
    type: directory
    permissions: 0o755
    recursive: true
```

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>