### PR TITLE
Introduce common logging policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module chainguard.dev/apko
 go 1.19
 
 require (
-	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220920003936-cd2dbcbbab49
 	github.com/blang/vfs v1.0.0
@@ -27,6 +26,7 @@ require (
 	golang.org/x/build v0.0.0-20220928220451-9294235e16f5
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.7.0
+	golang.org/x/term v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/release-utils v0.7.3
 )
@@ -121,7 +121,6 @@ require (
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UMEoHck02Q9L0FP13b/xSbQ=
-github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/pkg/apk/impl/implementation.go
+++ b/pkg/apk/impl/implementation.go
@@ -545,7 +545,7 @@ func (a *APKImplementation) fetchAlpineKeys(versions []string) error {
 //
 //nolint:unparam // we do not use some params... yet.
 func (a *APKImplementation) installPackage(pkg *repository.RepositoryPackage, cache, updateCache, executeScripts bool, sourceDateEpoch *time.Time) error {
-	a.logger.Infof("installing %s (%s)", pkg.Name, pkg.Version)
+	a.logger.Debugf("installing %s (%s)", pkg.Name, pkg.Version)
 
 	u := pkg.Url()
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,107 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"io"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
+)
+
+const (
+	reset   = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 34
+	magenta = 35
+	cyan    = 36
+	gray    = 37
+)
+
+// A Formatter is a formatter that can be set on a logrus object to
+// apply our formatting policies.
+type Formatter struct {
+	logrus.Formatter
+}
+
+func isTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return term.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
+func color(w io.Writer, color int) string {
+	if !isTerminal(w) {
+		return ""
+	}
+
+	return fmt.Sprintf("\x1b[%dm", color)
+}
+
+func levelToColor(entry *logrus.Entry) int {
+	switch entry.Level {
+	case logrus.PanicLevel, logrus.FatalLevel:
+		return red
+	case logrus.ErrorLevel:
+		return magenta
+	case logrus.WarnLevel:
+		return yellow
+	case logrus.InfoLevel:
+		return cyan
+	default:
+		return gray
+	}
+}
+
+func levelEmoji(entry *logrus.Entry) string {
+	switch entry.Level {
+	case logrus.PanicLevel, logrus.FatalLevel:
+		return "🛑 "
+	case logrus.ErrorLevel:
+		return "❌ "
+	case logrus.WarnLevel:
+		return "⚠️ "
+	case logrus.InfoLevel:
+		return "ℹ️ "
+	default:
+		return "❕ "
+	}
+}
+
+// Format formats a logrus entry according to our formatting policies.
+func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
+	b := &bytes.Buffer{}
+	out := entry.Logger.Out
+	message := strings.TrimSuffix(entry.Message, "\n")
+
+	if arch, ok := entry.Data["arch"]; ok {
+		fmt.Fprintf(b, "%s %s%-10s|%s %s", levelEmoji(entry), color(out, levelToColor(entry)), arch, color(out, reset), message)
+	} else {
+		fmt.Fprintf(b, "%s %s%-10s|%s %s", levelEmoji(entry), color(out, levelToColor(entry)), "", color(out, reset), message)
+	}
+
+	b.WriteByte('\n')
+
+	return b.Bytes(), nil
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -16,8 +16,8 @@ package log
 
 import (
 	"bytes"
-	"io"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -20,10 +20,10 @@ import (
 	"runtime"
 	"time"
 
-	nested "github.com/antonfisher/nested-logrus-formatter"
 	"github.com/sirupsen/logrus"
 
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/log"
 )
 
 type Options struct {
@@ -52,9 +52,7 @@ type Options struct {
 var Default = Options{
 	Log: &logrus.Logger{
 		Out: os.Stderr,
-		Formatter: &nested.Formatter{
-			ShowFullLevel: true,
-		},
+		Formatter: &log.Formatter{},
 		Hooks: make(logrus.LevelHooks),
 		Level: logrus.InfoLevel,
 	},

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -51,10 +51,10 @@ type Options struct {
 
 var Default = Options{
 	Log: &logrus.Logger{
-		Out: os.Stderr,
+		Out:       os.Stderr,
 		Formatter: &log.Formatter{},
-		Hooks: make(logrus.LevelHooks),
-		Level: logrus.InfoLevel,
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.InfoLevel,
 	},
 	Arch: types.ParseArchitecture(runtime.GOARCH),
 }


### PR DESCRIPTION
Instead of using an external log formatter, provide our own formatting policy which is suitable both for apko and melange.  This will be consumed by melange when the logging is converted to logrus.