### PR TITLE
fix: don't annotate indexes, this panics

### DIFF
--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -105,20 +105,10 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		return nil, fmt.Errorf("unable to append %s layer to empty image: %w", imageType, err)
 	}
 
-	annotations := ic.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	if ic.VCSUrl != "" {
-		if url, hash, ok := strings.Cut(ic.VCSUrl, "@"); ok {
-			annotations["org.opencontainers.image.source"] = url
-			annotations["org.opencontainers.image.revision"] = hash
-		}
-	}
-
-	if mediaType != ggcrtypes.DockerLayer && len(annotations) > 0 {
-		v1Image = mutate.Annotations(v1Image, annotations).(v1.Image)
-	}
+	// TODO(jason): Also set annotations on the index. ggcr's
+	// pkg/v1/mutate.Annotations will drop the interface methods from
+	// oci.SignedImageIndex, so we may need to reimplement
+	// mutate.Annotations in ocimutate to keep it for now.
 
 	cfg, err := v1Image.ConfigFile()
 	if err != nil {
@@ -419,7 +409,7 @@ func publishIndexWithMediaType(mediaType ggcrtypes.MediaType, ic types.ImageConf
 		}
 	}
 	if mediaType != ggcrtypes.DockerLayer && len(annotations) > 0 {
-		idx = mutate.Annotations(idx, annotations).(oci.SignedImageIndex)
+		idx = mutate.Annotations(idx, annotations).(v1.ImageIndex)
 	}
 
 	h, err := idx.Digest()


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/pull/353 added a call to `mutate.Annotations(signedIndex, map[...]).(oci.SignedIndex)`, which panics because the type that comes out of `mutate.Annotations` doesn't implement `oci.SignedIndex`, only ggcr's `v1.ImageIndex`.

Example: https://github.com/chainguard-images/template/actions/runs/3153995862/jobs/5131103522#step:5:972

Just replace this with a TODO for now, since the solution is to reimplement `mutate.Annotations` in cosign (bleh) and that will take a minute. Nobody missed not having annotations on the indexes anyway.

As far as I know, the annotations added to images are just fine.