### PR TITLE
spdx: Move VCS URL to DownloadLocation

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -109,15 +109,10 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 	}
 
 	if opts.ImageInfo.VCSUrl != "" {
-		vcsURLRef := ExternalRef{
-			Category: "OTHER",
-			Locator:  opts.ImageInfo.VCSUrl,
-			Type:     "vcs",
-		}
 		if opts.ImageInfo.ImageDigest != "" {
-			imagePackage.ExternalRefs = append(imagePackage.ExternalRefs, vcsURLRef)
+			imagePackage.DownloadLocation = opts.ImageInfo.VCSUrl
 		} else {
-			layerPackage.ExternalRefs = append(layerPackage.ExternalRefs, vcsURLRef)
+			layerPackage.DownloadLocation = opts.ImageInfo.VCSUrl
 		}
 	}
 
@@ -403,11 +398,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 	}
 
 	if opts.ImageInfo.VCSUrl != "" {
-		indexPackage.ExternalRefs = append(indexPackage.ExternalRefs, ExternalRef{
-			Category: "OTHER",
-			Locator:  opts.ImageInfo.VCSUrl,
-			Type:     "vcs",
-		})
+		indexPackage.DownloadLocation = opts.ImageInfo.VCSUrl
 	}
 
 	doc.Packages = append(doc.Packages, indexPackage)


### PR DESCRIPTION
This commit moves the VCS URL obtained from the image config repository to the `DownloadLocation` field of the main package representing the artifact being built (image or index).

This change makes the apko sboms a little better in following what the spec recommends and aligns them with some of the prevailing practices.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>