### PR TITLE
sliced from wrong part of pinned repo name

### DIFF
--- a/pkg/apk/impl/repo.go
+++ b/pkg/apk/impl/repo.go
@@ -113,8 +113,8 @@ func (a *APKImplementation) getRepositoryIndexes(ignoreSignatures bool) ([]*name
 			if len(parts) < 2 {
 				return nil, errors.New("invalid repository line")
 			}
-			repoName = parts[0]
-			repoURL = parts[1][1:]
+			repoName = parts[0][1:]
+			repoURL = parts[1]
 		}
 
 		repoBase := fmt.Sprintf("%s/%s", repoURL, arch)


### PR DESCRIPTION
Fixes #549 

When processing a repo named `@local /foo/bar`, we need to take the reference name of the repo (`local`) and the path to it `/foo/bar`. That means a split (don't correctly), and removing the first char (`@`) of the _name_. We accidentally took it off the _path_. Which broke two things.

This fixes it.