### PR TITLE
improve VCS URL detection and add opt-out

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -33,6 +33,7 @@ func buildCmd() *cobra.Command {
 	var useProot bool
 	var useDockerMediaTypes bool
 	var debugEnabled bool
+	var withoutVCS bool
 	var buildDate string
 	var buildArch []string
 	var writeSBOM bool
@@ -80,6 +81,7 @@ bill of materials) describing the image contents.
 				build.WithExtraRepos(extraRepos),
 				build.WithArch(types.ParseArchitecture(ba)),
 				build.WithDebugLogging(debugEnabled),
+				build.WithoutVCS(withoutVCS),
 			)
 		},
 	}
@@ -87,6 +89,7 @@ bill of materials) describing the image contents.
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
+	cmd.Flags().BoolVar(&withoutVCS, "without-vcs", false, "disable VCS URL detection")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image in RFC3339 format")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate SBOMs")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate SBOMs in dir (defaults to image directory)")

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -33,7 +33,7 @@ func buildCmd() *cobra.Command {
 	var useProot bool
 	var useDockerMediaTypes bool
 	var debugEnabled bool
-	var withoutVCS bool
+	var withVCS bool
 	var buildDate string
 	var buildArch []string
 	var writeSBOM bool
@@ -81,7 +81,7 @@ bill of materials) describing the image contents.
 				build.WithExtraRepos(extraRepos),
 				build.WithArch(types.ParseArchitecture(ba)),
 				build.WithDebugLogging(debugEnabled),
-				build.WithoutVCS(withoutVCS),
+				build.WithVCS(withVCS),
 			)
 		},
 	}
@@ -89,7 +89,7 @@ bill of materials) describing the image contents.
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
-	cmd.Flags().BoolVar(&withoutVCS, "without-vcs", false, "disable VCS URL detection")
+	cmd.Flags().BoolVar(&withVCS, "vcs", true, "detect and embed VCS URLs")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image in RFC3339 format")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate SBOMs")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate SBOMs in dir (defaults to image directory)")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -43,6 +43,7 @@ func publish() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var debugEnabled bool
+	var withoutVCS bool
 	var writeSBOM bool
 
 	cmd := &cobra.Command{
@@ -71,6 +72,7 @@ in a keychain.`,
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
 				build.WithDebugLogging(debugEnabled),
+				build.WithoutVCS(withoutVCS),
 			); err != nil {
 				return err
 			}
@@ -82,6 +84,7 @@ in a keychain.`,
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
+	cmd.Flags().BoolVar(&withoutVCS, "without-vcs", false, "disable VCS URL detection")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate an SBOM")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "path to write the SBOMs")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -43,7 +43,7 @@ func publish() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var debugEnabled bool
-	var withoutVCS bool
+	var withVCS bool
 	var writeSBOM bool
 
 	cmd := &cobra.Command{
@@ -72,7 +72,7 @@ in a keychain.`,
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
 				build.WithDebugLogging(debugEnabled),
-				build.WithoutVCS(withoutVCS),
+				build.WithVCS(withVCS),
 			); err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ in a keychain.`,
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
-	cmd.Flags().BoolVar(&withoutVCS, "without-vcs", false, "disable VCS URL detection")
+	cmd.Flags().BoolVar(&withVCS, "vcs", true, "detect and embed VCS URLs")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate an SBOM")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "path to write the SBOMs")

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -37,6 +37,7 @@ import (
 type Context struct {
 	impl               buildImplementation
 	ImageConfiguration types.ImageConfiguration
+	ImageConfigFile    string
 	executor           *exec.Executor
 	s6                 *s6.Context
 	Assertions         []Assertion

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -156,7 +156,7 @@ func New(workDir string, opts ...Option) (*Context, error) {
 		bc.Options.Arch = types.ParseArchitecture(runtime.GOARCH)
 	}
 
-	if !bc.Options.WithoutVCS && bc.ImageConfiguration.VCSUrl == "" {
+	if bc.Options.WithVCS && bc.ImageConfiguration.VCSUrl == "" {
 		bc.ImageConfiguration.ProbeVCSUrl(bc.ImageConfigFile, bc.Logger())
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -156,7 +156,7 @@ func New(workDir string, opts ...Option) (*Context, error) {
 		bc.Options.Arch = types.ParseArchitecture(runtime.GOARCH)
 	}
 
-	if bc.ImageConfiguration.VCSUrl == "" {
+	if !bc.Options.WithoutVCS && bc.ImageConfiguration.VCSUrl == "" {
 		bc.ImageConfiguration.ProbeVCSUrl(bc.ImageConfigFile, bc.Logger())
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -156,6 +156,10 @@ func New(workDir string, opts ...Option) (*Context, error) {
 		bc.Options.Arch = types.ParseArchitecture(runtime.GOARCH)
 	}
 
+	if bc.ImageConfiguration.VCSUrl == "" {
+		bc.ImageConfiguration.ProbeVCSUrl(bc.ImageConfigFile, bc.Logger())
+	}
+
 	return &bc, nil
 }
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -38,6 +38,8 @@ func WithConfig(configFile string) Option {
 		}
 
 		bc.ImageConfiguration = ic
+		bc.ImageConfigFile = configFile
+
 		return nil
 	}
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -165,10 +165,10 @@ func WithDebugLogging(enable bool) Option {
 	}
 }
 
-// WithoutVCS disables VCS URL probing for the build context.
-func WithoutVCS(enable bool) Option {
+// WithVCS enables VCS URL probing for the build context.
+func WithVCS(enable bool) Option {
 	return func(bc *Context) error {
-		bc.Options.WithoutVCS = enable
+		bc.Options.WithVCS = enable
 		return nil
 	}
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -164,3 +164,11 @@ func WithDebugLogging(enable bool) Option {
 		return nil
 	}
 }
+
+// WithoutVCS disables VCS URL probing for the build context.
+func WithoutVCS(enable bool) Option {
+	return func(bc *Context) error {
+		bc.Options.WithoutVCS = enable
+		return nil
+	}
+}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -49,10 +49,6 @@ func (ic *ImageConfiguration) Load(imageConfigPath string, logger *logrus.Entry)
 		return fmt.Errorf("failed to parse image configuration: %w", err)
 	}
 
-	if ic.VCSUrl == "" {
-		ic.ProbeVCSUrl(imageConfigPath, logger)
-	}
-
 	return nil
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	UseDockerMediaTypes bool
 	WantSBOM            bool
 	UseProot            bool
+	WithoutVCS          bool
 	WorkDir             string
 	TarballPath         string
 	Tags                []string

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ type Options struct {
 	UseDockerMediaTypes bool
 	WantSBOM            bool
 	UseProot            bool
-	WithoutVCS          bool
+	WithVCS             bool
 	WorkDir             string
 	TarballPath         string
 	Tags                []string

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -82,6 +82,9 @@ func ProbeDirForVCSUrl(startDir, toplevelDir string) (string, error) {
 			}
 		}
 
+		// sanitize any user authentication data from the VCS URL
+		normalizedURL.User = nil
+
 		return normalizedURL.String(), nil
 	}
 }


### PR DESCRIPTION
Address concerns based on over-the-weekend testing of the VCS URL feature:

- sanitize authentication data from the generated VCS URLs
- add ability to disable VCS URL probing outside of setting one explicitly in the config
