### PR TITLE
Change back PACKAGE-MANAGER to PACKAGE_MANAGER

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -36,8 +36,12 @@ import (
 // https://spdx.github.io/spdx-spec/3-package-information/#32-package-spdx-identifier
 var validIDCharsRe = regexp.MustCompile(`[^a-zA-Z0-9-.]+`)
 
-const NOASSERTION = "NOASSERTION"
-const apkSBOMdir = "/var/lib/db/sbom"
+const (
+	NOASSERTION          = "NOASSERTION"
+	ExtRefPackageManager = "PACKAGE-MANAGER"
+	ExtRefTypePurl       = "purl"
+	apkSBOMdir           = "/var/lib/db/sbom"
+)
 
 type SPDX struct{}
 
@@ -360,8 +364,8 @@ func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE_MANAGER",
-				Type:     "purl",
+				Category: ExtRefPackageManager,
+				Type:     ExtRefTypePurl,
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.ImageDigest,
 					nil, "",
@@ -393,13 +397,13 @@ func (sx *SPDX) apkPackage(opts *options.Options, pkg *repository.Package) Packa
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE_MANAGER",
+				Category: ExtRefPackageManager,
 				Locator: purl.NewPackageURL(
 					"apk", opts.OS.ID, pkg.Name, pkg.Version,
 					purl.QualifiersFromMap(
 						map[string]string{"arch": opts.ImageInfo.Arch.ToAPK()},
 					), "").String(),
-				Type: "purl",
+				Type: ExtRefTypePurl,
 			},
 		},
 	}
@@ -421,8 +425,8 @@ func (sx *SPDX) layerPackage(opts *options.Options) *Package {
 		Checksums:        []Checksum{},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE_MANAGER",
-				Type:     "purl",
+				Category: ExtRefPackageManager,
+				Type:     ExtRefTypePurl,
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.ImagePurlName(), opts.ImageInfo.LayerDigest,
 					nil, "",
@@ -555,8 +559,8 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 		},
 		ExternalRefs: []ExternalRef{
 			{
-				Category: "PACKAGE_MANAGER",
-				Type:     "purl",
+				Category: ExtRefPackageManager,
+				Type:     ExtRefTypePurl,
 				Locator: purl.NewPackageURL(
 					purl.TypeOCI, "", opts.IndexPurlName(), opts.ImageInfo.IndexDigest.DeepCopy().String(),
 					nil, "",
@@ -585,8 +589,8 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 			},
 			ExternalRefs: []ExternalRef{
 				{
-					Category: "PACKAGE_MANAGER",
-					Type:     "purl",
+					Category: ExtRefPackageManager,
+					Type:     ExtRefTypePurl,
 					Locator: purl.NewPackageURL(
 						purl.TypeOCI, "", opts.ImagePurlName(), info.Digest.DeepCopy().String(),
 						nil, "",
@@ -651,8 +655,8 @@ func addSourcePackage(vcsURL string, doc *Document, parent *Package) {
 		if ok {
 			sourcePackage.ExternalRefs = []ExternalRef{
 				{
-					Category: "PACKAGE_MANAGER",
-					Type:     "purl",
+					Category: ExtRefPackageManager,
+					Type:     ExtRefTypePurl,
 					Locator: purl.NewPackageURL(
 						purl.TypeGithub, org, strings.TrimSuffix(user, ".git"), version,
 						nil, "",

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -131,8 +131,8 @@ func TestSourcePackage(t *testing.T) {
 
 	// Verify the purl
 	require.Len(t, doc.Packages[0].ExternalRefs, 1)
-	require.Equal(t, doc.Packages[0].ExternalRefs[0].Category, "PACKAGE_MANAGER")
-	require.Equal(t, doc.Packages[0].ExternalRefs[0].Type, "purl")
+	require.Equal(t, doc.Packages[0].ExternalRefs[0].Category, ExtRefPackageManager)
+	require.Equal(t, doc.Packages[0].ExternalRefs[0].Type, ExtRefTypePurl)
 	require.Equal(
 		t, doc.Packages[0].ExternalRefs[0].Locator,
 		"pkg:github/distroless/example@868f0dc23e721039f9669b56d01ea4b897f2fb24",


### PR DESCRIPTION
This PR changes back the external reference category label from `PACKAGE_MANAGER` to `PACKAGE-MANAGER`. It was resolved in the SPDX tech call that both would be supported but the preferred form [is the one documented in the schema](https://github.com/spdx/spdx-spec/blob/5c893ae8010d5d972ecdf1af953a95d9f53de415/schemas/spdx-schema.json#L325): `PACKAGE-MANAGER`. Tools should support both forms now.

Schema: https://github.com/spdx/spdx-spec/blob/5c893ae8010d5d972ecdf1af953a95d9f53de415/schemas/spdx-schema.json#L325

Ref: https://github.com/spdx/tools-java/pull/76/files#diff-2d62de45a362cf43a5c97c9481212a3f8b485b8488aeea7415fb5b7b5dfc2d8cL325

This essentially reverts https://github.com/chainguard-dev/apko/pull/446 but now that the SPDX tools in java and go have been updated we should sync.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>