### PR TITLE
add newlines to arch and world

### DIFF
--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -143,7 +143,7 @@ func (a *APKImplementation) ListInitFiles() []tar.Header {
 	// additionalFiles are files we need but can only be resolved in the context of
 	// this func, e.g. we need the architecture
 	additionalFiles := []file{
-		{"/etc/apk/arch", 0o644, []byte(a.arch)},
+		{"/etc/apk/arch", 0o644, []byte(a.arch + "\n")},
 	}
 
 	for _, e := range initDirectories {
@@ -199,7 +199,7 @@ func (a *APKImplementation) InitDB(versions ...string) error {
 	// additionalFiles are files we need but can only be resolved in the context of
 	// this func, e.g. we need the architecture
 	additionalFiles := []file{
-		{"/etc/apk/arch", 0o644, []byte(a.arch)},
+		{"/etc/apk/arch", 0o644, []byte(a.arch + "\n")},
 	}
 
 	for _, e := range baseDirectories {

--- a/pkg/apk/impl/implementation_test.go
+++ b/pkg/apk/impl/implementation_test.go
@@ -96,7 +96,7 @@ func TestSetWorld(t *testing.T) {
 	require.NoError(t, err)
 
 	sort.Strings(packages)
-	expected := strings.Join(packages, "\n")
+	expected := strings.Join(packages, "\n") + "\n"
 	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/world:\nexpected %s\nactual %s", expected, actual)
 }
 

--- a/pkg/apk/impl/repo.go
+++ b/pkg/apk/impl/repo.go
@@ -95,10 +95,12 @@ func (a *APKImplementation) getRepositoryIndexes(ignoreSignatures bool) ([]*name
 	if err != nil {
 		return nil, fmt.Errorf("could not open arch file in %s at %s: %w", a.fs, archFile, err)
 	}
-	arch, err := io.ReadAll(archFile)
+	archB, err := io.ReadAll(archFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read arch file: %w", err)
 	}
+	// trim the newline
+	arch := []byte(strings.TrimSuffix(string(archB), "\n"))
 	for _, repo := range repos {
 		// does it start with a pin?
 		var (

--- a/pkg/apk/impl/repo_test.go
+++ b/pkg/apk/impl/repo_test.go
@@ -31,7 +31,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	require.NoError(t, err, "unable to mkdir /etc/apk")
 	err = src.WriteFile(reposFilePath, []byte("https://dl-cdn.alpinelinux.org/alpine/v3.16/main"), 0644)
 	require.NoErrorf(t, err, "unable to write repositories")
-	err = src.WriteFile(archFilePath, []byte("aarch64"), 0644)
+	err = src.WriteFile(archFilePath, []byte("aarch64\n"), 0644)
 	require.NoErrorf(t, err, "unable to write arch")
 	err = src.MkdirAll(keysDirPath, 0755)
 	require.NoError(t, err, "unable to mkdir /etc/apk/keys")

--- a/pkg/apk/impl/world.go
+++ b/pkg/apk/impl/world.go
@@ -46,7 +46,7 @@ func (a *APKImplementation) SetWorld(packages []string) error {
 	copy(copied, packages)
 	sort.Strings(copied)
 
-	data := strings.Join(copied, "\n")
+	data := strings.Join(copied, "\n") + "\n"
 
 	// #nosec G306 -- apk world must be publicly readable
 	if err := a.fs.WriteFile(filepath.Join("etc", "apk", "world"),


### PR DESCRIPTION
Small change. apk-tools natively add a newline to `etc/apk/arch` and `etc/apk/world`. It doesn't break anything not to have it or to have it, but it makes it easier to compare built packages, so might as well.