### PR TITLE
Add org.opencontainers.image.source image annotation

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -148,10 +148,6 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		cfg.Config.WorkingDir = ic.WorkDir
 	}
 
-	if ic.VCSUrl != "" {
-		cfg.Config.Labels["org.opencontainers.image.source"] = ic.VCSUrl
-	}
-
 	if len(ic.Environment) > 0 {
 		envs := []string{}
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -103,6 +103,11 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		return nil, fmt.Errorf("unable to append %s layer to empty image: %w", imageType, err)
 	}
 
+	annotations := ic.Annotations
+	if ic.VCSUrl != "" {
+		annotations["org.opencontainers.image.source"] = ic.VCSUrl
+	}
+
 	if mediaType != ggcrtypes.DockerLayer && len(ic.Annotations) > 0 {
 		v1Image = mutate.Annotations(v1Image, ic.Annotations).(v1.Image)
 	}


### PR DESCRIPTION
We are currently adding a `org.opencontainers.image.source` label with the VCS URL to the image config. This commit adds the annotation to the manifest of the single arch images. Sample:

`crane manifest 172.17.0.1:5000/apko-tests/alpine@sha256:23d583... `

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "size": 642,
    "digest": "sha256:e304ce658035348bdd7b6748f9cb54fd4a28f0267fce1f57ae878953b4c0124d"
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "size": 3802370,
      "digest": "sha256:6770200400756823915c9e1bb0f8ffd2feff37517ecaa27234f4f9b52e9248ca"
    }
  ],
  "annotations": {
    "org.opencontainers.image.source": "git+ssh://github.com/puerco/apko.git@0e373ad19f6bf4797d6f803630ee12587219836e"
  }
}

```

**Update:** Pushed a commit to remove the label from the image config. We will only add the annotation

/cc @kaniini 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>