### PR TITLE
Remove proot support

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -27,7 +27,6 @@ import (
 )
 
 func buildMinirootFS() *cobra.Command {
-	var useProot bool
 	var debugEnabled bool
 	var buildDate string
 	var buildArch string
@@ -43,7 +42,6 @@ func buildMinirootFS() *cobra.Command {
 			return BuildMinirootFSCmd(cmd.Context(),
 				build.WithConfig(args[0]),
 				build.WithTarball(args[1]),
-				build.WithProot(useProot),
 				build.WithBuildDate(buildDate),
 				build.WithSBOM(sbomPath),
 				build.WithArch(types.ParseArchitecture(buildArch)),
@@ -52,7 +50,6 @@ func buildMinirootFS() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
 	cmd.Flags().StringVar(&buildArch, "build-arch", runtime.GOARCH, "architecture to build for -- default is Go runtime architecture")

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -30,7 +30,6 @@ import (
 )
 
 func buildCmd() *cobra.Command {
-	var useProot bool
 	var useDockerMediaTypes bool
 	var debugEnabled bool
 	var withVCS bool
@@ -70,7 +69,6 @@ bill of materials) describing the image contents.
 			}
 			return BuildCmd(cmd.Context(), args[1], args[2],
 				build.WithConfig(args[0]),
-				build.WithProot(useProot),
 				build.WithDockerMediatypes(useDockerMediaTypes),
 				build.WithBuildDate(buildDate),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
@@ -86,7 +84,6 @@ bill of materials) describing the image contents.
 		},
 	}
 
-	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
 	cmd.Flags().BoolVar(&withVCS, "vcs", true, "detect and embed VCS URLs")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -38,7 +38,6 @@ import (
 
 func publish() *cobra.Command {
 	var imageRefs string
-	var useProot bool
 	var useDockerMediaTypes bool
 	var buildDate string
 	var sbomPath string
@@ -77,7 +76,6 @@ in a keychain.`,
 			}
 			if err := PublishCmd(cmd.Context(), imageRefs, archs,
 				build.WithConfig(args[0]),
-				build.WithProot(useProot),
 				build.WithDockerMediatypes(useDockerMediaTypes),
 				build.WithTags(args[1:]...),
 				build.WithBuildDate(buildDate),
@@ -103,7 +101,6 @@ in a keychain.`,
 	}
 
 	cmd.Flags().StringVar(&imageRefs, "image-refs", "", "path to file where a list of the published image references will be written")
-	cmd.Flags().BoolVar(&useProot, "use-proot", false, "use proot to simulate privileged operations")
 	cmd.Flags().BoolVar(&useDockerMediaTypes, "use-docker-mediatypes", false, "use Docker mediatypes for image layers/manifest")
 	cmd.Flags().BoolVar(&debugEnabled, "debug", false, "enable debug logging")
 	cmd.Flags().BoolVar(&withVCS, "vcs", true, "detect and embed VCS URLs")

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -38,9 +38,9 @@ import (
 // Programmatic wrapper around apk-tools.
 
 type APK struct {
-	impl     apkImplementation
-	fs       rwfs.FS
-	Options  options.Options
+	impl    apkImplementation
+	fs      rwfs.FS
+	Options options.Options
 }
 
 func New() (*APK, error) {
@@ -68,9 +68,9 @@ func NewWithOptions(o options.Options) (*APK, error) {
 		apkimpl.WithIgnoreMknodErrors(true),
 	)
 	a := &APK{
-		Options:  o,
-		impl:     apkImpl,
-		fs:       src,
+		Options: o,
+		impl:    apkImpl,
+		fs:      src,
 	}
 	return a, nil
 }

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -81,13 +81,11 @@ func (di *defaultBuildImplementation) Refresh(o *options.Options) (*s6.Context, 
 
 	hostArch := types.ParseArchitecture(runtime.GOARCH)
 
-	execOpts := []exec.Option{exec.WithProot(o.UseProot)}
-	if o.UseProot && !o.Arch.Compatible(hostArch) {
-		o.Logger().Debugf("%q requires QEMU (not compatible with %q)", o.Arch, hostArch)
-		execOpts = append(execOpts, exec.WithQemu(o.Arch.ToQEmu()))
+	if !o.Arch.Compatible(hostArch) {
+		o.Logger().Warnf("%q requires QEMU binfmt emulation to be configured (not compatible with %q)", o.Arch, hostArch)
 	}
 
-	executor, err := exec.New(o.WorkDir, o.Logger(), execOpts...)
+	executor, err := exec.New(o.WorkDir, o.Logger())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -44,14 +44,6 @@ func WithConfig(configFile string) Option {
 	}
 }
 
-// WithProot enables proot for rootless image builds.
-func WithProot(enable bool) Option {
-	return func(bc *Context) error {
-		bc.Options.UseProot = enable
-		return nil
-	}
-}
-
 // WithTags sets the tags for the build context.
 func WithTags(tags ...string) Option {
 	return func(bc *Context) error {

--- a/pkg/exec/cmd.go
+++ b/pkg/exec/cmd.go
@@ -24,18 +24,8 @@ import (
 func (e *Executor) ExecuteChroot(name string, arg ...string) error {
 	var cmd *exec.Cmd
 
-	if e.UseProot {
-		baseargs := []string{"-S", e.WorkDir}
-		if e.UseQemu != "" {
-			baseargs = append(baseargs, "-q", e.UseQemu)
-		}
-		baseargs = append(baseargs, name)
-		arg = append(baseargs, arg...)
-		cmd = exec.Command("proot", arg...)
-	} else {
-		arg = append([]string{e.WorkDir, name}, arg...)
-		cmd = exec.Command("chroot", arg...)
-	}
+	arg = append([]string{e.WorkDir, name}, arg...)
+	cmd = exec.Command("chroot", arg...)
 
 	return e.impl.Run(cmd, name, e.Log)
 }
@@ -43,11 +33,6 @@ func (e *Executor) ExecuteChroot(name string, arg ...string) error {
 // Execute executes the named program with the given arguments.
 func (e *Executor) Execute(name string, arg ...string) error {
 	logname := name
-
-	if e.UseProot {
-		arg = append([]string{"-0", name}, arg...)
-		name = "proot"
-	}
 
 	cmd := exec.Command(name, arg...)
 	return e.impl.Run(cmd, logname, e.Log)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -24,10 +24,10 @@ import (
 )
 
 type Executor struct {
-	impl     executorImplementation
-	WorkDir  string
-	UseQemu  string
-	Log      *logrus.Entry
+	impl    executorImplementation
+	WorkDir string
+	UseQemu string
+	Log     *logrus.Entry
 }
 
 type Option func(*Executor) error

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -26,7 +26,6 @@ import (
 type Executor struct {
 	impl     executorImplementation
 	WorkDir  string
-	UseProot bool
 	UseQemu  string
 	Log      *logrus.Entry
 }
@@ -45,16 +44,9 @@ func New(workDir string, logger *logrus.Entry, opts ...Option) (*Executor, error
 		}
 	}
 
-	e.Log = logger.WithFields(logrus.Fields{"use-proot": e.UseProot, "use-qemu": e.UseQemu})
+	e.Log = logger.WithFields(logrus.Fields{"use-qemu": e.UseQemu})
 
 	return e, nil
-}
-
-func WithProot(proot bool) Option {
-	return func(e *Executor) error {
-		e.UseProot = proot
-		return nil
-	}
 }
 
 func WithQemu(qemuArch string) Option {

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -53,10 +53,7 @@ func TestExecute(t *testing.T) {
 		impl := execfakes.FakeExecutorImplementation{}
 		tc.prepare(&impl)
 		sut.SetImplementation(&impl)
-		// Test with and without proot
-		for b := range map[bool]struct{}{false: {}, true: {}} {
-			sut.Execute("command")
-		}
+		sut.Execute("command")
 	}
 }
 
@@ -85,10 +82,6 @@ func TestExecuteChroot(t *testing.T) {
 		impl := execfakes.FakeExecutorImplementation{}
 		tc.prepare(&impl)
 		sut.SetImplementation(&impl)
-
-		// Test with and without proot
-		for b := range map[bool]struct{}{false: {}, true: {}} {
-			sut.ExecuteChroot("command")
-		}
+		sut.ExecuteChroot("command")
 	}
 }

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -55,7 +55,6 @@ func TestExecute(t *testing.T) {
 		sut.SetImplementation(&impl)
 		// Test with and without proot
 		for b := range map[bool]struct{}{false: {}, true: {}} {
-			sut.UseProot = b
 			sut.Execute("command")
 		}
 	}
@@ -89,7 +88,6 @@ func TestExecuteChroot(t *testing.T) {
 
 		// Test with and without proot
 		for b := range map[bool]struct{}{false: {}, true: {}} {
-			sut.UseProot = b
 			sut.ExecuteChroot("command")
 		}
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,6 @@ import (
 type Options struct {
 	UseDockerMediaTypes     bool
 	WantSBOM                bool
-	UseProot                bool
 	WithVCS                 bool
 	WorkDir                 string
 	TarballPath             string
@@ -65,7 +64,6 @@ var Default = Options{
 func (o *Options) Summarize(logger *logrus.Entry) {
 	logger.Printf("  working directory: %s", o.WorkDir)
 	logger.Printf("  tarball path: %s", o.TarballPath)
-	logger.Printf("  use proot: %t", o.UseProot)
 	logger.Printf("  source date: %s", o.SourceDateEpoch)
 	logger.Printf("  Docker mediatypes: %t", o.UseDockerMediaTypes)
 	logger.Printf("  SBOM output path: %s", o.SBOMPath)


### PR DESCRIPTION
As all image building operations are now done on a VFS, we do not need to fake any root user anymore.  So proot can die.