### PR TITLE
Simplify purl index/image names, abstract to function

### DIFF
--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
 	purl "github.com/package-url/packageurl-go"
 
 	"chainguard.dev/apko/pkg/sbom/options"
@@ -212,26 +211,15 @@ type Hash struct {
 }
 
 func (cdx *CycloneDX) GenerateIndex(opts *options.Options, path string) error {
-	indexComponentName := opts.ImageInfo.IndexDigest.DeepCopy().String()
-	repoName := "index"
-	if opts.ImageInfo.Name != "" {
-		ref, err := name.ParseReference(opts.ImageInfo.Name)
-		if err != nil {
-			return fmt.Errorf("parsing image reference: %w", err)
-		}
-		repoName = ref.Context().RepositoryStr()
-		indexComponentName = repoName + "@" + indexComponentName
-	}
-
 	purlString := purl.NewPackageURL(
-		purl.TypeOCI, "", repoName, opts.ImageInfo.ImageDigest,
+		purl.TypeOCI, "", opts.IndexPurlName(), opts.ImageInfo.IndexDigest.String(),
 		purl.QualifiersFromMap(opts.IndexPurlQualifiers()), "",
 	).String()
 
 	indexComponent := Component{
 		BOMRef:      purlString,
 		Type:        "container",
-		Name:        indexComponentName,
+		Name:        opts.ImageInfo.IndexDigest.String(),
 		Version:     opts.ImageInfo.IndexDigest.DeepCopy().Hex,
 		Description: "Multi-arch image index",
 		PUrl:        purlString,

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -85,7 +86,17 @@ func (o *Options) ImagePurlName() string {
 		if err != nil {
 			return repoName
 		}
-		repoName = ref.Context().RepositoryStr()
+		parts := strings.Split(ref.Context().RepositoryStr(), "/")
+		repoName = parts[len(parts)-1]
+	}
+	return repoName
+}
+
+// IndexPurlName returns a name to refer to the image index in purls
+func (o *Options) IndexPurlName() string {
+	repoName := o.ImagePurlName()
+	if repoName == "image" {
+		return "index"
 	}
 	return repoName
 }

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -15,7 +15,7 @@
 package options
 
 import (
-	"strings"
+	"path/filepath"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -86,8 +86,7 @@ func (o *Options) ImagePurlName() string {
 		if err != nil {
 			return repoName
 		}
-		parts := strings.Split(ref.Context().RepositoryStr(), "/")
-		repoName = parts[len(parts)-1]
+		repoName = filepath.Base(ref.Context().RepositoryStr())
 	}
 	return repoName
 }


### PR DESCRIPTION
This commit adds a parser to the name returned by `RepositoryStr()` to return as the purl image name only the last part when several slashes are in the name. We now have a specific function in options to craft the purl name of the index.

The same commit also reuses the index function in the SPDX and CycloneDX implementations.

The previous purl names will now change to be as expected:

From: `pkg:oci/distroless%2Fstatic@sha256:ed7854ed`

To: `pkg:oci/static@sha256:ed7854ed`

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>