### PR TITLE
Use OCI arch and variant for image config

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -123,7 +123,9 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 
 	cfg = cfg.DeepCopy()
 	cfg.Author = "github.com/chainguard-dev/apko"
-	cfg.Architecture = arch.String()
+	platform := arch.ToOCIPlatform()
+	cfg.Architecture = platform.Architecture
+	cfg.Variant = platform.Variant
 	cfg.Created = v1.Time{Time: created}
 	cfg.Config.Labels = make(map[string]string)
 	cfg.OS = "linux"


### PR DESCRIPTION
This makes a small tweak to how we populate the `architecture` and `variant` fields in the image config, such that when the user builds images for architectures with variants (e.g. `arm/v7`), the image we produce is compliant with the [OCI spec for image configs](https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants).

This also may resolve an issue where Grype was unable to scan apko images that used architecture variants (reported as https://github.com/anchore/grype/issues/831).

If anyone can help point me toward a good way to add an automated test here, I'd greatly appreciate it!  🙏 😃 

### Steps to test manually

We can perform these steps first on the **"before"** (broken) state, and then on the **"after"** state to see the expected adjustment to behavior...

(I'm on an M1 Mac w/ Docker Desktop)

1. Build an image with apko for the architecture `arm/v7`:

```shell
docker run --rm -it -v "$PWD":/work -w /work golang:alpine go run . build examples/alpine-base.yaml apko-alpine:test apko-alpine.tar --build-arch arm/v7
```

2. Observe the image config:

```shell
tar -xOf ./apko-alpine.tar $(tar -tf ./apko-alpine.tar | grep 'sha256:.*') | jq
```

3. See if Grype bombs:

```shell
docker load < apko-alpine.tar
grype docker:apko-alpine:test -q
```

4. (Optional) Clean up image from Docker:

```shell
docker rmi apko-alpine:test
```
