### PR TITLE
Add melange-style build options for apko images

### DIFF
--- a/examples/options.yaml
+++ b/examples/options.yaml
@@ -1,0 +1,21 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - glibc
+    - libgcc
+
+archs:
+- x86_64
+- aarch64
+
+options:
+  debug:
+    contents:
+      packages:
+        add:
+          - busybox

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -43,6 +43,7 @@ func buildCmd() *cobra.Command {
 	var sbomFormats []string
 	var extraKeys []string
 	var extraRepos []string
+	var buildOptions []string
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -79,6 +80,7 @@ bill of materials) describing the image contents.
 				build.WithExtraRepos(extraRepos),
 				build.WithDebugLogging(debugEnabled),
 				build.WithVCS(withVCS),
+				build.WithBuildOptions(buildOptions),
 			)
 		},
 	}
@@ -93,6 +95,7 @@ bill of materials) describing the image contents.
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVar(&buildOptions, "build-option", []string{}, "build options to enable")
 
 	return cmd
 }

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -49,6 +49,7 @@ func publish() *cobra.Command {
 	var archstrs []string
 	var extraKeys []string
 	var extraRepos []string
+	var buildOptions []string
 	var rawAnnotations []string
 	var debugEnabled bool
 	var withVCS bool
@@ -93,6 +94,7 @@ in a keychain.`,
 				build.WithTagSuffix(tagSuffix),
 				build.WithLocal(local),
 				build.WithStageTags(stageTags),
+				build.WithBuildOptions(buildOptions),
 			); err != nil {
 				return err
 			}
@@ -115,6 +117,7 @@ in a keychain.`,
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVar(&buildOptions, "build-option", []string{}, "build options to enable")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().BoolVar(&local, "local", false, "publish image just to local Docker daemon")
 	cmd.Flags().StringVar(&stageTags, "stage-tags", "", "path to file to write list of tags to instead of publishing them")

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -220,3 +220,18 @@ func WithStageTags(stageTags string) Option {
 		return nil
 	}
 }
+
+// WithBuildOptions applies configured patches which have been requested to the ImageConfiguration.
+func WithBuildOptions(buildOptions []string) Option {
+	return func(bc *Context) error {
+		for _, opt := range buildOptions {
+			if bo, ok := bc.ImageConfiguration.Options[opt]; ok {
+				if err := bo.Apply(&bc.ImageConfiguration); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+}

--- a/pkg/build/types/build_option.go
+++ b/pkg/build/types/build_option.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// ListOption describes an optional deviation to a list, for example, a
+// list of packages.
+type ListOption struct {
+	Add    []string `yaml:"add,omitempty"`
+	Remove []string `yaml:"remove,omitempty"`
+}
+
+// ContentsOption describes an optional deviation to an apko environment's
+// contents block.
+type ContentsOption struct {
+	Packages ListOption `yaml:"packages,omitempty"`
+}
+
+// BuildOption describes an optional deviation to an apko environment.
+type BuildOption struct {
+	Contents ContentsOption `yaml:"contents,omitempty"`
+}
+
+// Apply applies a patch described by a BuildOption to an apko environment.
+func (bo BuildOption) Apply(ic *ImageConfiguration) error {
+	lo := bo.Contents.Packages
+	ic.Contents.Packages = append(ic.Contents.Packages, lo.Add...)
+
+	for _, pkg := range lo.Remove {
+		pkgList := ic.Contents.Packages
+
+		for pos, ppkg := range pkgList {
+			if pkg == ppkg {
+				pkgList[pos] = pkgList[len(pkgList)-1]
+				pkgList = pkgList[:len(pkgList)-1]
+			}
+		}
+
+		ic.Contents.Packages = pkgList
+	}
+
+	return nil
+}

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -87,6 +87,8 @@ type ImageConfiguration struct {
 	VCSUrl      string            `yaml:"vcs-url,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Include     string            `yaml:"include,omitempty"`
+
+	Options map[string]BuildOption `yaml:"options,omitempty"`
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
A typical pattern is to use a stripped down base image which does not contain anything more than necessary to support an application.  This is called "distroless" normally.  A configuration to support minimal glibc binaries might look like:

```yaml
contents:
  keyring:
    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
  repositories:
    - https://packages.wolfi.dev/os
  packages:
    - ca-certificates-bundle
    - wolfi-baselayout
    - glibc
    - libgcc
```

However, sometimes, we would like to debug our application, which might require a shell, amongst other tools.  For this purpose, we have `-dev` and `-debug` image variants.  But right now, we are having to maintain a lot of boilerplate YAML for this.

`include` can help a bit, e.g.:

```yaml
include: minimal.yaml

contents:
  packages:
    - busybox
```

But this requires having multiple yaml files on disk still.  What if we could define patches to an image configuration inside the image configuration itself?

This patch does that.  To bring it together based on our previous example, we would simply add an `options` block at the end:

```yaml
options:
  debug:
    contents:
      packages:
        add:
          - busybox
```

And then if we build the image with `--build-option debug`, the image will include the busybox package.