### PR TITLE
Dont attach SBOM if index is nil

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -294,10 +294,12 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			return fmt.Errorf("generating index SBOM: %w", err)
 		}
 
-		if _, err := oci.PostAttachSBOM(
-			idx, sbompath, bc.Options.SBOMFormats, types.Architecture{}, bc.Logger(), bc.Options.Tags...,
-		); err != nil {
-			return fmt.Errorf("attaching sboms to index: %w", err)
+		if idx != nil {
+			if _, err := oci.PostAttachSBOM(
+				idx, sbompath, bc.Options.SBOMFormats, types.Architecture{}, bc.Logger(), bc.Options.Tags...,
+			); err != nil {
+				return fmt.Errorf("attaching sboms to index: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
If an image index is nil when attaching the SBOM, skip attaching it

Tries to fix https://github.com/chainguard-dev/base-image-rumble/issues/214

/cc @jdolitsky @jspeed-meyers 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>