### PR TITLE
Fix nil map assingment for annotations

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -105,12 +105,15 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 	}
 
 	annotations := ic.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
 	if ic.VCSUrl != "" {
 		annotations["org.opencontainers.image.source"] = ic.VCSUrl
 	}
 
-	if mediaType != ggcrtypes.DockerLayer && len(ic.Annotations) > 0 {
-		v1Image = mutate.Annotations(v1Image, ic.Annotations).(v1.Image)
+	if mediaType != ggcrtypes.DockerLayer && len(annotations) > 0 {
+		v1Image = mutate.Annotations(v1Image, annotations).(v1.Image)
 	}
 
 	cfg, err := v1Image.ConfigFile()


### PR DESCRIPTION
PR https://github.com/chainguard-dev/apko/pull/322 appears to have introduced an panic error on the canary image:
```
panic: assignment to entry in nil map

goroutine 1 [running]:
chainguard.dev/apko/pkg/build/oci.buildImageFromLayerWithMediaType({_, _}, {_, _}, {{{0xc00038b9b0, 0x3, 0x3}, {0x0, 0x0, 0x0}, ...}, ...}, ...)
	chainguard.dev/apko/pkg/build/oci/oci.go:109 +0xbf5
chainguard.dev/apko/pkg/build/oci.buildImageTarballFromLayerWithMediaType({_, _}, {_, _}, {_, _}, {_, _}, {{{0xc00038b9b0, 0x3, ...}, ...}, ...}, ...)
	chainguard.dev/apko/pkg/build/oci/oci.go:285 +0x2d3
chainguard.dev/apko/pkg/build/oci.BuildImageTarballFromLayer({_, _}, {_, _}, {_, _}, {{{0xc00038b9b0, 0x3, 0x3}, {0x0, ...}, ...}, ...}, ...)
	chainguard.dev/apko/pkg/build/oci/oci.go:280 +0x179
chainguard.dev/apko/internal/cli.BuildCmd({0x1?, 0x0?}, {0x7fff2032f076, 0x28}, {0x7fff2032f09f, 0xa}, {0xc00021fd30, 0xd, 0xd})
	chainguard.dev/apko/internal/cli/build.go:145 +0x66b
chainguard.dev/apko/internal/cli.buildCmd.func1(0xc000383900?, {0xc0002b5180, 0x3, 0x8?})
	chainguard.dev/apko/internal/cli/build.go:71 +0x716
github.com/spf13/cobra.(*Command).execute(0xc000383900, {0xc0002b5100, 0x8, 0x8})
	github.com/spf13/cobra@v1.5.0/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0xc000383400)
	github.com/spf13/cobra@v1.5.0/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.5.0/command.go:918
main.main()
	chainguard.dev/apko/main.go:24 +0x1e
```

in addition, looks like the new annotations var is never used