### PR TITLE
when versions equal, sort by name

### DIFF
--- a/pkg/apk/impl/repo.go
+++ b/pkg/apk/impl/repo.go
@@ -502,6 +502,11 @@ func sortPackages(pkgs []*repository.RepositoryPackage, compare *repository.Repo
 		if err != nil {
 			return false
 		}
-		return compareVersions(iVersion, jVersion) == greater
+		versions := compareVersions(iVersion, jVersion)
+		if versions != equal {
+			return versions == greater
+		}
+		// if versions are equal, compare names
+		return pkgs[i].Name < pkgs[j].Name
 	})
 }

--- a/pkg/apk/impl/repo_test.go
+++ b/pkg/apk/impl/repo_test.go
@@ -241,6 +241,11 @@ func TestSortPackages(t *testing.T) {
 			{&repository.Package{Name: "package1", Version: "2.0.1"}, "http://a.b.com", 0},
 			{&repository.Package{Name: "package1", Version: "1.2.0"}, "http://a.b.com", 1},
 		}, nil, nil},
+		{"just names", []repoPkgBase{
+			{&repository.Package{Name: "package1", Version: "1.0.0"}, "http://a.b.com", 1},
+			{&repository.Package{Name: "package2", Version: "1.0.0"}, "http://a.b.com", 2},
+			{&repository.Package{Name: "earlier", Version: "1.0.0"}, "http://a.b.com", 0},
+		}, nil, nil},
 		{"just origins", []repoPkgBase{
 			{&repository.Package{Name: "package1", Version: "1.0.0", Origin: "c"}, "http://a.b.com", 2},
 			{&repository.Package{Name: "package1", Version: "2.0.1", Origin: "b"}, "http://a.b.com", 1},


### PR DESCRIPTION
After repository, origin, existing, and version are equal, we now also sort by package name lexicographically. 