### PR TITLE
build: accounts: go back to using 0o755 permissions for the homedir

### DIFF
--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -119,7 +119,7 @@ func (di *defaultBuildImplementation) MutateAccounts(
 			} else if !os.IsNotExist(err) {
 				return fmt.Errorf("checking homedir exists: %w", err)
 			}
-			if err := fsys.MkdirAll(targetHomedir, 0700); err != nil {
+			if err := fsys.MkdirAll(targetHomedir, 0o755); err != nil {
 				return fmt.Errorf("creating homedir: %w", err)
 			}
 			if err := fsys.Chown(targetHomedir, int(ue.UID), int(ue.GID)); err != nil {


### PR DESCRIPTION
this causes problems with melange, probably due to /home being 0o700 and owned by root

this probably also causes problems with our production images