### PR TITLE
Add --tag-suffix to apko publish command.

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -42,6 +42,7 @@ func publish() *cobra.Command {
 	var buildDate string
 	var sbomPath string
 	var packageVersionTag string
+	var tagSuffix string
 	var sbomFormats []string
 	var archstrs []string
 	var extraKeys []string
@@ -84,6 +85,7 @@ in a keychain.`,
 				build.WithVCS(withVCS),
 				build.WithAnnotations(annotations),
 				build.WithPackageVersionTag(packageVersionTag),
+				build.WithTagSuffix(tagSuffix),
 			); err != nil {
 				return err
 			}
@@ -98,6 +100,7 @@ in a keychain.`,
 	cmd.Flags().BoolVar(&withVCS, "vcs", true, "detect and embed VCS URLs")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().StringVar(&packageVersionTag, "package-version-tag", "", "Tag the final image with the version of the package passed in")
+	cmd.Flags().StringVar(&tagSuffix, "tag-suffix", "", "suffix to use for automatically generated tags")
 	cmd.Flags().BoolVar(&writeSBOM, "sbom", true, "generate an SBOM")
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "path to write the SBOMs")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -146,6 +146,9 @@ func AdditionalTags(opts options.Options) ([]string, error) {
 			continue
 		}
 		version := pkg.Version
+		if opts.TagSuffix != "" {
+			version += opts.TagSuffix
+		}
 		opts.Log.Debugf("Found version, images will be tagged with %s", version)
 		return appendTag(opts, version)
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -187,3 +187,11 @@ func WithAnnotations(annotations map[string]string) Option {
 		return nil
 	}
 }
+
+// WithTagSuffix sets a tag suffix to use, e.g. `-glibc`.
+func WithTagSuffix(tagSuffix string) Option {
+	return func(bc *Context) error {
+		bc.Options.TagSuffix = tagSuffix
+		return nil
+	}
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	Log                 *logrus.Logger
 	TempDirPath         string
 	PackageVersionTag   string
+	TagSuffix           string
 }
 
 var Default = Options{


### PR DESCRIPTION
This is necessary to add a suffix to the generated version tags, e.g. `foo:1.2.3-glibc` instead of just `foo:1.2.3`.