### PR TITLE
Tag and omit references to the refs file

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -330,7 +330,7 @@ func publishImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarG
 
 	digest := name.Digest{}
 	for _, tag := range tags {
-		logger.Printf("publishing tag %v", tag)
+		logger.Printf("publishing image tag %v", tag)
 		digest, err = publishTagFromImage(v1Image, tag, h, logger)
 		if err != nil {
 			return name.Digest{}, nil, err
@@ -392,7 +392,7 @@ func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, imgs map[types.Arc
 
 	digest := name.Digest{}
 	for _, tag := range tags {
-		logger.Printf("publishing tag %v", tag)
+		logger.Printf("publishing index tag %v", tag)
 		digest, err = publishTagFromIndex(idx, tag, h, logger)
 		if err != nil {
 			return name.Digest{}, nil, err


### PR DESCRIPTION
We now tag and emit references into the refs file for all arch images to help external
tools know what we've built (for example to sign  them).

Closes: https://github.com/chainguard-dev/apko/issues/288

/cc @mattmoor 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>