### PR TITLE
makefile: separate image tag concern from git version identifier

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,8 +77,9 @@ jobs:
     - name: Publish/Sign apko image
       run: |
         # If not a tagged release, override image tag to "canary"
+        export IMAGE_TAG=${GITHUB_REF#refs/tags/}
         if [[ $GITHUB_REF != refs/tags/* ]]; then
-          export GIT_VERSION=canary
+          export IMAGE_TAG=canary
         fi
         make sign-image
 
@@ -116,8 +117,9 @@ jobs:
     - name: Generate Tekton Task
       run: |
         # If not a tagged release, override image tag to "canary"
+        export IMAGE_TAG=${GITHUB_REF#refs/tags/}
         if [[ $GITHUB_REF != refs/tags/* ]]; then
-          export GIT_VERSION=canary
+          export IMAGE_TAG=canary
         fi
         make ko-resolve
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ endif
 GOFILES ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 # Set version variables for LDFLAGS
+IMAGE_TAG ?= latest
 GIT_TAG ?= dirty-tag
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
@@ -61,7 +62,7 @@ ko: ## Build images using ko
 	$(create_kocache_path)
 	$(eval DIGEST := $(shell LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --bare \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(IMAGE_TAG) --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		chainguard.dev/apko))
 	@echo Image Digest $(DIGEST)
 
@@ -70,7 +71,7 @@ ko-local:  ## Build images locally using ko
 	$(create_kocache_path)
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --bare \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
+		--tags $(IMAGE_TAG) --tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		chainguard.dev/apko
 
 .PHONY: ko-apply


### PR DESCRIPTION
previously, sboms generated by apko canary would just identify the tool version as "canary" which various SBOM scoring tools penalized

Signed-off-by: Ariadne Conill <ariadne@chainguard.dev>