### PR TITLE
read keyfiles from local; read local repositories

### DIFF
--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -338,7 +338,7 @@ func (a *APKImplementation) InitKeyring(keyFiles, extraKeyFiles []string) (err e
 			var data []byte
 			switch asURL.Scheme {
 			case "file":
-				data, err = a.fs.ReadFile(element)
+				data, err = os.ReadFile(element)
 				if err != nil {
 					return fmt.Errorf("failed to read apk key: %w", err)
 				}

--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -529,20 +529,52 @@ func (a *APKImplementation) installPackage(pkg *repository.RepositoryPackage, ca
 	a.logger.Infof("installing %s (%s)", pkg.Name, pkg.Version)
 
 	u := pkg.Url()
-	client := a.client
-	if client == nil {
-		client = &http.Client{}
+
+	// Normalize the repo as a URI, so that local paths
+	// are translated into file:// URLs, allowing them to be parsed
+	// into a url.URL{}.
+	var (
+		r     io.Reader
+		asURI uri.URI
+	)
+	if strings.HasPrefix(u, "https://") {
+		asURI, _ = uri.Parse(u)
+	} else {
+		asURI = uri.New(u)
 	}
-	res, err := client.Get(u)
+	asURL, err := url.Parse(string(asURI))
 	if err != nil {
-		return fmt.Errorf("unable to get package apk at %s: %w", u, err)
+		return fmt.Errorf("failed to parse package as URI: %w", err)
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("unable to get package apk at %s: %v", u, res.Status)
+
+	switch asURL.Scheme {
+	case "file":
+		f, err := os.Open(u)
+		if err != nil {
+			return fmt.Errorf("failed to read repository package apk %s: %w", u, err)
+		}
+		defer f.Close()
+		r = f
+	case "https":
+		client := a.client
+		if client == nil {
+			client = &http.Client{}
+		}
+		res, err := client.Get(u)
+		if err != nil {
+			return fmt.Errorf("unable to get package apk at %s: %w", u, err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf("unable to get package apk at %s: %v", u, res.Status)
+		}
+		r = res.Body
+	default:
+		return fmt.Errorf("repository scheme %s not supported", asURL.Scheme)
 	}
+
 	// install the apk file
-	expanded, err := expandApk(res.Body)
+	expanded, err := expandApk(r)
 	if err != nil {
 		return fmt.Errorf("unable to expand apk for package %s: %w", pkg.Name, err)
 	}

--- a/pkg/apk/impl/implementation_test.go
+++ b/pkg/apk/impl/implementation_test.go
@@ -124,12 +124,13 @@ func TestInitKeyring(t *testing.T) {
 	a, err := NewAPKImplementation(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 
-	dir := "/foo/bar/keys"
-	err = src.MkdirAll(dir, 0o755)
+	dir, err := os.MkdirTemp("", "apko")
 	require.NoError(t, err)
 
 	keyPath := filepath.Join(dir, "alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub")
-	src.WriteFile(keyPath, []byte(testDemoKey), 0o644)
+	err = os.WriteFile(keyPath, []byte(testDemoKey), 0o644)
+	require.NoError(t, err)
+
 	// Add a local file and a remote key
 	keyfiles := []string{
 		keyPath, "https://alpinelinux.org/keys/alpine-devel%40lists.alpinelinux.org-4a6a0840.rsa.pub",

--- a/pkg/apk/impl/repo_test.go
+++ b/pkg/apk/impl/repo_test.go
@@ -51,6 +51,22 @@ Ok9WP8SOAIj+xdqoiHcC4j72BOVVgiITIJNHrbppZCq6qPR+fgXmXa+sDcGh30m6
 JZDr++FjKrnnijbyNF8b98UCAwEAAQ==
 -----END PUBLIC KEY-----`), 0644)
 	require.NoError(t, err, "unable to write key")
+	err = src.WriteFile("etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub", []byte(`
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAutQkua2CAig4VFSJ7v54
+ALyu/J1WB3oni7qwCZD3veURw7HxpNAj9hR+S5N/pNeZgubQvJWyaPuQDm7PTs1+
+tFGiYNfAsiibX6Rv0wci3M+z2XEVAeR9Vzg6v4qoofDyoTbovn2LztaNEjTkB+oK
+tlvpNhg1zhou0jDVYFniEXvzjckxswHVb8cT0OMTKHALyLPrPOJzVtM9C1ew2Nnc
+3848xLiApMu3NBk0JqfcS3Bo5Y2b1FRVBvdt+2gFoKZix1MnZdAEZ8xQzL/a0YS5
+Hd0wj5+EEKHfOd3A75uPa/WQmA+o0cBFfrzm69QDcSJSwGpzWrD1ScH3AK8nWvoj
+v7e9gukK/9yl1b4fQQ00vttwJPSgm9EnfPHLAtgXkRloI27H6/PuLoNvSAMQwuCD
+hQRlyGLPBETKkHeodfLoULjhDi1K2gKJTMhtbnUcAA7nEphkMhPWkBpgFdrH+5z4
+Lxy+3ek0cqcI7K68EtrffU8jtUj9LFTUC8dERaIBs7NgQ/LfDbDfGh9g6qVj1hZl
+k9aaIPTm/xsi8v3u+0qaq7KzIBc9s59JOoA8TlpOaYdVgSQhHHLBaahOuAigH+VI
+isbC9vmqsThF2QdDtQt37keuqoda2E6sL7PUvIyVXDRfwX7uMDjlzTxHTymvq2Ck
+htBqojBnThmjJQFgZXocHG8CAwEAAQ==
+-----END PUBLIC KEY-----`), 0644)
+	require.NoError(t, err, "unable to write key")
 
 	a, err := NewAPKImplementation(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err, "unable to create APKImplementation")


### PR DESCRIPTION
Fixes #464 

Issue with two problems was a regression caused by #426 

It was treating keyfiles to read when passed via `--keyring-append` as relative to workdir, which made no sense; when someone types `build --keyring-append /path/to/file`, they mean, "relative to where I am running apko".

This fixes it.

It also was doing the same for `--repository-append`; fixes that too.