### PR TITLE
Add MediaTypes to purls of all images and layers

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -236,6 +236,12 @@ func newSBOM(o *options.Options, ic *types.ImageConfiguration) *sbom.SBOM {
 	s.Options.Formats = o.SBOMFormats
 	s.Options.ImageInfo.VCSUrl = ic.VCSUrl
 
+	if o.UseDockerMediaTypes {
+		s.Options.ImageInfo.ImageMediaType = ggcrtypes.DockerManifestSchema2
+	} else {
+		s.Options.ImageInfo.ImageMediaType = ggcrtypes.OCIManifestSchema1
+	}
+
 	s.Options.OutputDir = o.TempDir()
 	if o.SBOMPath != "" {
 		s.Options.OutputDir = o.SBOMPath

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -110,7 +110,7 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 		Description: "apko OS layer",
 		PUrl: purl.NewPackageURL(
 			purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.LayerDigest,
-			purl.QualifiersFromMap(opts.ImagePurlQualifiers()), "",
+			purl.QualifiersFromMap(opts.LayerPurlQualifiers()), "",
 		).String(),
 		Version:    opts.OS.Version,
 		Type:       "operating-system",
@@ -279,7 +279,7 @@ func (cdx *CycloneDX) GenerateIndex(opts *options.Options, path string) error {
 func (cdx *CycloneDX) archImageComponent(opts *options.Options, info options.ArchImageInfo) Component {
 	purlString := purl.NewPackageURL(
 		purl.TypeOCI, "", opts.ImagePurlName(), info.Digest.DeepCopy().String(),
-		purl.QualifiersFromMap(info.PurlQualifiers()), "",
+		purl.QualifiersFromMap(opts.ArchImagePurlQualifiers(&info)), "",
 	).String()
 
 	return Component{

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -403,7 +403,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 	doc.Packages = append(doc.Packages, indexPackage)
 	doc.DocumentDescribes = append(doc.DocumentDescribes, indexPackage.ID)
 
-	for _, info := range opts.ImageInfo.Images {
+	for i, info := range opts.ImageInfo.Images {
 		imagePackageID := "SPDXRef-Package-" + stringToIdentifier(info.Digest.DeepCopy().String())
 
 		imageRepoName := "image"
@@ -431,7 +431,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 					Type:     "purl",
 					Locator: purl.NewPackageURL(
 						purl.TypeOCI, "", imageRepoName, info.Digest.DeepCopy().String(),
-						purl.QualifiersFromMap(info.PurlQualifiers()), "",
+						purl.QualifiersFromMap(opts.ArchImagePurlQualifiers(&opts.ImageInfo.Images[i])), "",
 					).String(),
 				},
 			},

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -171,18 +171,6 @@ func renderDoc(doc *Document, path string) error {
 }
 
 func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
-	// Main package purl
-	mmMain := map[string]string{}
-	if opts.ImageInfo.Repository != "" {
-		mmMain["repository_url"] = opts.ImageInfo.Repository
-	}
-	if opts.ImageInfo.Arch.String() != "" {
-		mmMain["arch"] = opts.ImageInfo.Arch.ToOCIPlatform().Architecture
-	}
-	if opts.ImageInfo.Arch.ToOCIPlatform().OS != "" {
-		mmMain["os"] = opts.ImageInfo.Arch.ToOCIPlatform().OS
-	}
-
 	return &Package{
 		ID: stringToIdentifier(fmt.Sprintf(
 			"SPDXRef-Package-%s", opts.ImageInfo.ImageDigest,
@@ -206,7 +194,7 @@ func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.ImageDigest,
-					purl.QualifiersFromMap(mmMain), "",
+					purl.QualifiersFromMap(opts.ImagePurlQualifiers()), "",
 				).String(),
 			},
 		},
@@ -273,7 +261,7 @@ func (sx *SPDX) layerPackage(opts *options.Options) (p *Package, err error) {
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.LayerDigest,
-					purl.QualifiersFromMap(opts.ImagePurlQualifiers()), "",
+					purl.QualifiersFromMap(opts.LayerPurlQualifiers()), "",
 				).String(),
 			},
 		},

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -64,6 +64,7 @@ type ImageInfo struct {
 	ImageDigest     string
 	VCSUrl          string
 	IndexMediaType  ggcrtypes.MediaType
+	ImageMediaType  ggcrtypes.MediaType
 	IndexDigest     v1.Hash
 	Images          []ArchImageInfo
 	Arch            types.Architecture

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -137,9 +137,18 @@ func (o *Options) IndexPurlQualifiers() map[string]string {
 	return qualifiers
 }
 
-func (aii *ArchImageInfo) PurlQualifiers() map[string]string {
-	qualifiers := map[string]string{}
+// ArchImagePurlQualifiers returns the details
+func (o *Options) ArchImagePurlQualifiers(aii *ArchImageInfo) map[string]string {
+	qualifiers := o.IndexPurlQualifiers()
 	qualifiers["arch"] = aii.Arch.ToOCIPlatform().Architecture
 	qualifiers["os"] = aii.Arch.ToOCIPlatform().OS
+	switch o.ImageInfo.IndexMediaType {
+	case ggcrtypes.OCIImageIndex:
+		qualifiers["mediaType"] = string(ggcrtypes.OCIManifestSchema1)
+	case ggcrtypes.DockerManifestList:
+		qualifiers["mediaType"] = string(ggcrtypes.DockerManifestSchema2)
+	default:
+		qualifiers["mediaType"] = ""
+	}
 	return qualifiers
 }

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -104,6 +104,24 @@ func (o *Options) ImagePurlQualifiers() (qualifiers map[string]string) {
 	if o.ImageInfo.Arch.ToOCIPlatform().OS != "" {
 		qualifiers["os"] = o.ImageInfo.Arch.ToOCIPlatform().OS
 	}
+	if o.ImageInfo.ImageMediaType != "" {
+		qualifiers["mediaType"] = string(o.ImageInfo.ImageMediaType)
+	}
+	return qualifiers
+}
+
+// LayerPurlQualifiers reurns the qualifiers for the purl, they are based
+// on the image with the corresponding mediatype
+func (o *Options) LayerPurlQualifiers() (qualifiers map[string]string) {
+	qualifiers = o.ImagePurlQualifiers()
+	switch o.ImageInfo.ImageMediaType {
+	case ggcrtypes.OCIManifestSchema1:
+		qualifiers["mediaType"] = string(ggcrtypes.OCILayer)
+	case ggcrtypes.DockerManifestSchema2:
+		qualifiers["mediaType"] = string(ggcrtypes.DockerLayer)
+	default:
+		qualifiers["mediaType"] = ""
+	}
 	return qualifiers
 }
 


### PR DESCRIPTION
This PR adds  media types to the SBOMs of all the indexes, layers and images. It honors the `UseDockerMediaTypes` and uses new functions shared by the SPDX and CycloneDX implementations.

/cc @kaniini @mattmoor 