### PR TITLE
use dedicated sub directory for building each arch

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -152,7 +152,7 @@ func (bc *Context) runAssertions() error {
 // The SOURCE_DATE_EPOCH env variable is supported and will
 // overwrite the provided timestamp if present.
 func New(workDir string, opts ...Option) (*Context, error) {
-	fs := apkfs.DirFS(workDir)
+	fs := apkfs.DirFS(workDir, apkfs.WithCreateDir(true))
 	bc := Context{
 		Options: options.Default,
 		impl: &defaultBuildImplementation{

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -125,6 +125,9 @@ func WithPackageVersionTagPrefix(packageVersionTagPrefix string) Option {
 func WithSBOMFormats(formats []string) Option {
 	return func(bc *Context) error {
 		bc.Options.SBOMFormats = formats
+		if len(formats) > 0 {
+			bc.Options.WantSBOM = true
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes #492 

`build` command only builds one architecture, while `publish` builds multiple. But the workdir provided for `builder.New(workdir)` only included the root of the tempdir. That meant that when building multiple archs, they would trounce each other.

This explicitly builds in an arch-specific subdirectory, which keeps everything clean.