### PR TITLE
postpone generating vendor release file until after generating os-release

### DIFF
--- a/pkg/build/os-release.go
+++ b/pkg/build/os-release.go
@@ -55,10 +55,6 @@ func maybeGenerateVendorReleaseFile(
 func (di *defaultBuildImplementation) GenerateOSRelease(
 	o *options.Options, ic *types.ImageConfiguration,
 ) error {
-	if err := maybeGenerateVendorReleaseFile(o, ic); err != nil {
-		return err
-	}
-
 	path := filepath.Join(o.WorkDir, "etc", "os-release")
 
 	osReleaseExists := true
@@ -122,6 +118,10 @@ func (di *defaultBuildImplementation) GenerateOSRelease(
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := maybeGenerateVendorReleaseFile(o, ic); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Previously, non-alpine distributions, such as Wolfi, may have an erroneous `/etc/alpine-release` file that shouldn't be there.

Before (with Trivy):

<img width="1160" alt="Screen Shot 2022-09-29 at 12 36 16 PM" src="https://user-images.githubusercontent.com/1522444/193102959-cf1cb7e5-4949-40f2-92bb-a0a8b5404327.png">

After (with Trivy):

<img width="1157" alt="Screen Shot 2022-09-29 at 12 36 45 PM" src="https://user-images.githubusercontent.com/1522444/193103038-0c1ff78b-5391-4b51-9315-873e8bb6fe68.png">

Trivy no longer detects a Wolfi image as an Alpine one, as intended.