### PR TITLE
Permissions fixes

### DIFF
--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -73,16 +73,6 @@ type Option func(*APK) error
 // and does everything short of installing the packages.
 func (a *APK) Initialize(ic *types.ImageConfiguration) error {
 	// initialize apk
-	// first set up required directories (tmp has different permissions)
-	if err := a.fs.MkdirAll("/tmp", 0o777|fs.ModeSticky); err != nil {
-		return err
-	}
-	baseDirs := []string{"/proc", "/dev", "/var", "/lib", "/etc"}
-	for _, d := range baseDirs {
-		if err := a.fs.MkdirAll(d, 0o755); err != nil {
-			return err
-		}
-	}
 	alpineVersions := parseOptionsFromRepositories(ic.Contents.Repositories)
 	if err := a.impl.InitDB(alpineVersions...); err != nil {
 		return fmt.Errorf("failed to initialize apk database: %w", err)

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -74,7 +74,7 @@ type Option func(*APK) error
 func (a *APK) Initialize(ic *types.ImageConfiguration) error {
 	// initialize apk
 	// first set up required directories (tmp has different permissions)
-	if err := a.fs.MkdirAll("/tmp", 0o777); err != nil {
+	if err := a.fs.MkdirAll("/tmp", 0o777|fs.ModeSticky); err != nil {
 		return err
 	}
 	baseDirs := []string{"/proc", "/dev", "/var", "/lib", "/etc"}

--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -81,7 +81,7 @@ type deviceFile struct {
 }
 
 var baseDirectories = []directory{
-	{"/tmp", 0o777},
+	{"/tmp", 0o777 | fs.ModeSticky},
 	{"/dev", 0o755},
 	{"/etc", 0o755},
 	{"/lib", 0o755},

--- a/pkg/apk/impl/implementation_test.go
+++ b/pkg/apk/impl/implementation_test.go
@@ -45,13 +45,6 @@ func TestInitDB(t *testing.T) {
 	src := apkfs.NewMemFS()
 	apk, err := NewAPKImplementation(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
-	err = src.MkdirAll("/tmp", 0o777|fs.ModeSticky)
-	require.NoError(t, err, "error creating %s", "/tmp")
-	baseDirs := []string{"/tmp", "/proc", "/dev", "/var", "/lib", "/etc"}
-	for _, d := range baseDirs {
-		err := src.MkdirAll(d, 0o755)
-		require.NoError(t, err, "error creating %s", d)
-	}
 	err = apk.InitDB()
 	require.NoError(t, err)
 	// check all of the contents

--- a/pkg/apk/impl/implementation_test.go
+++ b/pkg/apk/impl/implementation_test.go
@@ -45,7 +45,7 @@ func TestInitDB(t *testing.T) {
 	src := apkfs.NewMemFS()
 	apk, err := NewAPKImplementation(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
-	err = src.MkdirAll("/tmp", 0o777)
+	err = src.MkdirAll("/tmp", 0o777|fs.ModeSticky)
 	require.NoError(t, err, "error creating %s", "/tmp")
 	baseDirs := []string{"/tmp", "/proc", "/dev", "/var", "/lib", "/etc"}
 	for _, d := range baseDirs {

--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -119,7 +119,7 @@ func (di *defaultBuildImplementation) MutateAccounts(
 			} else if !os.IsNotExist(err) {
 				return fmt.Errorf("checking homedir exists: %w", err)
 			}
-			if err := fsys.MkdirAll(targetHomedir, 0755); err != nil {
+			if err := fsys.MkdirAll(targetHomedir, 0700); err != nil {
 				return fmt.Errorf("creating homedir: %w", err)
 			}
 			if err := fsys.Chown(targetHomedir, int(ue.UID), int(ue.GID)); err != nil {


### PR DESCRIPTION
The commits in here fix several permissions mistakes around directories (homedirs, tmp sticky bit, /proc, etc.) They also unify what was in multiple places, and handle errors in perms of existing directories and setting them up better.