### PR TITLE
VFS core (for rootless apko)

### DIFF
--- a/pkg/vfs/dirfs.go
+++ b/pkg/vfs/dirfs.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type dirFS string
+
+// DirFS is a DirFS implementation that is suitable for use as a
+// BaseFS.
+func DirFS(path string) (BaseFS, error) {
+	return dirFS(path), nil
+}
+
+func (dir dirFS) finalPath(path string) string {
+	return filepath.Join(string(dir), path)
+}
+
+func (dir dirFS) Create(path string) (fs.File, error) {
+	return os.Create(dir.finalPath(path))
+}
+
+func (dir dirFS) Open(path string) (fs.File, error) {
+	return os.Open(dir.finalPath(path))
+}
+
+func (dir dirFS) ReadDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(dir.finalPath(path))
+}
+
+func (dir dirFS) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(dir.finalPath(path))
+}
+
+func (dir dirFS) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(dir.finalPath(path))
+}

--- a/pkg/vfs/dirfs.go
+++ b/pkg/vfs/dirfs.go
@@ -52,3 +52,11 @@ func (dir dirFS) ReadFile(path string) ([]byte, error) {
 func (dir dirFS) Stat(path string) (fs.FileInfo, error) {
 	return os.Stat(dir.finalPath(path))
 }
+
+func (dir dirFS) Remove(path string) error {
+	return os.Remove(dir.finalPath(path))
+}
+
+func (dir dirFS) RemoveAll(path string) error {
+	return os.RemoveAll(dir.finalPath(path))
+}

--- a/pkg/vfs/dirfs.go
+++ b/pkg/vfs/dirfs.go
@@ -15,6 +15,7 @@
 package vfs
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -32,7 +33,7 @@ func (dir dirFS) finalPath(path string) string {
 	return filepath.Join(string(dir), path)
 }
 
-func (dir dirFS) Create(path string) (fs.File, error) {
+func (dir dirFS) Create(path string) (io.WriteCloser, error) {
 	return os.Create(dir.finalPath(path))
 }
 

--- a/pkg/vfs/dirfs_unit_test.go
+++ b/pkg/vfs/dirfs_unit_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs
+
+import (
+	"io"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirFS(t *testing.T) {
+	dir, err := DirFS("testdata")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dentry, err := dir.ReadDir(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Equal(t, len(dentry), 1, "There should only be one directory entry")
+	assert.Equal(t, dentry[0].Name(), "etc", "That directory entry should be named etc")
+
+	dentry, err = dir.ReadDir("./etc")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Equal(t, len(dentry), 1, "etc/ should only have one child entry")
+	assert.Equal(t, dentry[0].Name(), "motd", "That directory entry should be named motd")
+
+	st, err := dir.Stat("./etc")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Equal(t, st.IsDir(), true, "etc/ is a directory")
+
+	st, err = dir.Stat("./etc/motd")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Equal(t, st.IsDir(), false, "etc/motd is a normal file")
+
+	inF, err := dir.Open("./etc/motd")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer inF.Close()
+
+	data, err := io.ReadAll(inF)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Equal(t, data, []byte{'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '\n'}, "motd should return Hello world")
+
+	otherdata, err := dir.ReadFile("./etc/motd")
+	assert.Equal(t, data, otherdata, "dir.ReadFile behavior should match os.ReadFile")
+
+	outF, err := dir.Create("./etc/motd2")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer outF.Close()
+	defer dir.Remove("./etc/motd2")
+
+	if _, err := outF.Write(data); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/vfs/dirfs_unit_test.go
+++ b/pkg/vfs/dirfs_unit_test.go
@@ -55,7 +55,7 @@ func TestDirFS(t *testing.T) {
 	data, err := io.ReadAll(inF)
 	require.NoError(t, err)
 
-	assert.Equal(t, data, []byte{'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '\n'}, "motd should return Hello world")
+	assert.Equal(t, data, []byte("Hello world\n"), "motd should return Hello world")
 
 	otherdata, err := dir.ReadFile("./etc/motd")
 	require.NoError(t, err)

--- a/pkg/vfs/dirfs_unit_test.go
+++ b/pkg/vfs/dirfs_unit_test.go
@@ -68,4 +68,8 @@ func TestDirFS(t *testing.T) {
 
 	_, err = outF.Write(data)
 	require.NoError(t, err)
+
+	moredata, err := dir.ReadFile("./etc/motd2")
+	require.NoError(t, err)
+	assert.Equal(t, data, moredata, "motd2 should match motd")
 }

--- a/pkg/vfs/dirfs_unit_test.go
+++ b/pkg/vfs/dirfs_unit_test.go
@@ -16,72 +16,56 @@ package vfs
 
 import (
 	"io"
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDirFS(t *testing.T) {
 	dir, err := DirFS("testdata")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	dentry, err := dir.ReadDir(".")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, len(dentry), 1, "There should only be one directory entry")
 	assert.Equal(t, dentry[0].Name(), "etc", "That directory entry should be named etc")
 
 	dentry, err = dir.ReadDir("./etc")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, len(dentry), 1, "etc/ should only have one child entry")
 	assert.Equal(t, dentry[0].Name(), "motd", "That directory entry should be named motd")
 
 	st, err := dir.Stat("./etc")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, st.IsDir(), true, "etc/ is a directory")
 
 	st, err = dir.Stat("./etc/motd")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, st.IsDir(), false, "etc/motd is a normal file")
 
 	inF, err := dir.Open("./etc/motd")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer inF.Close()
 
 	data, err := io.ReadAll(inF)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, data, []byte{'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '\n'}, "motd should return Hello world")
 
 	otherdata, err := dir.ReadFile("./etc/motd")
+	require.NoError(t, err)
 	assert.Equal(t, data, otherdata, "dir.ReadFile behavior should match os.ReadFile")
 
 	outF, err := dir.Create("./etc/motd2")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer outF.Close()
 	defer dir.Remove("./etc/motd2")
 
-	if _, err := outF.Write(data); err != nil {
-		log.Fatal(err)
-	}
+	_, err = outF.Write(data)
+	require.NoError(t, err)
 }

--- a/pkg/vfs/testdata/etc/motd
+++ b/pkg/vfs/testdata/etc/motd
@@ -1,0 +1,1 @@
+Hello world

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -195,6 +195,10 @@ func (vfs *VFS) Stat(path string) (os.FileInfo, error) {
 	return vfs.FS.Stat(path)
 }
 
+func (vfs *VFS) Create(path string) (fs.File, error) {
+	return vfs.FS.Create(path)
+}
+
 func (vfs *VFS) Open(path string) (fs.File, error) {
 	return vfs.FS.Open(path)
 }
@@ -226,6 +230,14 @@ func (vfs *VFS) ReadDir(path string) ([]fs.DirEntry, error) {
 	}
 
 	return out, nil
+}
+
+func (vfs *VFS) Chmod(path string, mode fs.FileMode) error {
+	return vfs.Root.Chmod(path, mode)
+}
+
+func (vfs *VFS) Chown(path string, uid, gid uint32) error {
+	return vfs.Root.Chown(path, uid, gid)
 }
 
 func New(base BaseFS) (*VFS, error) {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1,0 +1,236 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// An INode contains overlay metadata for a filesystem entry that would
+// otherwise be represented by a traditional inode on disk.
+type INode struct {
+	Filename      string
+	Children      map[string]INode
+	UnderlayINode syscall.Stat_t
+}
+
+func parseElements(path string) (string, string, bool) {
+	pathElements := filepath.SplitList(path)
+	currentElement := pathElements[0]
+	otherElements := filepath.Join(pathElements[1:]...)
+
+	if pathElements[0] == "." {
+		currentElement = pathElements[1]
+		otherElements = filepath.Join(pathElements[2:]...)
+	}
+
+	return currentElement, otherElements, len(pathElements) == 1
+}
+
+func (i *INode) walk(path string) (*INode, error) {
+	currentElement, otherElements, terminated := parseElements(path)
+
+	// We are at the end of the path, return ourselves.
+	if terminated {
+		return i, nil
+	}
+
+	// We are not at the end of the path, traverse downward.
+	if child, ok := i.Children[currentElement]; ok {
+		return child.walk(otherElements)
+	}
+
+	// We do not have any overlay INode.  Pass through to owning FS.
+	return nil, fmt.Errorf("no underlay inode found")
+}
+
+// Stat looks up a child INode in the VFS or returns nothing.
+// Note: We intentionally do not implement support for the `..` directory
+// entry for security reasons.
+func (i *INode) Stat(path string) (os.FileInfo, error) {
+	child, err := i.walk(path)
+	if err != nil {
+		return INode{}, err
+	}
+
+	return *child, nil
+}
+
+// Create creates a new underlay INode.
+func (i *INode) Create(path string) (*INode, error) {
+	currentElement, otherElements, terminated := parseElements(path)
+
+	// We are at the end of the path, return ourselves.
+	if terminated {
+		return i, nil
+	}
+
+	// We are not at the end of the path, traverse downward.
+	if child, ok := i.Children[currentElement]; ok {
+		return child.Create(otherElements)
+	}
+
+	// We do not yet have an overlay INode, create one and
+	// continue downward.
+	child := INode{}
+	i.Children[currentElement] = child
+	return child.Create(otherElements)
+}
+
+func (i *INode) walkOrCreate(path string) (*INode, error) {
+	node, err := i.walk(path)
+	if err != nil {
+		// No overlay node, create a new one.
+		node, err = i.Create(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+// Chmod updates the permissions on an INode.
+func (i *INode) Chmod(path string, mode fs.FileMode) error {
+	node, err := i.walkOrCreate(path)
+	if err != nil {
+		return err
+	}
+
+	isDir := node.IsDir()
+	newMode := mode
+
+	if isDir {
+		newMode |= fs.ModeDir
+	}
+
+	node.UnderlayINode.Mode = uint32(newMode)
+	return nil
+}
+
+// Chown updates the ownership on an INode.
+func (i *INode) Chown(path string, uid, gid uint32) error {
+	node, err := i.walkOrCreate(path)
+	if err != nil {
+		return err
+	}
+
+	node.UnderlayINode.Uid = uid
+	node.UnderlayINode.Gid = gid
+	return nil
+}
+
+func (i INode) IsDir() bool {
+	return i.Mode() & fs.ModeDir == fs.ModeDir
+}
+
+func (i INode) Mode() fs.FileMode {
+	return fs.FileMode(i.UnderlayINode.Mode)
+}
+
+func (i INode) ModTime() time.Time {
+	ts, tns := i.UnderlayINode.Mtim.Unix()
+	return time.Unix(ts, tns)
+}
+
+func (i INode) Name() string {
+	return i.Filename
+}
+
+func (i INode) Size() int64 {
+	return i.UnderlayINode.Size
+}
+
+func (i INode) Sys() any {
+	return &i.UnderlayINode
+}
+
+func (i INode) Info() (os.FileInfo, error) {
+	return i, nil
+}
+
+func (i INode) Type() fs.FileMode {
+	return i.Mode()
+}
+
+// A VFS is an overlay virtual filesystem which tracks an underlying
+// io/fs.FS.
+type BaseFS interface {
+	fs.FS
+	fs.ReadDirFS
+	fs.ReadFileFS
+	fs.StatFS
+}
+
+type VFS struct {
+	FS   BaseFS
+	Root INode
+}
+
+func (vfs *VFS) Stat(path string) (os.FileInfo, error) {
+	inode, err := vfs.Root.Stat(path)
+	if err == nil {
+		return inode, err
+	}
+
+	return vfs.FS.Stat(path)
+}
+
+func (vfs *VFS) Open(path string) (fs.File, error) {
+	return vfs.FS.Open(path)
+}
+
+func (vfs *VFS) ReadFile(path string) ([]byte, error) {
+	return vfs.FS.ReadFile(path)
+}
+
+func (vfs *VFS) ReadDir(path string) ([]fs.DirEntry, error) {
+	de, err := vfs.FS.ReadDir(path)
+	if err != nil {
+		return []fs.DirEntry{}, err
+	}
+
+	basePath := filepath.Dir(path)
+
+	baseINode, err := vfs.Root.walk(basePath)
+	if err != nil {
+		return de, nil
+	}
+
+	out := []fs.DirEntry{}
+	for _, dentry := range de {
+		if patchedINode, ok := baseINode.Children[dentry.Name()]; ok {
+			out = append(out, patchedINode)
+		} else {
+			out = append(out, dentry)
+		}
+	}
+
+	return out, nil
+}
+
+func New(base BaseFS) (*VFS, error) {
+	return &VFS{
+		FS: base,
+		Root: INode{
+			Filename: ".",
+		},
+	}, nil
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -35,11 +35,19 @@ type INode struct {
 func parseElements(path string) (string, string, bool) {
 	pathElements := filepath.SplitList(path)
 	currentElement := pathElements[0]
-	otherElements := filepath.Join(pathElements[1:]...)
 
+	if len(pathElements) == 1 {
+		return currentElement, "", true
+	}
+
+	otherElements := filepath.Join(pathElements[1:]...)
 	if pathElements[0] == "." {
 		currentElement = pathElements[1]
-		otherElements = filepath.Join(pathElements[2:]...)
+		otherElements = ""
+
+		if len(pathElements) > 2 {
+			otherElements = filepath.Join(pathElements[2:]...)
+		}
 	}
 
 	return currentElement, otherElements, len(pathElements) == 1

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -33,6 +33,9 @@ type INode struct {
 	UnderlayINode syscall.Stat_t
 }
 
+// parseElements parses a path into components, and returns the current
+// path component, followed by the remaining path components, and a hint
+// as to whether or not the path list is terminated or not.
 func parseElements(path string) (string, string, bool) {
 	pathElements := strings.Split(path, "/")
 	currentElement := pathElements[0]
@@ -203,8 +206,8 @@ func (i INode) Type() fs.FileMode {
 	return i.Mode()
 }
 
-// A VFS is an overlay virtual filesystem which tracks an underlying
-// io/fs.FS.
+// BaseFS is the required interfaces for an underlay filesystem
+// which is used with VFS.
 type BaseFS interface {
 	fs.FS
 	fs.ReadDirFS
@@ -216,6 +219,12 @@ type BaseFS interface {
 	RemoveAll(path string) error
 }
 
+// VFS is an overlay virtual filesystem which tracks an underlying
+// BaseFS.
+//
+// It allows for things like permission and ownership changes that
+// do not require physical root access, because it is tracked at
+// the VFS level instead.
 type VFS struct {
 	FS   BaseFS
 	Root *INode

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -16,6 +16,7 @@ package vfs
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -178,7 +179,7 @@ type BaseFS interface {
 	fs.ReadFileFS
 	fs.StatFS
 
-	Create(path string) (fs.File, error)
+	Create(path string) (io.WriteCloser, error)
 }
 
 type VFS struct {
@@ -195,7 +196,7 @@ func (vfs *VFS) Stat(path string) (os.FileInfo, error) {
 	return vfs.FS.Stat(path)
 }
 
-func (vfs *VFS) Create(path string) (fs.File, error) {
+func (vfs *VFS) Create(path string) (io.WriteCloser, error) {
 	return vfs.FS.Create(path)
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -177,6 +177,8 @@ type BaseFS interface {
 	fs.ReadDirFS
 	fs.ReadFileFS
 	fs.StatFS
+
+	Create(path string) (fs.File, error)
 }
 
 type VFS struct {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -139,7 +139,7 @@ func (i *INode) Chown(path string, uid, gid uint32) error {
 }
 
 func (i INode) IsDir() bool {
-	return i.Mode() & fs.ModeDir == fs.ModeDir
+	return i.Mode()&fs.ModeDir == fs.ModeDir
 }
 
 func (i INode) Mode() fs.FileMode {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -180,6 +180,8 @@ type BaseFS interface {
 	fs.StatFS
 
 	Create(path string) (io.WriteCloser, error)
+	Remove(path string) error
+	RemoveAll(path string) error
 }
 
 type VFS struct {

--- a/pkg/vfs/vfs_unit_test.go
+++ b/pkg/vfs/vfs_unit_test.go
@@ -15,8 +15,8 @@
 package vfs
 
 import (
-	"testing"
 	"syscall"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,6 +77,7 @@ func TestVFS(t *testing.T) {
 	require.Equal(t, st.Gid, uint32(65532), "Gid must be 65532")
 
 	err = vfs.Chmod("./etc/motd", 0755)
+	require.NoError(t, err)
 
 	fi, err = vfs.Stat("./etc/motd")
 	require.NoError(t, err)
@@ -84,5 +85,5 @@ func TestVFS(t *testing.T) {
 	st, ok = fi.Sys().(*syscall.Stat_t)
 	require.True(t, ok, "must present a Stat_t")
 
-	require.Equal(t, st.Mode & 0755, uint32(0755), "must have mode 0755")
+	require.Equal(t, st.Mode&0755, uint32(0755), "must have mode 0755")
 }

--- a/pkg/vfs/vfs_unit_test.go
+++ b/pkg/vfs/vfs_unit_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs
+
+import (
+	"testing"
+	"syscall"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVFS(t *testing.T) {
+	dir, err := DirFS("testdata")
+	require.NoError(t, err)
+
+	vfs, err := New(dir)
+	require.NoError(t, err)
+
+	dentry, err := vfs.ReadDir(".")
+	require.NoError(t, err)
+
+	assert.Equal(t, len(dentry), 1, "There should only be one directory entry")
+	assert.Equal(t, dentry[0].Name(), "etc", "That directory entry should be named etc")
+
+	dentry, err = vfs.ReadDir("./etc")
+	require.NoError(t, err)
+
+	assert.Equal(t, len(dentry), 1, "etc/ should only have one child entry")
+	assert.Equal(t, dentry[0].Name(), "motd", "That directory entry should be named motd")
+
+	fi, err := vfs.Stat("./etc/motd")
+	require.NoError(t, err)
+
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "must present a Stat_t")
+
+	assert.NotEqual(t, st.Uid, uint32(65532), "Uid should not be 65532")
+
+	err = vfs.Chown("./etc/motd", 65532, 65532)
+	require.NoError(t, err)
+
+	fi, err = vfs.Stat("./etc/motd")
+	require.NoError(t, err)
+
+	st, ok = fi.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "must present a Stat_t")
+
+	assert.Equal(t, st.Uid, uint32(65532), "Uid must be 65532")
+	assert.Equal(t, st.Gid, uint32(65532), "Gid must be 65532")
+
+	dentry, err = vfs.ReadDir("./etc")
+	require.NoError(t, err)
+
+	assert.Equal(t, len(dentry), 1, "etc/ should only have one child entry")
+	assert.Equal(t, dentry[0].Name(), "motd", "That directory entry should be named motd")
+
+	fi, err = dentry[0].Info()
+	require.NoError(t, err)
+
+	st, ok = fi.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "must present a Stat_t")
+
+	require.Equal(t, st.Uid, uint32(65532), "Uid must be 65532")
+	require.Equal(t, st.Gid, uint32(65532), "Gid must be 65532")
+
+	err = vfs.Chmod("./etc/motd", 0755)
+
+	fi, err = vfs.Stat("./etc/motd")
+	require.NoError(t, err)
+
+	st, ok = fi.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "must present a Stat_t")
+
+	require.Equal(t, st.Mode & 0755, uint32(0755), "must have mode 0755")
+}


### PR DESCRIPTION
The VFS package provides an overlay filesystem, where files are physically backed by an underlay filesystem, but permission and ownership are tracked by the VFS itself.  This allows for `Chown` and `Chmod` operations to work without requiring root.