### PR TITLE
support for case-insensitive filesystems

### DIFF
--- a/pkg/apk/impl/fs/doc.go
+++ b/pkg/apk/impl/fs/doc.go
@@ -22,5 +22,6 @@
 // capabilities, such as Chown when running as non-root. These can be special
 // files on disk, kept in-memory, or even coloured strips on the computer, as long as the
 // writes and reads are consistent.
+// All implementations are expected to be case-sensitive.
 
 package fs

--- a/pkg/apk/impl/fs/memfs.go
+++ b/pkg/apk/impl/fs/memfs.go
@@ -201,7 +201,7 @@ func (m *memFS) Chown(path string, uid int, gid int) error {
 	return nil
 }
 func (m *memFS) Create(name string) (File, error) {
-	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC, 0o666)
+	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o666)
 }
 
 func (m *memFS) Symlink(oldname, newname string) error {

--- a/pkg/apk/impl/fs/rwosfs.go
+++ b/pkg/apk/impl/fs/rwosfs.go
@@ -15,24 +15,82 @@
 package fs
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-func DirFS(dir string) FullFS {
+type dirFSOpts struct {
+	caseSensitive    bool
+	caseSensitiveSet bool
+}
+
+// DirFSOption is an option for DirFS
+type DirFSOption func(*dirFSOpts) error
+
+// DirFSWithCaseSensitive allows you to specify whether the underlying filesystem
+// should be treated as case-sensitive or insensitive. If you do not specify this,
+// it determines it by testing the underlying filesystem.
+// Normally you should let the filesystem determine this, but sometimes this can be useful.
+func DirFSWithCaseSensitive(caseSensitive bool) DirFSOption {
+	return func(opts *dirFSOpts) error {
+		opts.caseSensitive = caseSensitive
+		opts.caseSensitiveSet = true
+		return nil
+	}
+}
+
+func DirFS(dir string, opts ...DirFSOption) FullFS {
+	var options dirFSOpts
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return nil
+		}
+	}
+
 	memfs := NewMemFS()
 	m := memfs.(*memFS)
+
+	var caseSensitive bool
+	if options.caseSensitiveSet {
+		caseSensitive = options.caseSensitive
+	} else {
+		// check if the underlying filesystem is case-sensitive
+		// we cannot just use it in TempDir() because these might be different filesystems
+		// find a file that does not exist
+		for i := 0; ; i++ {
+			filename := fmt.Sprintf("test-dirfs-%d", i)
+			if _, err := os.Stat(filepath.Join(dir, filename)); err == nil {
+				continue
+			}
+			if err := os.WriteFile(filepath.Join(dir, filename), []byte("test"), 0o600); err != nil {
+				return nil
+			}
+			// see if it exists
+			if _, err := os.Stat(filepath.Join(dir, strings.ToUpper(filename))); err != nil {
+				caseSensitive = true
+			}
+			// clean up our own messes
+			_ = os.Remove(filepath.Join(dir, filename))
+			break
+		}
+	}
+
+	var caseMap map[string]string
+	if !caseSensitive {
+		caseMap = map[string]string{}
+	}
 	f := &dirFS{
 		base:      dir,
 		overrides: m,
+		caseMap:   caseMap,
 	}
 	// need to populate the overrides with appropriate info
 	root := os.DirFS(dir)
@@ -88,6 +146,15 @@ func DirFS(dir string) FullFS {
 // For those features that are not supported, e.g. activities that are non-permissioned
 // or unsupported by the underlying filesystem or operating system, it keeps a separate map
 // in memory.
+//
+// How case-sensitivity works.
+// If the underlying filesystem is case-sensitive, then all files are mapped both on disk and in memory,
+// with content solely on disk to save space.
+// If the underlying filesystem is case-insensitive, then we can only have one variant of each file on disk,
+// but multiple in memory. Each file provided is converted to lower-case. That is then used as a key
+// in a map, whose value is the one that is on disk. Any other variant is in memory.
+// If the case-sensitive filename you are looking for is the same as the value in the map, it is on disk,
+// else in memory.
 type dirFS struct {
 	base string
 	// overrides is a map of overrides for things that could not be kept on disk because of permission,
@@ -95,15 +162,18 @@ type dirFS struct {
 	// It will include all directories, but no file contents.
 	// If there are permissions in memory, they override the disk.
 	overrides *memFS
+	// caseMap if non-nil, underlying filesystem is case-insensitive, so only one variant of each file
+	// can exist on disk. Maps the case-sensitive to the case-insensitive variant
+	caseMap      map[string]string
+	caseMapMutex sync.Mutex
 }
 
 func (f *dirFS) Readlink(name string) (string, bool, error) {
-	target, err := os.Readlink(filepath.Join(f.base, name))
+	// The underlying filesystem might not support symlinks, and it might be case-insensitive, so just
+	// use the one in memory.
+	target, _, err := f.overrides.Readlink(name)
 	if err != nil {
-		target, _, err = f.overrides.Readlink(name)
-		if err != nil {
-			return "", false, err
-		}
+		return "", false, err
 	}
 	return target, true, err
 }
@@ -122,28 +192,44 @@ func (f *dirFS) open(name string) (*fileImpl, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := os.Open(fullpath)
-	if err == nil {
-		return &fileImpl{file, nil}, nil
+	baseName := filepath.Base(name)
+	if f.caseSensitiveOnDisk(name) {
+		file, err := os.Open(fullpath)
+		if err == nil {
+			return &fileImpl{
+				file: file,
+				name: baseName,
+			}, nil
+		}
+		if !os.IsPermission(err) {
+			return nil, err
+		}
+		// get the original permissions
+		fi, err := os.Stat(fullpath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to stat file %s: %w", fullpath, err)
+		}
+		// Try to change permissions and open again.
+		if err := os.Chmod(fullpath, 0600); err != nil {
+			return nil, fmt.Errorf("unable to read file or change permissions: %s", name)
+		}
+		file, err = os.Open(fullpath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file even after change permissions: %s", name)
+		}
+		perms := fi.Mode()
+		return &fileImpl{
+			file:  file,
+			name:  baseName,
+			perms: &perms,
+		}, nil
 	}
-	if !os.IsPermission(err) {
+
+	file, err := f.overrides.OpenReaderAt(name)
+	if err != nil {
 		return nil, err
 	}
-	// get the original permissions
-	fi, err := os.Stat(fullpath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to stat file %s: %w", fullpath, err)
-	}
-	// Try to change permissions and open again.
-	if err := os.Chmod(fullpath, 0600); err != nil {
-		return nil, fmt.Errorf("unable to read file or change permissions: %s", name)
-	}
-	file, err = os.Open(fullpath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read file even after change permissions: %s", name)
-	}
-	perms := fi.Mode()
-	return &fileImpl{file, &perms}, nil
+	return &fileImpl{file: file, name: baseName}, nil
 }
 
 // Open open a file for reading. Returns fs.File.
@@ -152,17 +238,32 @@ func (f *dirFS) open(name string) (*fileImpl, error) {
 // This only works if the user reading the file actually has
 // permissions to change the file permissions.
 func (f *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
-	file, err := os.OpenFile(filepath.Join(f.base, name), flag, perm)
-	if err != nil {
-		return nil, err
-	}
-	// ensure it exists in memory, if it was open for create
-	if flag&os.O_CREATE != 0 {
-		memFile, err := f.overrides.OpenFile(name, flag, perm)
+	var (
+		file File
+		err  error
+	)
+	if flag&os.O_CREATE == os.O_CREATE {
+		file, err = f.overrides.OpenFile(name, flag, perm)
 		if err != nil {
 			return nil, err
 		}
-		_ = memFile.Close()
+		// do we create it on disk?
+		if f.createOnDisk(name) {
+			_ = file.Close()
+			file, err = os.OpenFile(filepath.Join(f.base, name), flag, perm)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		if f.caseSensitiveOnDisk(name) {
+			file, err = os.OpenFile(filepath.Join(f.base, name), flag, perm)
+		} else {
+			file, err = f.overrides.OpenFile(name, flag, perm)
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 	return file, nil
 }
@@ -172,13 +273,21 @@ func (f *dirFS) OpenReaderAt(name string) (File, error) {
 }
 
 func (f *dirFS) Stat(name string) (fs.FileInfo, error) {
-	fi, err := os.Stat(filepath.Join(f.base, name))
-	if err != nil {
-		return nil, err
-	}
+	var (
+		fi  fs.FileInfo
+		err error
+	)
 	mi, err := f.overrides.Stat(name)
 	if err != nil {
 		return nil, err
+	}
+	if f.caseSensitiveOnDisk(name) {
+		fi, err = os.Stat(filepath.Join(f.base, name))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		fi = mi
 	}
 	return &fileInfo{
 		file: fi,
@@ -190,59 +299,107 @@ func (f *dirFS) Lstat(name string) (fs.FileInfo, error) {
 }
 
 func (f *dirFS) Create(name string) (File, error) {
-	file, err := os.Create(filepath.Join(f.base, name))
+	// if the underlying filesystem is case-insensitive, check if the file exists and, if so,
+	// do it only in memory.
+	var (
+		file File
+		err  error
+	)
+	file, err = f.overrides.Create(name)
 	if err != nil {
 		return nil, err
 	}
-	// ensure it exists in memory
-	_, err = f.overrides.Create(name)
+	// do we create it on disk?
+	if f.createOnDisk(name) {
+		// close the memory one
+		_ = file.Close()
+		file, err = os.Create(filepath.Join(f.base, name))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return file, err
 }
 
 func (f *dirFS) Remove(name string) error {
-	if err := os.Remove(filepath.Join(f.base, name)); err != nil {
+	if err := f.overrides.Remove(name); err != nil {
 		return err
 	}
-	return f.overrides.Remove(name)
+	if f.removeOnDisk(name) {
+		return os.Remove(filepath.Join(f.base, name))
+	}
+	return nil
 }
 
 func (f *dirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	// get those on disk
-	onDisk, err := os.ReadDir(filepath.Join(f.base, name))
+	var (
+		onDisk, inMem []fs.DirEntry
+		err           error
+	)
+	if f.caseSensitiveOnDisk(name) {
+		onDisk, err = os.ReadDir(filepath.Join(f.base, name))
+		if err != nil {
+			return nil, err
+		}
+	}
+	// get those in memory
+	inMem, err = f.overrides.ReadDir(name)
 	if err != nil {
 		return nil, err
 	}
-	// should be identical in memory
-	inMem, err := f.overrides.ReadDir(name)
-	if err != nil {
-		return nil, err
+	// possibilities:
+	// - directory on disk is case-insensitive and not the unique one: no entries on disk
+	// - directory on disk is case-insensitive and the unique one: disk entries and memory entries; all disk must be in mem, but mem may have more
+	// - directory on disk is case-sensitive: disk entries and memory entries; all disk must be in mem, but mem may have more
+	//
+	// either way, memory always should be >= disk
+	diskEntries := make(map[string]fs.DirEntry, len(onDisk))
+	for _, d := range onDisk {
+		diskEntries[d.Name()] = d
 	}
-	if len(onDisk) != len(inMem) {
-		return nil, errors.New("mismatched entries in filesystems disk vs memory")
-	}
-	// merge them
-	dirEntries := make([]fs.DirEntry, len(onDisk))
-	for i, m := range inMem {
-		f := onDisk[i]
-		dirEntries[i] = &dirEntry{disk: f, mem: m}
+
+	dirEntries := make([]fs.DirEntry, 0, len(inMem))
+	for _, m := range inMem {
+		f := m
+		if d, ok := diskEntries[m.Name()]; ok {
+			f = d
+		}
+		dirEntries = append(dirEntries, &dirEntry{disk: f, mem: m})
 	}
 	return dirEntries, nil
 }
 func (f *dirFS) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(filepath.Join(f.base, name))
+	if f.caseSensitiveOnDisk(name) {
+		return os.ReadFile(filepath.Join(f.base, name))
+	}
+	return f.overrides.ReadFile(name)
 }
 func (f *dirFS) WriteFile(name string, b []byte, mode fs.FileMode) error {
-	if err := os.WriteFile(filepath.Join(f.base, name), b, mode); err != nil {
-		return err
+	var (
+		memContent []byte
+	)
+	if f.createOnDisk(name) {
+		if err := os.WriteFile(filepath.Join(f.base, name), b, mode); err != nil {
+			return err
+		}
+	} else {
+		memContent = b
 	}
-	// ensure file exists in memory, but with zero size
-	return f.overrides.WriteFile(name, nil, mode)
+
+	// ensure file exists in memory
+	// if this is just a flag for what is on disk, make it with zero size
+	// if it is the actual file because of case sensitivity, then use the actual content
+	return f.overrides.WriteFile(name, memContent, mode)
 }
 
 func (f *dirFS) Readnod(name string) (dev int, err error) {
-	_, err = os.Stat(filepath.Join(f.base, name))
-	if err != nil {
-		return 0, err
+	if f.caseSensitiveOnDisk(name) {
+		_, err = os.Stat(filepath.Join(f.base, name))
+		if err != nil {
+			return 0, err
+		}
 	}
 	return f.overrides.Readnod(name)
 }
@@ -255,7 +412,9 @@ func (f *dirFS) Link(oldname, newname string) error {
 	if !strings.HasPrefix(target, f.base) {
 		return fmt.Errorf("hardlink target %s is outside of the filesystem", target)
 	}
-	_ = os.Link(target, filepath.Join(f.base, newname))
+	if f.caseSensitiveOnDisk(newname) {
+		_ = os.Link(target, filepath.Join(f.base, newname))
+	}
 	return f.overrides.Link(oldname, newname)
 }
 
@@ -263,7 +422,9 @@ func (f *dirFS) Symlink(oldname, newname string) error {
 	// For symlink, take target as is.
 	// If it is outside of the base, it will be resolved by Readlink.
 	// This enables proper symlink behaviour.
-	_ = os.Symlink(oldname, filepath.Join(f.base, newname))
+	if f.caseSensitiveOnDisk(newname) {
+		_ = os.Symlink(oldname, filepath.Join(f.base, newname))
+	}
 	return f.overrides.Symlink(oldname, newname)
 }
 
@@ -279,26 +440,36 @@ func (f *dirFS) MkdirAll(name string, perm fs.FileMode) error {
 func (f *dirFS) Mkdir(name string, perm fs.FileMode) error {
 	// just in case, because some underlying systems miss this
 	fullPerm := os.ModeDir | perm
-	if err := os.Mkdir(filepath.Join(f.base, name), fullPerm); err != nil {
-		return err
+	if f.caseSensitiveOnDisk(name) {
+		if err := os.Mkdir(filepath.Join(f.base, name), fullPerm); err != nil {
+			return err
+		}
 	}
 	return f.overrides.Mkdir(name, fullPerm)
 }
 
 func (f *dirFS) Chmod(path string, perm fs.FileMode) error {
-	_ = os.Chmod(filepath.Join(f.base, path), perm)
+	if f.caseSensitiveOnDisk(path) {
+		// ignore error, as we track it in memory anyways, and disk filesystem might not support it
+		_ = os.Chmod(filepath.Join(f.base, path), perm)
+	}
 	return f.overrides.Chmod(path, perm)
 }
 func (f *dirFS) Chown(path string, uid int, gid int) error {
-	_ = os.Chown(filepath.Join(f.base, path), uid, gid)
+	if f.caseSensitiveOnDisk(path) {
+		// ignore error, as we track it in memory anyways, and disk filesystem might not support it
+		_ = os.Chown(filepath.Join(f.base, path), uid, gid)
+	}
 	return f.overrides.Chown(path, uid, gid)
 }
 
 func (f *dirFS) Mknod(name string, mode uint32, dev int) error {
-	err := unix.Mknod(filepath.Join(f.base, name), mode, dev)
-	// what if we could not create it? Just create a regular file there, and memory will override
-	if err != nil {
-		_ = os.WriteFile(filepath.Join(f.base, name), nil, 0)
+	if f.caseSensitiveOnDisk(name) {
+		err := unix.Mknod(filepath.Join(f.base, name), mode, dev)
+		// what if we could not create it? Just create a regular file there, and memory will override
+		if err != nil {
+			_ = os.WriteFile(filepath.Join(f.base, name), nil, 0)
+		}
 	}
 	return f.overrides.Mknod(name, mode, dev)
 }
@@ -316,21 +487,61 @@ func sanitizePath(base, p string) (v string, err error) {
 	return "", fmt.Errorf("%s: %s", "content filepath is tainted", p)
 }
 
+func (f *dirFS) caseSensitiveOnDisk(p string) bool {
+	if f.caseMap == nil {
+		return true
+	}
+	result, ok := f.caseMap[strings.ToLower(p)]
+	if !ok {
+		return true
+	}
+	return result == p
+}
+
+// createOnDisk given a path p, determine if it should be created on disk, and, if relevant,
+// add it to the caseMap.
+func (f *dirFS) createOnDisk(p string) (createOnDisk bool) {
+	f.caseMapMutex.Lock()
+	defer f.caseMapMutex.Unlock()
+	key := strings.ToLower(p)
+	if f.caseMap == nil {
+		createOnDisk = true
+	} else if _, ok := f.caseMap[key]; !ok {
+		createOnDisk = true
+		f.caseMap[key] = p
+	}
+	return
+}
+
+// removeOnDisk given a path p, determine if it should be removed from disk, and, if relevant,
+// remove it from the caseMap.
+func (f *dirFS) removeOnDisk(p string) (removeOnDisk bool) {
+	f.caseMapMutex.Lock()
+	defer f.caseMapMutex.Unlock()
+	key := strings.ToLower(p)
+	if f.caseMap == nil {
+		removeOnDisk = true
+	} else if v, ok := f.caseMap[key]; ok && v == p {
+		delete(f.caseMap, key)
+		removeOnDisk = true
+	}
+	return
+}
+
+type file File
 type fileImpl struct {
-	*os.File
+	file
+	name  string
 	perms *os.FileMode
 }
 
-func (f fileImpl) ReadAt(b []byte, off int64) (int, error) {
-	return f.File.ReadAt(b, off)
-}
 func (f fileImpl) Close() error {
 	if f.perms != nil {
 		defer func() {
-			_ = os.Chmod(f.Name(), *f.perms)
+			_ = os.Chmod(f.name, *f.perms)
 		}()
 	}
-	return f.File.Close()
+	return f.file.Close()
 }
 
 type fileInfo struct {


### PR DESCRIPTION
One thing that we didn't think of earlier in, in terms of missing OS/filesystem capabilities, is case-insensitivity. apk packages are assumed to be running on Linux, where case-sensitivity is the norm. While the vast majority of packages are unlikely to use it, some will. For example, `linux-headers` does. The melange example `sshfs.yaml` triggers this by including `linux-headers`.

memfs already is case-sensitive.

This adds case-sensitivity to `dirFS`. When started, it tests the filesystem to see if it is case-insensitive, and if it is, it keeps track of sensitive-duplicate files in memory. It relies on there not being too many of them, or their being too big.

It also adds a test for it.

We may want to start thinking about a more persistent option, where `dirFS` stores _everything_ on disk, but uses its own encoding for it. That is an option for the future.