### PR TITLE
Fix installed database

### DIFF
--- a/pkg/apk/impl/const.go
+++ b/pkg/apk/impl/const.go
@@ -27,6 +27,8 @@ const (
 	scriptsFilePath   = "lib/apk/db/scripts.tar"
 	scriptsTarPerms   = 0o644
 	triggersFilePath  = "lib/apk/db/triggers"
+	// which PAX record we use in the tar header
+	paxRecordsChecksumKey = "APK-TOOLS.checksum.SHA1"
 
 	// for fetching the alpine keys
 	alpineReleasesURL = "https://alpinelinux.org/releases.json"

--- a/pkg/apk/impl/installed.go
+++ b/pkg/apk/impl/installed.go
@@ -58,12 +58,6 @@ func (a *APKImplementation) addInstalledPackage(pkg *repository.Package, files [
 
 	// sort the files by directory
 	sort.Slice(files, func(i, j int) bool {
-		if filepath.Dir(files[i].Name) < filepath.Dir(files[j].Name) {
-			return true
-		}
-		if filepath.Dir(files[i].Name) > filepath.Dir(files[j].Name) {
-			return false
-		}
 		return files[i].Name < files[j].Name
 	})
 	// package lines

--- a/pkg/apk/impl/installed.go
+++ b/pkg/apk/impl/installed.go
@@ -78,6 +78,9 @@ func (a *APKImplementation) addInstalledPackage(pkg *repository.Package, files [
 			if perm != 0o644 || user != 0 || group != 0 {
 				pkgLines = append(pkgLines, fmt.Sprintf("a:%d:%d:%04o", user, group, perm))
 			}
+			if f.PAXRecords != nil && f.PAXRecords[paxRecordsChecksumKey] != "" {
+				pkgLines = append(pkgLines, fmt.Sprintf("Z:%s", f.PAXRecords[paxRecordsChecksumKey]))
+			}
 		}
 	}
 	// write to installed file

--- a/pkg/apk/impl/installed.go
+++ b/pkg/apk/impl/installed.go
@@ -84,7 +84,7 @@ func (a *APKImplementation) addInstalledPackage(pkg *repository.Package, files [
 		}
 	}
 	// write to installed file
-	b := []byte("\n\n" + strings.Join(pkgLines, "\n") + "\n\n")
+	b := []byte(strings.Join(pkgLines, "\n") + "\n\n")
 	if _, err := installedFile.Write(b); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #558 

There are two issues.

1. The checksum (in the case of apk, sha1 base64-encoded with a "Q1" header) was not included in the installed file. It now does it. I compared several files to ensure that they are correct and match with apk-tools.
2. It was trying to be too smart in sorting files, which messed up their order, thereby confusing the installation list in the apk installed db. This now is fixed.

While I was at it, I removed unnecessary extra newlines from the installed db. They didn't hurt, but they made it a bit harder to read.