### PR TITLE
correctly handle archs

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -121,13 +121,18 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 		bc.Options.SBOMPath = filepath.Dir(dir)
 	}
 
-	if len(archs) == 0 {
-		archs = types.AllArchs
-	}
-	if len(bc.ImageConfiguration.Archs) == 0 {
+	// cases:
+	// - archs set: use those archs
+	// - archs not set, bc.ImageConfiguration.Archs set: use Config archs
+	// - archs not set, bc.ImageConfiguration.Archs not set: use all archs
+	switch {
+	case len(archs) != 0:
 		bc.ImageConfiguration.Archs = archs
+	case len(bc.ImageConfiguration.Archs) != 0:
+		// do nothing
+	default:
+		bc.ImageConfiguration.Archs = types.AllArchs
 	}
-
 	// save the final set we will build
 	archs = bc.ImageConfiguration.Archs
 	bc.Logger().Infof(

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -134,11 +134,17 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		return err
 	}
 
-	if len(archs) == 0 {
-		archs = types.AllArchs
-	}
-	if len(bc.ImageConfiguration.Archs) == 0 {
+	// cases:
+	// - archs set: use those archs
+	// - archs not set, bc.ImageConfiguration.Archs set: use Config archs
+	// - archs not set, bc.ImageConfiguration.Archs not set: use all archs
+	switch {
+	case len(archs) != 0:
 		bc.ImageConfiguration.Archs = archs
+	case len(bc.ImageConfiguration.Archs) != 0:
+		// do nothing
+	default:
+		bc.ImageConfiguration.Archs = types.AllArchs
 	}
 	// save the final set we will build
 	archs = bc.ImageConfiguration.Archs


### PR DESCRIPTION
The `apko publish` and `apko build` logic for reconciling requested archs vs config archs was off. It was ignoring the CLI flags sometimes. This reconciles them.