### PR TITLE
accounts: resolve non-UID run-as users to their UIDs

### DIFF
--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -143,6 +143,16 @@ func (di *defaultBuildImplementation) MutateAccounts(
 			return err
 		}
 
+		// Resolve run-as user if requested.
+		if ic.Accounts.RunAs != "" {
+			for _, ue := range uf.Entries {
+				if ue.UserName == ic.Accounts.RunAs {
+					ic.Accounts.RunAs = fmt.Sprintf("%d", ue.UID)
+					break
+				}
+			}
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
```
accounts:
  run-as: nonroot
```

now automatically becomes

```
accounts:
  run-as: 65532
```

closes #129