### PR TITLE
fix mutateaccounts

### DIFF
--- a/pkg/apk/impl/installed.go
+++ b/pkg/apk/impl/installed.go
@@ -126,7 +126,7 @@ func (a *APKImplementation) updateScriptsTar(pkg *repository.Package, controlTar
 	}
 	// only need to rewind if the file has tar in it
 	if fi.Size() >= 1024 {
-		if _, err = scripts.Seek(-1024, os.SEEK_END); err != nil {
+		if _, err = scripts.Seek(-1024, io.SeekEnd); err != nil {
 			return fmt.Errorf("could not seek to end of tar file: %w", err)
 		}
 	}

--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -96,7 +96,8 @@ func (di *defaultBuildImplementation) MutateAccounts(
 		for _, u := range ic.Accounts.Users {
 			ue := userToUserEntry(u)
 			uf.Entries = append(uf.Entries, ue)
-
+		}
+		for _, ue := range uf.Entries {
 			// This is what the home directory is set to for our homeless users.
 			if ue.HomeDir == "/dev/null" {
 				continue


### PR DESCRIPTION
In switching to native, we broke mutate accounts. It was ensuring home directories only for those explicitly added, not those already in `/etc/passwd`. This fixes it by largely bringing it back in sync with the original.