### PR TITLE
Preserve suid/sgid/sticky bits in generated tarballs

### DIFF
--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -134,6 +134,12 @@ func (ctx *Context) writeTar(tw *tar.Writer, fsys fs.FS, users, groups map[int]s
 			header.Devmajor = int64(major)
 			header.Devminor = int64(minor)
 		}
+
+		// use mode of actual installed file from workdir
+		// seems like archive/tar header.Mode / header.FileInfo().Mode()
+		// generated modes don't include suid/sgid/sticky bits??
+		header.Mode = int64(info.Mode())
+
 		// work around some weirdness, without this we wind up with just the basename
 		header.Name = path
 


### PR DESCRIPTION
Refs #561 - this PR uses the detected mode attributes for the tar header field from the files that are fed to the `fs.WalkDir` function here: https://github.com/chainguard-dev/apko/blob/cb833a59c509b9ffe54660a0ef9280be331bb142/pkg/tarball/write.go#L82 

For some reason, the modes that `archive/tar` generates don't include the extra suid/sgid/sticky bits, even when the files in the workdir have them set, despite the library attempting to set them e.g. https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/archive/tar/common.go;l=560-591.

I tried removing the various `.Perms()` invocations in a few places like `pkg/apk/impl/install.go` and `pkg/apk/fs/rwosfs.go` since that function uses a logical `&fs.ModePerm` to only return user/group/other bits. But I couldn't manage to preserve permissions from unpacking to the final tarball.

Everything looks ok when I check the contents of a tarball, including device files, symlinks, directory permissions, and the bits I'm after. e.g.:

```
/work # ./apko build --arch aarch64 apko.yaml test test.tar -k melange.rsa.pub
. . .
Mar  9 19:09:29.490 [INFO] [arch:aarch64] OCI layer digest: sha256:9d712ac6744c86029c385485ddbd165e878ce763f6fa9be649cc2cb73ac40461
Mar  9 19:09:29.490 [INFO] [arch:aarch64] OCI layer diffID: sha256:fba9ce57517e492fbcd4dcb08f358d88ec5fd1fa444caa0a98fb13f2aaed2e29
. . .
Mar  9 19:09:29.528 [INFO] [arch:aarch64] Final index tgz at: test.tar

/work # tar xvf test.tar
sha256:f8dd0a1f6b7a7612bec32473d8c317f6c52efc0dc0a79bb97499b8e66ec86b15
9d712ac6744c86029c385485ddbd165e878ce763f6fa9be649cc2cb73ac40461.tar.gz
manifest.json
sha256:cc2a85a839cdf8fb3e3d7d1316a68445882e499d607f0edc646bb66b997945f0
index.json

/work # tar tvf 9d712ac6744c86029c385485ddbd165e878ce763f6fa9be649cc2cb73ac40461.tar.gz
drwxr-xr-x bin/bin         0 1970-01-01 00:00:00 bin
drwxr-xr-x root/root         0 1970-01-01 00:00:00 dev
crw--w---- root/root         0 1970-01-01 00:00:00 dev/console
crw-rw-rw- root/root         0 1970-01-01 00:00:00 dev/null
. . .
lrwxrwxrwx root/root         0 1970-01-01 00:00:00 lib/libc.musl-aarch64.so.1 -> ld-musl-aarch64.so.1
lrwxrwxrwx root/root         0 1970-01-01 00:00:00 lib/libz.so.1 -> libz.so.1.2.13
. . .
drwx--x--x root/root         0 1970-01-01 00:00:00 run/sudo
. . .
-rwsr-xr-x root/root    203336 1970-01-01 00:00:00 usr/bin/sudo
```

That said, I'm not sure how to test this properly, or if there's a better way to record these bits in the tarball.