### PR TITLE
Always generate index SBOM

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -263,16 +263,14 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			}
 		}
 
-		if len(imgs) > 1 {
-			if err := bc.GenerateIndexSBOM(finalDigest, imgs); err != nil {
-				return fmt.Errorf("generating index SBOM: %w", err)
-			}
+		if err := bc.GenerateIndexSBOM(finalDigest, imgs); err != nil {
+			return fmt.Errorf("generating index SBOM: %w", err)
+		}
 
-			if _, err := oci.PostAttachSBOM(
-				idx, sbompath, bc.Options.SBOMFormats, types.Architecture{}, bc.Logger(), bc.Options.Tags...,
-			); err != nil {
-				return fmt.Errorf("attaching sboms to index: %w", err)
-			}
+		if _, err := oci.PostAttachSBOM(
+			idx, sbompath, bc.Options.SBOMFormats, types.Architecture{}, bc.Logger(), bc.Options.Tags...,
+		); err != nil {
+			return fmt.Errorf("attaching sboms to index: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This commit modifies `apko publish` to always generate an index regardless of the number of architectures that are built.

Closes https://github.com/chainguard-dev/registry-ui/issues/110

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>