### PR TITLE
get entire mode when opening, not just permission bits

### DIFF
--- a/pkg/apk/impl/install.go
+++ b/pkg/apk/impl/install.go
@@ -27,7 +27,7 @@ import (
 
 // writeOneFile writes one file from the APK given the tar header and tar reader.
 func (a *APKImplementation) writeOneFile(header *tar.Header, r io.Reader) error {
-	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_WRONLY, header.FileInfo().Mode().Perm())
+	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_WRONLY, header.FileInfo().Mode())
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", header.Name, err)
 	}


### PR DESCRIPTION
We were creating the file in the local file system using just the perms, not the entire mode. This uses the whole mode, causing it to include setuid bits, etc.

@kaniini found this (thank you).