### PR TITLE
run ldconfig after busybox symlinks are installed

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -219,14 +219,14 @@ func buildImage(
 		return fmt.Errorf("failed to mutate paths: %w", err)
 	}
 
-	// maybe run ldconfig to update it (e.g. on glibc)
-	if err := di.UpdateLdconfig(o, e); err != nil {
-		return fmt.Errorf("failed to update ldconfig: %w", err)
-	}
-
 	// maybe install busybox symlinks
 	if err := di.InstallBusyboxSymlinks(o, e); err != nil {
 		return fmt.Errorf("failed to install busybox symlinks: %w", err)
+	}
+
+	// maybe run ldconfig to update it (e.g. on glibc)
+	if err := di.UpdateLdconfig(o, e); err != nil {
+		return fmt.Errorf("failed to update ldconfig: %w", err)
 	}
 
 	if err := di.GenerateOSRelease(o, ic); err != nil {


### PR DESCRIPTION
this is necessary on alpine ldconfig

resolves flakes on distroless/alpine-base image which has ldconfig