### PR TITLE
Fix two bugfixes in SPDX output

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -360,7 +360,7 @@ func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE-MANAGER",
+				Category: "PACKAGE_MANAGER",
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.ImageDigest,
@@ -393,7 +393,7 @@ func (sx *SPDX) apkPackage(opts *options.Options, pkg *repository.Package) Packa
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE-MANAGER",
+				Category: "PACKAGE_MANAGER",
 				Locator: purl.NewPackageURL(
 					"apk", opts.OS.ID, pkg.Name, pkg.Version,
 					purl.QualifiersFromMap(
@@ -421,7 +421,7 @@ func (sx *SPDX) layerPackage(opts *options.Options) *Package {
 		Checksums:        []Checksum{},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE-MANAGER",
+				Category: "PACKAGE_MANAGER",
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.LayerDigest,
@@ -555,7 +555,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE-MANAGER",
+				Category: "PACKAGE_MANAGER",
 				Type:     "purl",
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.IndexPurlName(), opts.ImageInfo.IndexDigest.DeepCopy().String(),
@@ -585,7 +585,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 			},
 			ExternalRefs: []ExternalRef{
 				{
-					Category: "PACKAGE-MANAGER",
+					Category: "PACKAGE_MANAGER",
 					Type:     "purl",
 					Locator: purl.NewPackageURL(
 						purl.TypeOCI, "", opts.ImagePurlName(), info.Digest.DeepCopy().String(),
@@ -651,7 +651,7 @@ func addSourcePackage(vcsURL string, doc *Document, parent *Package) {
 		if ok {
 			sourcePackage.ExternalRefs = []ExternalRef{
 				{
-					Category: "PACKAGE-MANAGER",
+					Category: "PACKAGE_MANAGER",
 					Type:     "purl",
 					Locator: purl.NewPackageURL(
 						purl.TypeGithub, org, strings.TrimSuffix(user, ".git"), version,

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -383,7 +383,7 @@ func (sx *SPDX) apkPackage(opts *options.Options, pkg *repository.Package) Packa
 		LicenseConcluded: pkg.License,
 		Description:      pkg.Description,
 		DownloadLocation: pkg.URL,
-		Originator:       pkg.Maintainer,
+		Originator:       fmt.Sprintf("Person: %s", pkg.Maintainer),
 		SourceInfo:       "Package info from apk database",
 		Checksums: []Checksum{
 			{

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -131,7 +131,7 @@ func TestSourcePackage(t *testing.T) {
 
 	// Verify the purl
 	require.Len(t, doc.Packages[0].ExternalRefs, 1)
-	require.Equal(t, doc.Packages[0].ExternalRefs[0].Category, "PACKAGE-MANAGER")
+	require.Equal(t, doc.Packages[0].ExternalRefs[0].Category, "PACKAGE_MANAGER")
 	require.Equal(t, doc.Packages[0].ExternalRefs[0].Type, "purl")
 	require.Equal(
 		t, doc.Packages[0].ExternalRefs[0].Locator,


### PR DESCRIPTION
This PR fixes two bugs in the SPDX SBOM output:

1. Our originator values were missing the type label.  Now it is set to `Person:`
2. The second commit switches the external reference type label from `PACKAGE-MANAGER` to `PACKAGE_MANAGER`, modified in SPDX 2.3.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>