### PR TITLE
add support for pinned repos

### DIFF
--- a/pkg/apk/apk_implementation.go
+++ b/pkg/apk/apk_implementation.go
@@ -44,7 +44,7 @@ type apkImplementation interface {
 	ResolveWorld() (toInstall []*repository.RepositoryPackage, conflicts []string, err error)
 	// SetRepositories sets the repositories to use. Replaces any existing ones.
 	SetRepositories(repos []string) error
-	// GetRepositories gets the list of repositories in use.
+	// GetRepositories gets the list of repositories in use, including pinned ones with their names.
 	GetRepositories() ([]string, error)
 	// GetInstalled gets the list of installed packages.
 	GetInstalled() ([]*apkimpl.InstalledPackage, error)


### PR DESCRIPTION
Fixes #485 
Fixes #540

If `/etc/apk/repositories`, or `repositories` in `apko.yaml`, had pinned repositories, it didn't work:

```
https://foo.org/repos   <-- works
/my/local/dir  <-- works
@pin https://tester.org/repos   <-- FAILS
@local /local/dir   <-- FAILS
```

It wouldn't just ignore it, it would error out.

This PR provides support for:

* reading pinned repositories
* using the pinned repositories for packages

It follows the rules laid out [here](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Repository_pinning), specifically:

```
You can specify additional "tagged" repositories in /etc/apk/repositories:

Contents of /etc/apk/repositories

http://nl.alpinelinux.org/alpine/v3.7/main
http://nl.alpinelinux.org/alpine/v3.7/community
@edge http://nl.alpinelinux.org/alpine/edge/main
@edgecommunity http://nl.alpinelinux.org/alpine/edge/community
@testing http://nl.alpinelinux.org/alpine/edge/testing
After which you can "pin" dependencies to these tags using:

apk add stableapp newapp@edge bleedingapp@testing
Apk will now by default only use the untagged repositories, but adding a tag to specific package:

1. will prefer the repository with that tag for the named package, even if a later version of the package is available in another repository
2. allows pulling in dependencies for the tagged package from the tagged repository (though it prefers to use untagged repositories to satisfy dependencies if possible)
```

