### PR TITLE
support chmod/chown

### DIFF
--- a/pkg/apk/impl/sign.go
+++ b/pkg/apk/impl/sign.go
@@ -64,9 +64,6 @@ func SignIndex(logger *log.Logger, signingKey string, indexFile string) error {
 
 	// prepare control.tar.gz
 	multitarctx, err := tarball.NewContext(
-		tarball.WithOverrideUIDGID(0, 0),
-		tarball.WithOverrideUname("root"),
-		tarball.WithOverrideGname("root"),
 		tarball.WithSkipClose(true),
 	)
 	if err != nil {

--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -117,8 +117,12 @@ func (di *defaultBuildImplementation) MutateAccounts(
 				continue
 			} else if !os.IsNotExist(err) {
 				return fmt.Errorf("checking homedir exists: %w", err)
-			} else if err := fsys.MkdirAll(targetHomedir, 0755); err != nil {
+			}
+			if err := fsys.MkdirAll(targetHomedir, 0755); err != nil {
 				return fmt.Errorf("creating homedir: %w", err)
+			}
+			if err := fsys.Chown(targetHomedir, int(ue.UID), int(ue.GID)); err != nil {
+				return fmt.Errorf("chowning homedir: %w", err)
 			}
 		}
 

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -115,9 +115,6 @@ func (di *defaultBuildImplementation) BuildTarball(o *options.Options, fsys fs.F
 	// we use a general override of 0,0 for all files, but the specific overrides, that come from the installed package DB, come later
 	tw, err := tarball.NewContext(
 		tarball.WithSourceDateEpoch(o.SourceDateEpoch),
-		tarball.WithOverrideUIDGID(0, 0),
-		tarball.WithOverrideUname("root"),
-		tarball.WithOverrideGname("root"),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to construct tarball build context: %w", err)

--- a/pkg/tarball/append.go
+++ b/pkg/tarball/append.go
@@ -45,7 +45,7 @@ func (m *MultiTar) Append(ctx *Context, src fs.FS, extra ...io.Writer) error {
 
 	tw := tar.NewWriter(io.MultiWriter(all...))
 
-	if err := ctx.writeTar(tw, src); err != nil {
+	if err := ctx.writeTar(tw, src, nil, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #497

There were several issues:

* chown and chmod were non-functional (it was one of those thing set for "later" that never got addressed)
* Uname and Gname were not being provided for the tar headers
* Uname/Gname/UID/GID override were set, which caused _everything_ to be owned by root, and thus nonrunnable

