### PR TITLE
handle symlink dir correctly for installed db

### DIFF
--- a/pkg/apk/impl/install.go
+++ b/pkg/apk/impl/install.go
@@ -80,7 +80,8 @@ func (a *APKImplementation) installAPKFiles(gzipIn io.Reader) ([]tar.Header, err
 			if fi, err := a.fs.Stat(header.Name); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 				if target, symlink, err := a.fs.Readlink(header.Name); err == nil && symlink {
 					if fi, err = a.fs.Stat(target); err == nil && fi.IsDir() {
-						continue
+						// "break" rather than "continue", so that any handling outside of this switch statement is processed
+						break
 					}
 				}
 			}


### PR DESCRIPTION
We correctly handled the `lib64` directory symlink, but did `continue`, rather than `break`, so we missed adding it back to the list of headers, which are used later to process the apk installed db.

Also added a comment to describe it.