### PR TITLE
handle package that is only an alias

### DIFF
--- a/examples/alias-only.yaml
+++ b/examples/alias-only.yaml
@@ -1,0 +1,5 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - openssh-client

--- a/pkg/apk/impl/repo.go
+++ b/pkg/apk/impl/repo.go
@@ -264,7 +264,14 @@ func (p *PkgResolver) GetPackagesWithDependencies(packages []string) (toInstall 
 		name, version, compare := resolvePackageNameVersion(pkgName)
 		pkg, ok := p.nameMap[name]
 		if !ok {
-			return nil, nil, fmt.Errorf("could not find package %s in indexes", pkgName)
+			trueName, ok := p.providesMap[name]
+			if !ok {
+				return nil, nil, fmt.Errorf("could not find package %s in indexes", pkgName)
+			}
+			pkg, ok = p.nameMap[trueName]
+			if !ok {
+				return nil, nil, fmt.Errorf("could not find package %s in indexes", pkgName)
+			}
 		}
 
 		if compare != versionNone {
@@ -355,7 +362,14 @@ func (p *PkgResolver) getPackageDependencies(pkg string, parents map[string]bool
 	}
 	ref, ok := p.nameMap[pkg]
 	if !ok {
-		return nil, nil, fmt.Errorf("package %s not found in indexes", pkg)
+		trueName, ok := p.providesMap[pkg]
+		if !ok {
+			return nil, nil, fmt.Errorf("package %s not found in indexes", pkg)
+		}
+		ref, ok = p.nameMap[trueName]
+		if !ok {
+			return nil, nil, fmt.Errorf("package %s not found in indexes", pkg)
+		}
 	}
 
 	// each dependency has only one of two possibilities:


### PR DESCRIPTION
Fixes #469 

It knows how to handle aliases (or provided-by) for dependencies, but not for direct packages. This fixes that. It also adds a test case using the example provided by @kaniini in #469 

