### PR TITLE
Add VCS URL to SBOMs

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -112,7 +112,7 @@ func (di *defaultBuildImplementation) GenerateImageSBOM(o *options.Options, ic *
 		return nil
 	}
 
-	s := newSBOM(o)
+	s := newSBOM(o, ic)
 
 	if err := s.ReadLayerTarball(o.TarballPath); err != nil {
 		return fmt.Errorf("reading layer tar: %w", err)
@@ -145,7 +145,7 @@ func (di *defaultBuildImplementation) GenerateSBOM(o *options.Options, ic *types
 		return nil
 	}
 
-	s := newSBOM(o)
+	s := newSBOM(o, ic)
 
 	if err := s.ReadLayerTarball(o.TarballPath); err != nil {
 		return fmt.Errorf("reading layer tar: %w", err)
@@ -219,7 +219,7 @@ func buildImage(
 	return nil
 }
 
-func newSBOM(o *options.Options) *sbom.SBOM {
+func newSBOM(o *options.Options, ic *types.ImageConfiguration) *sbom.SBOM {
 	s := sbom.NewWithWorkDir(o.WorkDir, o.Arch)
 	// Parse the image reference
 	if len(o.Tags) > 0 {
@@ -234,6 +234,7 @@ func newSBOM(o *options.Options) *sbom.SBOM {
 
 	s.Options.ImageInfo.SourceDateEpoch = o.SourceDateEpoch
 	s.Options.Formats = o.SBOMFormats
+	s.Options.ImageInfo.VCSUrl = ic.VCSUrl
 
 	s.Options.OutputDir = o.TempDir()
 	if o.SBOMPath != "" {
@@ -252,7 +253,7 @@ func (di *defaultBuildImplementation) GenerateIndexSBOM(
 		return nil
 	}
 
-	s := newSBOM(o)
+	s := newSBOM(o, ic)
 	o.Logger().Infof("Generating index SBOM")
 
 	// Add the image digest

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -40,7 +40,7 @@ func (cdx *CycloneDX) Ext() string {
 	return "cdx"
 }
 
-// Generate writes a cyclondx sbom in path
+// Generate writes a CycloneDX sbom in path
 func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 	pkgComponents := []Component{}
 	pkgDependencies := []Dependency{}
@@ -139,6 +139,19 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 				purl.QualifiersFromMap(mmMain), "",
 			).String(),
 			Components: []Component{layerComponent},
+		}
+	}
+
+	if opts.ImageInfo.VCSUrl != "" {
+		vcsURLRef := ExternalReference{
+			URL:  "vcs",
+			Type: opts.ImageInfo.VCSUrl,
+		}
+
+		if opts.ImageInfo.ImageDigest != "" {
+			imageComponent.ExternalReferences = append(imageComponent.ExternalReferences, vcsURLRef)
+		} else {
+			layerComponent.ExternalReferences = append(layerComponent.ExternalReferences, vcsURLRef)
 		}
 	}
 
@@ -247,6 +260,13 @@ func (cdx *CycloneDX) GenerateIndex(opts *options.Options, path string) error {
 			},
 		},
 		Components: []Component{},
+	}
+
+	if opts.ImageInfo.VCSUrl != "" {
+		indexComponent.ExternalReferences = append(indexComponent.ExternalReferences, ExternalReference{
+			URL:  "vcs",
+			Type: opts.ImageInfo.VCSUrl,
+		})
 	}
 
 	// Add the images as subcomponents

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -109,6 +109,19 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 		})
 	}
 
+	if opts.ImageInfo.VCSUrl != "" {
+		vcsURLRef := ExternalRef{
+			Category: "OTHER",
+			Locator:  opts.ImageInfo.VCSUrl,
+			Type:     "vcs",
+		}
+		if opts.ImageInfo.ImageDigest != "" {
+			imagePackage.ExternalRefs = append(imagePackage.ExternalRefs, vcsURLRef)
+		} else {
+			layerPackage.ExternalRefs = append(layerPackage.ExternalRefs, vcsURLRef)
+		}
+	}
+
 	doc.Packages = append(doc.Packages, *layerPackage)
 
 	for _, pkg := range opts.Packages {
@@ -415,6 +428,15 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 			},
 		},
 	}
+
+	if opts.ImageInfo.VCSUrl != "" {
+		indexPackage.ExternalRefs = append(indexPackage.ExternalRefs, ExternalRef{
+			Category: "OTHER",
+			Locator:  opts.ImageInfo.VCSUrl,
+			Type:     "vcs",
+		})
+	}
+
 	doc.Packages = append(doc.Packages, indexPackage)
 	doc.DocumentDescribes = append(doc.DocumentDescribes, indexPackage.ID)
 

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -61,6 +61,7 @@ type ImageInfo struct {
 	Repository      string
 	LayerDigest     string
 	ImageDigest     string
+	VCSUrl          string
 	IndexMediaType  ggcrtypes.MediaType
 	IndexDigest     v1.Hash
 	Images          []ArchImageInfo


### PR DESCRIPTION
This PR adds the VCS URLs to the SBOMs as external references. Both standards are implemented as follows:

#### CycloneDX:

```json
      "externalReferences": [
        {
          "url": "vcs",
          "type": "git+ssh://git@github.com/puerco/apko.git"
        }
      ],

```

##### SPDX:
```json
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:oci/apko-test?mediaType=application%2Fvnd.oci.image.index.v1+json\u0026tag=latest",
          "referenceType": "purl"
        },
        {
          "referenceCategory": "OTHER",
          "referenceLocator": "git+ssh://git@github.com/puerco/apko.git",
          "referenceType": "vcs"
        }
      ]

```

/cc @kaniini 