### PR TITLE
Fix for SBOMs not being generated

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -138,7 +138,8 @@ func (di *defaultBuildImplementation) GenerateImageSBOM(o *options.Options, ic *
 		return nil
 	}
 
-	s := newSBOM(di.workdirFS, o, ic)
+	archWorkdirFS := apkfs.DirFS(o.WorkDir, apkfs.WithCreateDir(true))
+	s := newSBOM(archWorkdirFS, o, ic)
 
 	if err := s.ReadLayerTarball(o.TarballPath); err != nil {
 		return fmt.Errorf("reading layer tar: %w", err)


### PR DESCRIPTION
Regression possibly introduced by #495 cc @deitch 

```
time="2023-02-09T21:00:42Z" level=info msg="Generating arch image SBOMs"
Error: generating sbom for amd64: reading layer tar: failed to create OCI layer from tar.gz: open /tmp/apko-temp-2864749245/apko-x86_64.tar.gz: no such file or directory
2023/02/09 21:00:43 error during command execution: generating sbom for amd64: reading layer tar: failed to create OCI layer from tar.gz: open /tmp/apko-temp-2864749245/apko-x86_64.tar.gz: no such file or directory
```
