### PR TITLE
FIX VCS package SPDX identifier

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -461,7 +461,7 @@ func addSourcePackage(vcsURL string, doc *Document, parent *Package) {
 	packageName = strings.TrimPrefix(packageName, "https://")
 
 	sourcePackage := Package{
-		ID:                   stringToIdentifier(vcsURL),
+		ID:                   fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(vcsURL)),
 		Name:                 packageName,
 		Version:              version,
 		FilesAnalyzed:        false,


### PR DESCRIPTION
This commit fixes an invalid SPDX identifier on in the VCS package. Thanks for investigating it Dan!

/cc @luhring 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>