### PR TITLE
use highest version of package when found by provided files

### DIFF
--- a/pkg/apk/impl/version.go
+++ b/pkg/apk/impl/version.go
@@ -345,17 +345,20 @@ func getBestVersion(versions []string, version string, compare versionDependency
 	if len(passed) == 1 {
 		return passed[0]
 	}
+	SortVersions(passed)
+	return passed[0]
+}
 
-	sort.Slice(passed, func(i, j int) bool {
-		actualVersion, err := parseVersion(passed[i])
+func SortVersions(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		actualVersion, err := parseVersion(versions[i])
 		if err != nil {
 			return false
 		}
-		requiredVersion, err := parseVersion(passed[j])
+		requiredVersion, err := parseVersion(versions[j])
 		if err != nil {
 			return false
 		}
 		return compareVersions(actualVersion, requiredVersion) == greater
 	})
-	return passed[0]
 }


### PR DESCRIPTION
Before, when a dependency was found not by package name, but by a provided file, we just took whichever version was first. That was inconsistent, and not the right answer anyways.

This consistently does the following:

1. If the package declaring the dependency also provides the dependency, do nothing, as we satisfy it ourselves.
2. If any of the packages providing the dependency are of the same origin `o:` as the package requesting the dependency, restrict our selection set to just those packages with a matching origin; else look in all packages providing the dependency
3. Of the packages remaining that provide the dependency (matching origin or, if none, then all), take the highest version (highest as defined by the package logic)

