### PR TITLE
more flexible header template

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,9 @@ linters-settings:
       - '^t\.Fatal.*$(# forbid t\.Fatal in favor of using testify\.)?'
   goheader:
     template-path: header.tmpl
+    values:
+      regexp:
+        ws: "\\s*"
   goimports:
     local-prefixes: chainguard.dev/apko
 

--- a/header.tmpl
+++ b/header.tmpl
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+{{ ws }}http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
An update to the goheader header.tmpl to support any whitespace before the apache URL; some editors change the format and it fails on tab vs space vs 2 space vs space+tab vs I have no idea what. This makes it much more tolerant.
