### PR TITLE
fix some build-breaking bugs with the native apk implementation

### DIFF
--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -526,6 +526,8 @@ func (a *APKImplementation) fetchAlpineKeys(versions []string) error {
 //
 //nolint:unparam // we do not use some params... yet.
 func (a *APKImplementation) installPackage(pkg *repository.RepositoryPackage, cache, updateCache, executeScripts bool, sourceDateEpoch *time.Time) error {
+	a.logger.Infof("installing %s (%s)", pkg.Name, pkg.Version)
+
 	u := pkg.Url()
 	client := a.client
 	if client == nil {

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -430,7 +430,10 @@ func installBusyboxLinks(root fs.FS) (fs.FS, error) {
 	// does busybox exist? if not, do not bother with symlinks
 	f, err := root.Open("/bin/busybox")
 	if err != nil {
-		return memfsImpl, err
+		if !errors.Is(err, os.ErrNotExist) {
+			return memfsImpl, err
+		}
+		return memfsImpl, nil
 	}
 	f.Close()
 	for _, link := range busyboxLinks {


### PR DESCRIPTION
With these fixes, apko should be able to build all images again without using apk-tools.