### PR TITLE
build all archs indicated in a file

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: build image
         run: |
-          ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx-${{ matrix.arch }}.tar --debug --build-arch ${{ matrix.arch }}
+          ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx-${{ matrix.arch }}.tar --debug --arch ${{ matrix.arch }}
 
   build-all-examples-one-arch:
     name: build-all-examples-amd64
@@ -52,5 +52,5 @@ jobs:
         run: |
           for cfg in $(find ./examples/ -name '*.yaml'); do
             name=$(basename ${cfg} .yaml)
-            ./apko build ${cfg} ${name}:build /tmp/${name}.tar --debug --build-arch amd64
+            ./apko build ${cfg} ${name}:build /tmp/${name}.tar --debug --arch amd64
           done


### PR DESCRIPTION
Currently, there is a split between how `build` works and how `publish` works:

* `publish`: build all archs indicated an a yaml file, unless overridden by `--arch`
* `build`: build your local arch, unless overridden by `--build-arch`, which will only take the first arch

The problems are:

* will only build one arch, which means no way to generate an index or multiple archs
* no way to test multi-arch build without doing `publish`, which you may not want to do
* `build` always ignores the `arches` in the yaml
* inconsistent behaviour between the two
* inconsistent flags

This changes the above to make it consistent:

* same flag `--arch`
* builds for all archs in yaml, unless explicitly overrides
* supports building for multiple archs
* supports the `--arch host` for "build local"

This _is_ a change in the default behaviour, so it should be reviewed properly, but I do believe this is the right thing to do.

This does lead to a lot of duplication between `build` and `publish`. I think that, once this is in (assuming we agree to this), we should remove most of the logic from `publish`, have `publish` just call `build`, and then use the outputs to publish.