### PR TITLE
Potential fix for SBOMs missing file data

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -38,6 +38,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom"
 	soptions "chainguard.dev/apko/pkg/sbom/options"
 	"chainguard.dev/apko/pkg/tarball"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 //counterfeiter:generate . buildImplementation
@@ -339,7 +340,8 @@ func buildPackageList(
 }
 
 func newSBOM(fsys apkfs.FullFS, o *options.Options, ic *types.ImageConfiguration) *sbom.SBOM {
-	s := sbom.NewWithFS(fsys, o.Arch)
+	basefs, _ := vfs.DirFS(o.WorkDir)
+	s := sbom.NewWithFS(basefs, fsys, o.Arch)
 	// Parse the image reference
 	if len(o.Tags) > 0 {
 		tag, err := name.NewTag(o.Tags[0])

--- a/pkg/sbom/generator/cyclonedx/cyclonedx.go
+++ b/pkg/sbom/generator/cyclonedx/cyclonedx.go
@@ -22,15 +22,15 @@ import (
 
 	purl "github.com/package-url/packageurl-go"
 
-	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/sbom/options"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 type CycloneDX struct {
-	fs apkfs.FullFS
+	fs vfs.BaseFS
 }
 
-func New(fs apkfs.FullFS) CycloneDX {
+func New(fs vfs.BaseFS) CycloneDX {
 	return CycloneDX{fs}
 }
 

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -22,6 +22,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/idb"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/apko/pkg/sbom/options"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 //counterfeiter:generate . Generator
@@ -33,13 +34,13 @@ type Generator interface {
 	GenerateIndex(*options.Options, string) error
 }
 
-func Generators(fsys apkfs.FullFS) map[string]Generator {
+func Generators(basefs vfs.BaseFS, fsys apkfs.FullFS) map[string]Generator {
 	generators := map[string]Generator{}
 
-	sx := spdx.New(fsys)
+	sx := spdx.New(basefs)
 	generators[sx.Key()] = &sx
 
-	cdx := cyclonedx.New(fsys)
+	cdx := cyclonedx.New(basefs)
 	generators[cdx.Key()] = &cdx
 
 	idb := idb.New(fsys)

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -29,8 +29,8 @@ import (
 
 	purl "github.com/package-url/packageurl-go"
 
-	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/sbom/options"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 // https://spdx.github.io/spdx-spec/3-package-information/#32-package-spdx-identifier
@@ -44,10 +44,10 @@ const (
 )
 
 type SPDX struct {
-	fs apkfs.FullFS
+	fs vfs.BaseFS
 }
 
-func New(fs apkfs.FullFS) SPDX {
+func New(fs vfs.BaseFS) SPDX {
 	return SPDX{fs}
 }
 
@@ -189,7 +189,7 @@ func replacePackage(doc *Document, originalID, newID string) {
 }
 
 // locateApkSBOM returns the SBOM
-func locateApkSBOM(fsys apkfs.FullFS, p *Package) (string, error) {
+func locateApkSBOM(fsys vfs.BaseFS, p *Package) (string, error) {
 	re := regexp.MustCompile(`-r\d+$`)
 	for _, s := range []string{
 		fmt.Sprintf("%s/%s-%s.spdx.json", apkSBOMdir, p.Name, p.Version),

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -26,8 +26,8 @@ import (
 	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
 	"sigs.k8s.io/release-utils/command"
 
-	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/sbom/options"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 var testOpts = &options.Options{
@@ -60,10 +60,11 @@ var testOpts = &options.Options{
 
 func TestGenerate(t *testing.T) {
 	dir := t.TempDir()
-	fsys := apkfs.NewMemFS()
+	fsys, err := vfs.DirFS(dir)
+	require.NoError(t, err)
 	sx := New(fsys)
 	path := filepath.Join(dir, testOpts.FileName+"."+sx.Ext())
-	err := sx.Generate(testOpts, path)
+	err = sx.Generate(testOpts, path)
 	require.NoError(t, err)
 	require.FileExists(t, path)
 }
@@ -72,7 +73,8 @@ func TestReproducible(t *testing.T) {
 	// Create two sboms based on the same input and ensure
 	// they are identical
 	dir := t.TempDir()
-	fsys := apkfs.NewMemFS()
+	fsys, err := vfs.DirFS(dir)
+	require.NoError(t, err)
 	sx := New(fsys)
 	d := [][]byte{}
 	for i := 0; i < 2; i++ {
@@ -97,10 +99,11 @@ func TestValidateSPDX(t *testing.T) {
 		return
 	}
 	dir := t.TempDir()
-	fsys := apkfs.NewMemFS()
+	fsys, err := vfs.DirFS(dir)
+	require.NoError(t, err)
 	sx := New(fsys)
 	path := filepath.Join(dir, testOpts.FileName+"."+sx.Ext())
-	err := sx.Generate(testOpts, path)
+	err = sx.Generate(testOpts, path)
 	require.NoError(t, err)
 	require.FileExists(t, path)
 	require.NoError(t, command.New(

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -30,6 +30,7 @@ import (
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/sbom/generator"
 	"chainguard.dev/apko/pkg/sbom/options"
+	"chainguard.dev/apko/pkg/vfs"
 )
 
 var (
@@ -56,17 +57,17 @@ type SBOM struct {
 	Options    options.Options
 }
 
-func New(fs apkfs.FullFS) *SBOM {
+func New(basefs vfs.BaseFS, fs apkfs.FullFS) *SBOM {
 	return &SBOM{
-		Generators: generator.Generators(fs),
+		Generators: generator.Generators(basefs, fs),
 		impl:       &defaultSBOMImplementation{},
 		Options:    DefaultOptions,
 	}
 }
 
-// NewWithWorkDir returns a new sbom object with a working dir preset
-func NewWithFS(fs apkfs.FullFS, a types.Architecture) *SBOM {
-	s := New(fs)
+// NewWithFS returns a new sbom object with fs.
+func NewWithFS(basefs vfs.BaseFS, fs apkfs.FullFS, a types.Architecture) *SBOM {
+	s := New(basefs, fs)
 	s.Options.FS = fs
 	s.Options.FileName = fmt.Sprintf("sbom-%s", a.ToAPK())
 	return s


### PR DESCRIPTION
Resolves #584 

@deitch - tagging you here since you did a bunch with the filesystem stuff recently. Basically the issue is that the `apkfs.FullFS` is completely empty at the time of SBOM generation. So as a workaround, I've created a temporary `vfs.BaseFS` based on the workdir, and pass that around all over the place. I'm guessing there is another way.

This does appear to fix the issue as reported. I've published a copy of the chainguard maven image with these changes to `ghcr.io/jdolitsky/maven-test:apko-584`:

```
$ cosign download sbom --platform linux/arm64 ghcr.io/jdolitsky/maven-test:apko-584 | jq 'keys | contains(["files"])'
...
true
```