### PR TITLE
option to show-packages

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -32,6 +32,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(buildMinirootFS())
 	cmd.AddCommand(showConfig())
 	cmd.AddCommand(publish())
+	cmd.AddCommand(showPackages())
 	cmd.AddCommand(version.Version())
 	return cmd
 }

--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -1,0 +1,134 @@
+// Copyright 2022, 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+func showPackages() *cobra.Command {
+	var extraKeys []string
+	var extraRepos []string
+	var archstrs []string
+
+	cmd := &cobra.Command{
+		Use:   "show-packages",
+		Short: "Show the packages and versions that would be installed by a configuration",
+		Long: `Show the packages and versions that would be installed by a configuration.
+The result is similar to the first stages of a build, but does not actuall install anything.
+`,
+		Example: `  apko show-packages <config.yaml>`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			archs := types.ParseArchitectures(archstrs)
+			return ShowPackagesCmd(cmd.Context(), archs,
+				build.WithConfig(args[0]),
+				build.WithExtraKeys(extraKeys),
+				build.WithExtraRepos(extraRepos),
+			)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
+	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
+
+	return cmd
+}
+
+func ShowPackagesCmd(ctx context.Context, archs []types.Architecture, opts ...build.Option) error {
+	wd, err := os.MkdirTemp("", "apko-*")
+	if err != nil {
+		return fmt.Errorf("failed to create working directory: %w", err)
+	}
+	defer os.RemoveAll(wd)
+
+	bc, err := build.New(wd, opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := bc.Refresh(); err != nil {
+		return err
+	}
+
+	// cases:
+	// - archs set: use those archs
+	// - archs not set, bc.ImageConfiguration.Archs set: use Config archs
+	// - archs not set, bc.ImageConfiguration.Archs not set: use all archs
+	switch {
+	case len(archs) != 0:
+		bc.ImageConfiguration.Archs = archs
+	case len(bc.ImageConfiguration.Archs) != 0:
+		// do nothing
+	default:
+		bc.ImageConfiguration.Archs = types.AllArchs
+	}
+	// save the final set we will build
+	archs = bc.ImageConfiguration.Archs
+	bc.Logger().Infof(
+		"Determining packages for %d architectures: %+v",
+		len(bc.ImageConfiguration.Archs),
+		bc.ImageConfiguration.Archs,
+	)
+
+	// The build context options is sometimes copied in the next functions. Ensure
+	// we have the directory defined and created by invoking the function early.
+	bc.Options.TempDir()
+	defer os.RemoveAll(bc.Options.TempDir())
+
+	workDir := bc.Options.WorkDir
+
+	for _, arch := range archs {
+		arch := arch
+		// working directory for this architecture
+		wd := filepath.Join(workDir, arch.ToAPK())
+		bc, err := build.New(wd, opts...)
+		if err != nil {
+			return err
+		}
+
+		// we do not generate SBOMs for each arch, only possibly for final image
+		bc.Options.SBOMFormats = []string{}
+		bc.Options.WantSBOM = false
+		bc.ImageConfiguration.Archs = archs
+
+		bc.Options.Arch = arch
+		bc.Options.WorkDir = wd
+
+		if err := bc.Refresh(); err != nil {
+			return fmt.Errorf("failed to update build context for %q: %w", arch, err)
+		}
+
+		pkgs, _, err := bc.BuildPackageList()
+		if err != nil {
+			return fmt.Errorf("failed to get package list for image: %w", err)
+		}
+		fmt.Println(arch)
+		for _, pkg := range pkgs {
+			fmt.Printf("  %s %s\n", pkg.Name, pkg.Version)
+		}
+		fmt.Println()
+	}
+	return nil
+}

--- a/pkg/apk/apk_implementation.go
+++ b/pkg/apk/apk_implementation.go
@@ -18,6 +18,8 @@ import (
 	"archive/tar"
 	"time"
 
+	"gitlab.alpinelinux.org/alpine/go/repository"
+
 	apkimpl "chainguard.dev/apko/pkg/apk/impl"
 )
 
@@ -37,6 +39,9 @@ type apkImplementation interface {
 	GetWorld() ([]string, error)
 	// FixateWorld use the world file to set the state of the system, including any dependencies.
 	FixateWorld(cache, updateCache, executeScripts bool, sourceDateEpoch *time.Time) error
+	// ResolveWorld use the world file to determine the target state of the system, including any dependencies.
+	// Does not install or remove any packages.
+	ResolveWorld() (toInstall []*repository.RepositoryPackage, conflicts []string, err error)
 	// SetRepositories sets the repositories to use. Replaces any existing ones.
 	SetRepositories(repos []string) error
 	// GetRepositories gets the list of repositories in use.

--- a/pkg/apk/apkfakes/fake_apk_implementation.go
+++ b/pkg/apk/apkfakes/fake_apk_implementation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"chainguard.dev/apko/pkg/apk/impl"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
 type FakeApkImplementation struct {
@@ -92,6 +93,20 @@ type FakeApkImplementation struct {
 	}
 	listInitFilesReturnsOnCall map[int]struct {
 		result1 []tar.Header
+	}
+	ResolveWorldStub        func() ([]*repository.RepositoryPackage, []string, error)
+	resolveWorldMutex       sync.RWMutex
+	resolveWorldArgsForCall []struct {
+	}
+	resolveWorldReturns struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}
+	resolveWorldReturnsOnCall map[int]struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
 	}
 	SetRepositoriesStub        func([]string) error
 	setRepositoriesMutex       sync.RWMutex
@@ -537,6 +552,65 @@ func (fake *FakeApkImplementation) ListInitFilesReturnsOnCall(i int, result1 []t
 	}{result1}
 }
 
+func (fake *FakeApkImplementation) ResolveWorld() ([]*repository.RepositoryPackage, []string, error) {
+	fake.resolveWorldMutex.Lock()
+	ret, specificReturn := fake.resolveWorldReturnsOnCall[len(fake.resolveWorldArgsForCall)]
+	fake.resolveWorldArgsForCall = append(fake.resolveWorldArgsForCall, struct {
+	}{})
+	stub := fake.ResolveWorldStub
+	fakeReturns := fake.resolveWorldReturns
+	fake.recordInvocation("ResolveWorld", []interface{}{})
+	fake.resolveWorldMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeApkImplementation) ResolveWorldCallCount() int {
+	fake.resolveWorldMutex.RLock()
+	defer fake.resolveWorldMutex.RUnlock()
+	return len(fake.resolveWorldArgsForCall)
+}
+
+func (fake *FakeApkImplementation) ResolveWorldCalls(stub func() ([]*repository.RepositoryPackage, []string, error)) {
+	fake.resolveWorldMutex.Lock()
+	defer fake.resolveWorldMutex.Unlock()
+	fake.ResolveWorldStub = stub
+}
+
+func (fake *FakeApkImplementation) ResolveWorldReturns(result1 []*repository.RepositoryPackage, result2 []string, result3 error) {
+	fake.resolveWorldMutex.Lock()
+	defer fake.resolveWorldMutex.Unlock()
+	fake.ResolveWorldStub = nil
+	fake.resolveWorldReturns = struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeApkImplementation) ResolveWorldReturnsOnCall(i int, result1 []*repository.RepositoryPackage, result2 []string, result3 error) {
+	fake.resolveWorldMutex.Lock()
+	defer fake.resolveWorldMutex.Unlock()
+	fake.ResolveWorldStub = nil
+	if fake.resolveWorldReturnsOnCall == nil {
+		fake.resolveWorldReturnsOnCall = make(map[int]struct {
+			result1 []*repository.RepositoryPackage
+			result2 []string
+			result3 error
+		})
+	}
+	fake.resolveWorldReturnsOnCall[i] = struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeApkImplementation) SetRepositories(arg1 []string) error {
 	var arg1Copy []string
 	if arg1 != nil {
@@ -686,6 +760,8 @@ func (fake *FakeApkImplementation) Invocations() map[string][][]interface{} {
 	defer fake.initKeyringMutex.RUnlock()
 	fake.listInitFilesMutex.RLock()
 	defer fake.listInitFilesMutex.RUnlock()
+	fake.resolveWorldMutex.RLock()
+	defer fake.resolveWorldMutex.RUnlock()
 	fake.setRepositoriesMutex.RLock()
 	defer fake.setRepositoriesMutex.RUnlock()
 	fake.setWorldMutex.RLock()

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sirupsen/logrus"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/build/types"
@@ -87,6 +88,11 @@ func (bc *Context) BuildImage() (fs.FS, error) {
 		return nil, err
 	}
 	return bc.fs, nil
+}
+
+func (bc *Context) BuildPackageList() (toInstall []*repository.RepositoryPackage, conflicts []string, err error) {
+	// TODO(puerco): Point to final interface (see comment on buildImage fn)
+	return buildPackageList(bc.fs, bc.impl, &bc.Options, &bc.ImageConfiguration)
 }
 
 func (bc *Context) Logger() *logrus.Entry {

--- a/pkg/build/buildfakes/fake_build_implementation.go
+++ b/pkg/build/buildfakes/fake_build_implementation.go
@@ -12,6 +12,7 @@ import (
 	"chainguard.dev/apko/pkg/s6"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/v2/pkg/oci"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
 type FakeBuildImplementation struct {
@@ -155,6 +156,19 @@ type FakeBuildImplementation struct {
 	installLdconfigLinksReturnsOnCall map[int]struct {
 		result1 error
 	}
+	InstallPackagesStub        func(fs.FullFS, *options.Options, *types.ImageConfiguration) error
+	installPackagesMutex       sync.RWMutex
+	installPackagesArgsForCall []struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+		arg3 *types.ImageConfiguration
+	}
+	installPackagesReturns struct {
+		result1 error
+	}
+	installPackagesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	MutateAccountsStub        func(fs.FullFS, *options.Options, *types.ImageConfiguration) error
 	mutateAccountsMutex       sync.RWMutex
 	mutateAccountsArgsForCall []struct {
@@ -194,6 +208,23 @@ type FakeBuildImplementation struct {
 	refreshReturnsOnCall map[int]struct {
 		result1 *s6.Context
 		result2 *exec.Executor
+		result3 error
+	}
+	ResolvePackagesStub        func(fs.FullFS, *options.Options, *types.ImageConfiguration) ([]*repository.RepositoryPackage, []string, error)
+	resolvePackagesMutex       sync.RWMutex
+	resolvePackagesArgsForCall []struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+		arg3 *types.ImageConfiguration
+	}
+	resolvePackagesReturns struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}
+	resolvePackagesReturnsOnCall map[int]struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
 		result3 error
 	}
 	ValidateImageConfigurationStub        func(*types.ImageConfiguration) error
@@ -915,6 +946,69 @@ func (fake *FakeBuildImplementation) InstallLdconfigLinksReturnsOnCall(i int, re
 	}{result1}
 }
 
+func (fake *FakeBuildImplementation) InstallPackages(arg1 fs.FullFS, arg2 *options.Options, arg3 *types.ImageConfiguration) error {
+	fake.installPackagesMutex.Lock()
+	ret, specificReturn := fake.installPackagesReturnsOnCall[len(fake.installPackagesArgsForCall)]
+	fake.installPackagesArgsForCall = append(fake.installPackagesArgsForCall, struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+		arg3 *types.ImageConfiguration
+	}{arg1, arg2, arg3})
+	stub := fake.InstallPackagesStub
+	fakeReturns := fake.installPackagesReturns
+	fake.recordInvocation("InstallPackages", []interface{}{arg1, arg2, arg3})
+	fake.installPackagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuildImplementation) InstallPackagesCallCount() int {
+	fake.installPackagesMutex.RLock()
+	defer fake.installPackagesMutex.RUnlock()
+	return len(fake.installPackagesArgsForCall)
+}
+
+func (fake *FakeBuildImplementation) InstallPackagesCalls(stub func(fs.FullFS, *options.Options, *types.ImageConfiguration) error) {
+	fake.installPackagesMutex.Lock()
+	defer fake.installPackagesMutex.Unlock()
+	fake.InstallPackagesStub = stub
+}
+
+func (fake *FakeBuildImplementation) InstallPackagesArgsForCall(i int) (fs.FullFS, *options.Options, *types.ImageConfiguration) {
+	fake.installPackagesMutex.RLock()
+	defer fake.installPackagesMutex.RUnlock()
+	argsForCall := fake.installPackagesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBuildImplementation) InstallPackagesReturns(result1 error) {
+	fake.installPackagesMutex.Lock()
+	defer fake.installPackagesMutex.Unlock()
+	fake.InstallPackagesStub = nil
+	fake.installPackagesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBuildImplementation) InstallPackagesReturnsOnCall(i int, result1 error) {
+	fake.installPackagesMutex.Lock()
+	defer fake.installPackagesMutex.Unlock()
+	fake.InstallPackagesStub = nil
+	if fake.installPackagesReturnsOnCall == nil {
+		fake.installPackagesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.installPackagesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeBuildImplementation) MutateAccounts(arg1 fs.FullFS, arg2 *options.Options, arg3 *types.ImageConfiguration) error {
 	fake.mutateAccountsMutex.Lock()
 	ret, specificReturn := fake.mutateAccountsReturnsOnCall[len(fake.mutateAccountsArgsForCall)]
@@ -1108,6 +1202,75 @@ func (fake *FakeBuildImplementation) RefreshReturnsOnCall(i int, result1 *s6.Con
 	}{result1, result2, result3}
 }
 
+func (fake *FakeBuildImplementation) ResolvePackages(arg1 fs.FullFS, arg2 *options.Options, arg3 *types.ImageConfiguration) ([]*repository.RepositoryPackage, []string, error) {
+	fake.resolvePackagesMutex.Lock()
+	ret, specificReturn := fake.resolvePackagesReturnsOnCall[len(fake.resolvePackagesArgsForCall)]
+	fake.resolvePackagesArgsForCall = append(fake.resolvePackagesArgsForCall, struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+		arg3 *types.ImageConfiguration
+	}{arg1, arg2, arg3})
+	stub := fake.ResolvePackagesStub
+	fakeReturns := fake.resolvePackagesReturns
+	fake.recordInvocation("ResolvePackages", []interface{}{arg1, arg2, arg3})
+	fake.resolvePackagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeBuildImplementation) ResolvePackagesCallCount() int {
+	fake.resolvePackagesMutex.RLock()
+	defer fake.resolvePackagesMutex.RUnlock()
+	return len(fake.resolvePackagesArgsForCall)
+}
+
+func (fake *FakeBuildImplementation) ResolvePackagesCalls(stub func(fs.FullFS, *options.Options, *types.ImageConfiguration) ([]*repository.RepositoryPackage, []string, error)) {
+	fake.resolvePackagesMutex.Lock()
+	defer fake.resolvePackagesMutex.Unlock()
+	fake.ResolvePackagesStub = stub
+}
+
+func (fake *FakeBuildImplementation) ResolvePackagesArgsForCall(i int) (fs.FullFS, *options.Options, *types.ImageConfiguration) {
+	fake.resolvePackagesMutex.RLock()
+	defer fake.resolvePackagesMutex.RUnlock()
+	argsForCall := fake.resolvePackagesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBuildImplementation) ResolvePackagesReturns(result1 []*repository.RepositoryPackage, result2 []string, result3 error) {
+	fake.resolvePackagesMutex.Lock()
+	defer fake.resolvePackagesMutex.Unlock()
+	fake.ResolvePackagesStub = nil
+	fake.resolvePackagesReturns = struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeBuildImplementation) ResolvePackagesReturnsOnCall(i int, result1 []*repository.RepositoryPackage, result2 []string, result3 error) {
+	fake.resolvePackagesMutex.Lock()
+	defer fake.resolvePackagesMutex.Unlock()
+	fake.ResolvePackagesStub = nil
+	if fake.resolvePackagesReturnsOnCall == nil {
+		fake.resolvePackagesReturnsOnCall = make(map[int]struct {
+			result1 []*repository.RepositoryPackage
+			result2 []string
+			result3 error
+		})
+	}
+	fake.resolvePackagesReturnsOnCall[i] = struct {
+		result1 []*repository.RepositoryPackage
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeBuildImplementation) ValidateImageConfiguration(arg1 *types.ImageConfiguration) error {
 	fake.validateImageConfigurationMutex.Lock()
 	ret, specificReturn := fake.validateImageConfigurationReturnsOnCall[len(fake.validateImageConfigurationArgsForCall)]
@@ -1256,12 +1419,16 @@ func (fake *FakeBuildImplementation) Invocations() map[string][][]interface{} {
 	defer fake.installCharDevicesMutex.RUnlock()
 	fake.installLdconfigLinksMutex.RLock()
 	defer fake.installLdconfigLinksMutex.RUnlock()
+	fake.installPackagesMutex.RLock()
+	defer fake.installPackagesMutex.RUnlock()
 	fake.mutateAccountsMutex.RLock()
 	defer fake.mutateAccountsMutex.RUnlock()
 	fake.mutatePathsMutex.RLock()
 	defer fake.mutatePathsMutex.RUnlock()
 	fake.refreshMutex.RLock()
 	defer fake.refreshMutex.RUnlock()
+	fake.resolvePackagesMutex.RLock()
+	defer fake.resolvePackagesMutex.RUnlock()
 	fake.validateImageConfigurationMutex.RLock()
 	defer fake.validateImageConfigurationMutex.RUnlock()
 	fake.writeSupervisionTreeMutex.RLock()


### PR DESCRIPTION
```
apko show-packages ./file.yaml
```

Shows all of the dependencies for whichever archs are chosen. Allows to check dependency trees and packages without a full rebuild. Much faster than having to do a `build`, as it only needs to download the indexes, not all of the packages.

Also separates some calls out into their own parts to make it doable.

E.g.

```
$ apko show-packages --arch amd64,arm64 ../../chainguard-images/images/images/ko/configs/latest.apko.yaml
Feb 22 12:18:04.971 [INFO] loading config file: ../../chainguard-images/images/images/ko/configs/latest.apko.yaml
Feb 22 12:18:04.972 [INFO] [arch:aarch64] Determining packages for 2 architectures: [amd64 arm64]
Feb 22 12:18:04.972 [INFO] loading config file: ../../chainguard-images/images/images/ko/configs/latest.apko.yaml
Feb 22 12:18:04.972 [WARNING] [arch:x86_64] "amd64" requires QEMU binfmt emulation to be configured (not compatible with "arm64")
Feb 22 12:18:04.972 [INFO] [arch:x86_64] doing pre-flight checks
Feb 22 12:18:04.972 [INFO] [arch:x86_64] building apk info in /var/folders/7k/011x7ywd3ss305ntyxldy6mc0000gn/T/apko-4113652589/x86_64
Feb 22 12:18:04.973 [INFO] [arch:x86_64] initializing apk database
Feb 22 12:18:05.386 [INFO] [arch:x86_64] finished initializing apk database
Feb 22 12:18:05.386 [INFO] [arch:x86_64] setting apk world
Feb 22 12:18:05.386 [INFO] [arch:x86_64] initializing apk keyring
Feb 22 12:18:05.386 [INFO] [arch:x86_64] setting apk repositories
Feb 22 12:18:05.748 [INFO] [arch:x86_64] determining desired apk world
Feb 22 12:18:06.196 [INFO] [arch:x86_64] finished gathering apk info in /var/folders/7k/011x7ywd3ss305ntyxldy6mc0000gn/T/apko-4113652589/x86_64
amd64
  glibc-locale-posix 2.37-r0
  wolfi-baselayout 20230201-r0
  glibc 2.37-r0
  libgcc 12.2.0-r9
  libstdc++ 12.2.0-r9
  binutils 2.40-r2
  libstdc++-dev 12.2.0-r9
  gmp 6.2.1-r6
  isl 0.24-r5
  mpfr 4.2.0-r2
  mpc 1.2.1-r4
  zlib 1.2.13-r3
  gcc 12.2.0-r9
  linux-headers 5.19.17-r2
  glibc-dev 2.37-r0
  make 4.3-r3
  pkgconf 1.9.4-r2
  build-base 1-r5
  busybox 1.36.0-r0
  ncurses-terminfo-base 6.4-r2
  ncurses 6.4-r2
  bash 5.2.15-r2
  binutils-gold 2.40-r2
  go-1.20 1.20.0-r1
  ko 0.12.0-r0

Feb 22 12:18:06.197 [INFO] loading config file: ../../chainguard-images/images/images/ko/configs/latest.apko.yaml
Feb 22 12:18:06.197 [INFO] [arch:aarch64] doing pre-flight checks
Feb 22 12:18:06.197 [INFO] [arch:aarch64] building apk info in /var/folders/7k/011x7ywd3ss305ntyxldy6mc0000gn/T/apko-4113652589/aarch64
Feb 22 12:18:06.197 [INFO] [arch:aarch64] initializing apk database
Feb 22 12:18:06.428 [INFO] [arch:aarch64] finished initializing apk database
Feb 22 12:18:06.428 [INFO] [arch:aarch64] setting apk world
Feb 22 12:18:06.428 [INFO] [arch:aarch64] initializing apk keyring
Feb 22 12:18:06.428 [INFO] [arch:aarch64] setting apk repositories
Feb 22 12:18:06.626 [INFO] [arch:aarch64] determining desired apk world
Feb 22 12:18:06.886 [INFO] [arch:aarch64] finished gathering apk info in /var/folders/7k/011x7ywd3ss305ntyxldy6mc0000gn/T/apko-4113652589/aarch64
arm64
  glibc-locale-posix 2.37-r0
  wolfi-baselayout 20230201-r0
  glibc 2.37-r0
  libgcc 12.2.0-r9
  libstdc++ 12.2.0-r9
  binutils 2.40-r2
  libstdc++-dev 12.2.0-r9
  gmp 6.2.1-r6
  isl 0.24-r5
  mpfr 4.2.0-r2
  mpc 1.2.1-r4
  zlib 1.2.13-r3
  gcc 12.2.0-r9
  linux-headers 5.19.17-r2
  glibc-dev 2.37-r0
  make 4.3-r3
  pkgconf 1.9.4-r2
  build-base 1-r5
  busybox 1.36.0-r0
  ncurses-terminfo-base 6.4-r2
  ncurses 6.4-r2
  bash 5.2.15-r2
  binutils-gold 2.40-r2
  go-1.20 1.20.1-r1
  ko 0.12.0-r0
```

The above took:

```
0.14s user 0.07s system 9% cpu 2.264 total
```