### PR TITLE
Call ReadReleaseData() when generate img SBOM

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -144,6 +144,10 @@ func (di *defaultBuildImplementation) GenerateImageSBOM(o *options.Options, ic *
 		return fmt.Errorf("reading layer tar: %w", err)
 	}
 
+	if err := s.ReadReleaseData(); err != nil {
+		return fmt.Errorf("getting os-release: %w", err)
+	}
+
 	if err := s.ReadPackageIndex(); err != nil {
 		return fmt.Errorf("getting installed packages from sbom: %w", err)
 	}


### PR DESCRIPTION
This PR fixes a bug where ReadReleaseData was not being called when generating the image SBOMs. This caused purls to be incomplete when generated for packages that don't include an SBOM. Fixed now:

```
 📂 SPDX Document sbom-sha256:48f32f7b63728353062f85d42ed792f6736a61e2730043eee1c8b773d137c841
  │ 
  │ 📦 DESCRIBES 1 Packages
  │ 
  ├ pkg:oci/static@sha256:9b041a3a16992f1b1409b2e4...
  │  │ 🔗 2 Relationships
  │  ├ CONTAINS PACKAGE pkg:oci/static@sha256:48f32f7b63728353062f85d42ed79...
  │  │  │ 🔗 5 Relationships
  │  │  ├ CONTAINS PACKAGE pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0?arch=x86_64
  │  │  ├ CONTAINS PACKAGE pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64
  │  │  ├ CONTAINS PACKAGE pkg:apk/alpine/alpine-release@3.17.0-r0?arch=x86_64
  │  │  ├ CONTAINS PACKAGE pkg:apk/alpine/ca-certificates-bundle@20230106-r0?arch=x86_64
  │  │  └ CONTAINS PACKAGE pkg:apk/alpine/tzdata@2022g-r0?arch=x86_64
  │  │ 
  │  └ GENERATED_FROM PACKAGE pkg:github/puerco/apko@21159b6209b534ceb7db040ce9d35d08bd9924f9
  │ 
  └ 📄 DESCRIBES 0 Files

```

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>