### PR TITLE
include full tags on images

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -238,7 +238,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 	}
 
 	// finally generate the tar.gz file that includes all of the arch images and an index
-	finalDigest, err = oci.BuildIndex(outputTarGZ, bc.ImageConfiguration, imgs, bc.Logger())
+	finalDigest, err = oci.BuildIndex(outputTarGZ, bc.ImageConfiguration, imgs, bc.Options.Tags, bc.Logger())
 	if err != nil {
 		return fmt.Errorf("failed to build index: %w", err)
 	}


### PR DESCRIPTION
Fixes #529 

The multi-arch build we added in #499 synchronized `publish` and `build`, and added support for building any arch.

But it did change the `manifest.json` that is output from `apko build`. That PR left the `RepoTags` as just the arch, so your ended up with:

```json
[
  {
    "Config": "sha256:62e228b24e42fe9a41ffc83ad0c244424844ff5e016d7fc3aef8cba21fb0ea42",
    "RepoTags": [
      "amd64:latest"
    ],
    "Layers": [
      "23b249c599ffedf344a4e6477354208ff76a10ede3ba4237d70c0addb65da953.tar.gz"
    ]
  },
  {
    "Config": "sha256:849180d1f62d1cee300b9d3958609f7c1dab924927da039c63d08c8691067d50",
    "RepoTags": [
      "arm64:latest"
    ],
    "Layers": [
      "7c214dde647610bc0f9569f45515bba51285ca8b681516908a9bca4cc6d1c626.tar.gz"
    ]
  }
]
```

That obviously was not is desired. This fixes it so that it includes the names of the tags, so if I build with:

```
go run .  build chainguard-images/images/images/etcd/configs/latest.apko.yaml cgr.dev/etcd /tmp/output.tar
```

i.e. the tag is `cgr.dev/etcd`, the `manifest.json` looks like:

```json
[
  {
    "Config": "sha256:62e228b24e42fe9a41ffc83ad0c244424844ff5e016d7fc3aef8cba21fb0ea42",
    "RepoTags": [
      "cgr.dev/etcd:latest-amd64"
    ],
    "Layers": [
      "23b249c599ffedf344a4e6477354208ff76a10ede3ba4237d70c0addb65da953.tar.gz"
    ]
  },
  {
    "Config": "sha256:849180d1f62d1cee300b9d3958609f7c1dab924927da039c63d08c8691067d50",
    "RepoTags": [
      "cgr.dev/etcd:latest-arm64"
    ],
    "Layers": [
      "7c214dde647610bc0f9569f45515bba51285ca8b681516908a9bca4cc6d1c626.tar.gz"
    ]
  }

```

Now we are using the provided tags correctly. If multiple tags are provided, they all will be used.