### PR TITLE
CycloneDX: Update inverted fields in VCS externalRef

### DIFF
--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -137,8 +137,8 @@ func (cdx *CycloneDX) Generate(opts *options.Options, path string) error {
 
 	if opts.ImageInfo.VCSUrl != "" {
 		vcsURLRef := ExternalReference{
-			URL:  "vcs",
-			Type: opts.ImageInfo.VCSUrl,
+			URL:  opts.ImageInfo.VCSUrl,
+			Type: "vcs",
 		}
 
 		if opts.ImageInfo.ImageDigest != "" {
@@ -246,8 +246,8 @@ func (cdx *CycloneDX) GenerateIndex(opts *options.Options, path string) error {
 
 	if opts.ImageInfo.VCSUrl != "" {
 		indexComponent.ExternalReferences = append(indexComponent.ExternalReferences, ExternalReference{
-			URL:  "vcs",
-			Type: opts.ImageInfo.VCSUrl,
+			URL:  opts.ImageInfo.VCSUrl,
+			Type: "vcs",
 		})
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the VCS external reference fields
where inverted in the CycloneDX implementation

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>