### PR TITLE
Add purls to VCS source package

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -479,6 +479,25 @@ func addSourcePackage(vcsURL string, doc *Document, parent *Package) {
 		ExternalRefs:         []ExternalRef{},
 		VerificationCode:     PackageVerificationCode{},
 	}
+
+	// If this is a github package, add a purl to it:
+	if strings.HasPrefix(packageName, "github.com/") {
+		slug := strings.TrimPrefix(packageName, "github.com/")
+		org, user, ok := strings.Cut(slug, "/")
+		if ok {
+			sourcePackage.ExternalRefs = []ExternalRef{
+				{
+					Category: "PACKAGE_MANAGER",
+					Type:     "purl",
+					Locator: purl.NewPackageURL(
+						purl.TypeGithub, org, strings.TrimSuffix(user, ".git"), version,
+						nil, "",
+					).String(),
+				},
+			}
+		}
+	}
+
 	doc.Packages = append(doc.Packages, sourcePackage)
 	doc.Relationships = append(doc.Relationships, Relationship{
 		Element: parent.ID,

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -129,6 +129,15 @@ func TestSourcePackage(t *testing.T) {
 	// Call the function
 	addSourcePackage(vcsURL, &doc, &imagePackage)
 
+	// Verify the purl
+	require.Len(t, doc.Packages[0].ExternalRefs, 1)
+	require.Equal(t, doc.Packages[0].ExternalRefs[0].Category, "PACKAGE_MANAGER")
+	require.Equal(t, doc.Packages[0].ExternalRefs[0].Type, "purl")
+	require.Equal(
+		t, doc.Packages[0].ExternalRefs[0].Locator,
+		"pkg:github/distroless/example@868f0dc23e721039f9669b56d01ea4b897f2fb24",
+	)
+
 	// Verify the package is added
 	require.Len(t, doc.Packages, 1)
 


### PR DESCRIPTION
This commit updates the `spdx.addSourcePackage()` function to add a purl to the generated package representing the source code.

```release-note
The SPDX package representing the source code now includes a purl of type `github` if the URL is a GitHub repository
```


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>