### PR TITLE
When build and publish, carry buildcontext to sbom generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,3 +31,11 @@ jobs:
         run: |
           make snapshot
           ./dist/apko-build_linux_amd64_v1/apko version
+
+      # Required in SBOM quality test below
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Check SBOM quality
+        run: |
+          ./hack/sbom-quality.sh

--- a/hack/sbom-quality.sh
+++ b/hack/sbom-quality.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ ! -f apko ]]; then
+    echo "Please first run \"make apko\". Exiting."
+    exit 1
+fi
+
+SBOM_FILENAME="sbom.json"
+APKO_CONFIG="sbom-quality-test.yaml"
+REGISTRY_BASE_IMAGE="index.docker.io/library/registry:2.8.1"
+REGISTRY_CONTAINER_NAME="apko-sbom-quality-test"
+REF="localhost:5000/sbom-quality:test"
+
+trap "rm -f \"${SBOM_FILENAME}\" && \
+rm -f \"${APKO_CONFIG}\" &&
+docker rm -f \"${REGISTRY_CONTAINER_NAME}\"" EXIT
+
+docker rm -f "${REGISTRY_CONTAINER_NAME}"
+docker run --name "${REGISTRY_CONTAINER_NAME}" -d -p 5000:5000 "${REGISTRY_BASE_IMAGE}"
+
+cat > "${APKO_CONFIG}" << EOF
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - maven
+archs:
+  - x86_64
+  - aarch64
+EOF
+
+# Publish image to registry
+./apko publish --debug "${APKO_CONFIG}" "${REF}"
+
+# Download the SBOM
+cosign download sbom --platform=linux/amd64 "${REF}" | tee "${SBOM_FILENAME}"
+
+# Test #1: Check that SBOMs contains files derived from
+# package SBOMs melange produces in /var/lib/db/sbom
+HAS_FILES="$(cat "${SBOM_FILENAME}" | jq 'keys | contains(["files"])')"
+if [[ "${HAS_FILES}" != "true" ]]; then
+  echo "SBOM does not have files. Exiting."
+  exit 1
+fi

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -154,6 +154,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 	var errg errgroup.Group
 	workDir := bc.Options.WorkDir
 	imgs := map[types.Architecture]coci.SignedImage{}
+	contexts := map[types.Architecture]*build.Context{}
 	imageTars := map[types.Architecture]string{}
 
 	// This is a hack to skip the SBOM generation during
@@ -184,6 +185,9 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 		bc.Options.SBOMFormats = []string{}
 		bc.Options.WantSBOM = false
 		bc.ImageConfiguration.Archs = archs
+
+		// save the build context for later
+		contexts[arch] = bc
 
 		errg.Go(func() error {
 			bc.Options.Arch = arch
@@ -218,17 +222,11 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 	if wantSBOM {
 		logrus.Info("Generating arch image SBOMs")
 		for arch, img := range imgs {
-			// working directory for this architecture
-			wd := filepath.Join(workDir, arch.ToAPK())
-			bc, err := build.New(wd, opts...)
-			if err != nil {
-				return err
-			}
-			bc.Options.WantSBOM = true
-			bc.Options.Arch = arch
-			bc.Options.TarballPath = imageTars[arch]
-			bc.Options.WorkDir = wd
+			bc := contexts[arch]
+
+			// override the SBOM options
 			bc.Options.SBOMFormats = formats
+			bc.Options.WantSBOM = true
 			bc.Options.SBOMPath = sbomPath
 
 			if err := bc.GenerateImageSBOM(arch, img); err != nil {


### PR DESCRIPTION
Fixes #584 

We were creating a new `BuildContext` for the SBoM generation, rather than reusing the one from the build stage. That meant a new `fsys`, which lost all of the information about the existing one.

This carries it through, enabling us to get all of the information.

This could use a cleaner review, as I am _fairly_ confident I understood the issue in #584 and that this fixes it, but not 100% sure.