### PR TITLE
Support OCI annotations in apko publish w/ --annotations

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -102,6 +102,10 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		return nil, fmt.Errorf("unable to append %s layer to empty image: %w", imageType, err)
 	}
 
+	if mediaType != ggcrtypes.DockerLayer && len(ic.Annotations) > 0 {
+		v1Image = mutate.Annotations(v1Image, ic.Annotations).(v1.Image)
+	}
+
 	cfg, err := v1Image.ConfigFile()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get %s config file: %w", imageType, err)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -172,3 +172,11 @@ func WithVCS(enable bool) Option {
 		return nil
 	}
 }
+
+// WithAnnotations parses and populates the annotations in the ImageConfiguration
+func WithAnnotations(annotations map[string]string) Option {
+	return func(bc *Context) error {
+		bc.ImageConfiguration.Annotations = annotations
+		return nil
+	}
+}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -140,4 +140,10 @@ func (ic *ImageConfiguration) Summarize(logger *logrus.Entry) {
 			logger.Printf("      - gid=%d(%s) members=%v", g.GID, g.GroupName, g.Members)
 		}
 	}
+	if len(ic.Annotations) > 0 {
+		logger.Printf("    annotations:")
+		for k, v := range ic.Annotations {
+			logger.Printf("      %s: %s", k, v)
+		}
+	}
 }

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -75,8 +75,9 @@ type ImageConfiguration struct {
 	Archs       []Architecture
 	Environment map[string]string
 	Paths       []PathMutation
-	OSRelease   OSRelease `yaml:"os-release"`
-	VCSUrl      string    `yaml:"vcs-url"`
+	OSRelease   OSRelease         `yaml:"os-release"`
+	VCSUrl      string            `yaml:"vcs-url"`
+	Annotations map[string]string `yaml:"annotations"`
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
This PR adds support for annotating apko images with a new flag `--annotations`. Example:

```
apko publish --annotations="org.chainguard.made:True" --arch=amd64 \
   examples/nginx-rootless.yaml 172.17.0.1:5000/apko-test/nginx


crane manifest 172.17.0.1:5000/apko-test/nginx@sha256:5e870632a8a833251888a811c798e4595759aa60a0e379d788509410705e8ebe | jq .annotations
{
  "org.chainguard.made": "True"
}

```   