### PR TITLE
Use abstract logger type throughout apko core

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -26,13 +26,13 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/oci"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/log"
 	"chainguard.dev/apko/pkg/sbom"
 )
 
@@ -295,7 +295,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	}
 
 	if wantSBOM {
-		logrus.Info("Generating arch image SBOMs")
+		log.NewLogger().Infof("Generating arch image SBOMs")
 		for arch, img := range imgs {
 			bc := contexts[arch]
 
@@ -371,12 +371,12 @@ func publishIndex(bc *build.Context, imgs map[types.Architecture]coci.SignedImag
 ) {
 	shouldPushTags := bc.Options.StageTags == ""
 	if bc.Options.UseDockerMediaTypes {
-		indexDigest, idx, err = oci.PublishDockerIndex(bc.ImageConfiguration, imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Local, shouldPushTags, bc.Options.Tags...)
+		indexDigest, idx, err = oci.PublishDockerIndex(bc.ImageConfiguration, imgs, bc.Options.Log, bc.Options.Local, shouldPushTags, bc.Options.Tags...)
 		if err != nil {
 			return name.Digest{}, nil, fmt.Errorf("failed to build Docker index: %w", err)
 		}
 	} else {
-		indexDigest, idx, err = oci.PublishIndex(bc.ImageConfiguration, imgs, logrus.NewEntry(bc.Options.Log), bc.Options.Local, shouldPushTags, bc.Options.Tags...)
+		indexDigest, idx, err = oci.PublishIndex(bc.ImageConfiguration, imgs, bc.Options.Log, bc.Options.Local, shouldPushTags, bc.Options.Tags...)
 		if err != nil {
 			return name.Digest{}, nil, fmt.Errorf("failed to build OCI index: %w", err)
 		}

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -144,7 +144,7 @@ func AdditionalTags(fsys fs.FS, opts options.Options) ([]string, error) {
 		}
 		version := pkg.Version
 		if version == "" {
-			opts.Log.Warningf("Version for package %s is empty", pkg.Name)
+			opts.Log.Warnf("Version for package %s is empty", pkg.Name)
 			continue
 		}
 		if opts.TagSuffix != "" {

--- a/pkg/apk/apk_test.go
+++ b/pkg/apk/apk_test.go
@@ -16,17 +16,18 @@ package apk
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"chainguard.dev/apko/pkg/apk/apkfakes"
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/log"
 	"chainguard.dev/apko/pkg/options"
 )
 
@@ -201,7 +202,7 @@ A:bop
 				PackageVersionTagPrefix: test.packageVersionTagPrefix,
 				Tags:                    test.tags,
 				WorkDir:                 td,
-				Log:                     &logrus.Logger{},
+				Log:                     &log.Adapter{Out: io.Discard},
 			}
 			fsys := apkfs.DirFS(td)
 			got, err := AdditionalTags(fsys, opts)

--- a/pkg/apk/impl/options.go
+++ b/pkg/apk/impl/options.go
@@ -18,9 +18,8 @@ import (
 	"io"
 	"runtime"
 
-	"github.com/sirupsen/logrus"
-
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
+	"chainguard.dev/apko/pkg/log"
 )
 
 type opts struct {
@@ -85,8 +84,7 @@ func WithFS(fs apkfs.FullFS) Option {
 
 func defaultOpts() *opts {
 	fs := apkfs.DirFS("/")
-	discardLogger := logrus.New()
-	discardLogger.Out = io.Discard
+	discardLogger := &log.Adapter{Out: io.Discard}
 	logger := discardLogger
 
 	return &opts{

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -27,12 +27,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/hashicorp/go-multierror"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
-	"github.com/sirupsen/logrus"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/exec"
+	"chainguard.dev/apko/pkg/log"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/s6"
 )
@@ -95,7 +95,7 @@ func (bc *Context) BuildPackageList() (toInstall []*repository.RepositoryPackage
 	return buildPackageList(bc.fs, bc.impl, &bc.Options, &bc.ImageConfiguration)
 }
 
-func (bc *Context) Logger() *logrus.Entry {
+func (bc *Context) Logger() log.Logger {
 	return bc.Options.Logger()
 }
 
@@ -138,7 +138,7 @@ func (bc *Context) ImageLayoutToLayer() (string, error) {
 			return "", fmt.Errorf("generating SBOMs: %w", err)
 		}
 	} else {
-		bc.Logger().Debug("Not generating SBOMs (WantSBOM = false)")
+		bc.Logger().Debugf("Not generating SBOMs (WantSBOM = false)")
 	}
 
 	return layerTarGZ, nil

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -18,9 +18,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/log"
 )
 
 // Option is an option for the build context.
@@ -175,7 +174,7 @@ func WithDockerMediatypes(useDockerMediaTypes bool) Option {
 func WithDebugLogging(enable bool) Option {
 	return func(bc *Context) error {
 		if enable {
-			bc.Options.Log.SetLevel(logrus.DebugLevel)
+			bc.Options.Log.SetLevel(log.DebugLevel)
 		}
 		return nil
 	}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -19,15 +19,15 @@ import (
 	"os"
 
 	"github.com/jinzhu/copier"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
 	"chainguard.dev/apko/pkg/fetch"
+	"chainguard.dev/apko/pkg/log"
 	"chainguard.dev/apko/pkg/vcs"
 )
 
 // Attempt to probe an upstream VCS URL if known.
-func (ic *ImageConfiguration) ProbeVCSUrl(imageConfigPath string, logger *logrus.Entry) {
+func (ic *ImageConfiguration) ProbeVCSUrl(imageConfigPath string, logger log.Logger) {
 	url, err := vcs.ProbeDirFromPath(imageConfigPath)
 	if err != nil {
 		logger.Debugf("failed to probe VCS URL: %v", err)
@@ -41,7 +41,7 @@ func (ic *ImageConfiguration) ProbeVCSUrl(imageConfigPath string, logger *logrus
 }
 
 // Parse a configuration blob into an ImageConfiguration struct.
-func (ic *ImageConfiguration) parse(configData []byte, logger *logrus.Entry) error {
+func (ic *ImageConfiguration) parse(configData []byte, logger log.Logger) error {
 	if err := yaml.Unmarshal(configData, ic); err != nil {
 		return fmt.Errorf("failed to parse image configuration: %w", err)
 	}
@@ -90,7 +90,7 @@ func (ic *ImageConfiguration) parse(configData []byte, logger *logrus.Entry) err
 }
 
 // Loads an image configuration given a configuration file path.
-func (ic *ImageConfiguration) Load(imageConfigPath string, logger *logrus.Entry) error {
+func (ic *ImageConfiguration) Load(imageConfigPath string, logger log.Logger) error {
 	data, err := os.ReadFile(imageConfigPath)
 	if err == nil {
 		return ic.parse(data, logger)
@@ -167,7 +167,7 @@ func (ic *ImageConfiguration) ValidateServiceBundle() error {
 	return nil
 }
 
-func (ic *ImageConfiguration) Summarize(logger *logrus.Entry) {
+func (ic *ImageConfiguration) Summarize(logger log.Logger) {
 	logger.Printf("image configuration:")
 	logger.Printf("  contents:")
 	logger.Printf("    repositories: %v", ic.Contents.Repositories)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -20,19 +20,19 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/sirupsen/logrus"
+	"chainguard.dev/apko/pkg/log"
 )
 
 type Executor struct {
 	impl    executorImplementation
 	WorkDir string
 	UseQemu string
-	Log     *logrus.Entry
+	Log     log.Logger
 }
 
 type Option func(*Executor) error
 
-func New(workDir string, logger *logrus.Entry, opts ...Option) (*Executor, error) {
+func New(workDir string, logger log.Logger, opts ...Option) (*Executor, error) {
 	e := &Executor{
 		impl:    &defaultBuildImplementation{},
 		WorkDir: workDir,
@@ -44,7 +44,7 @@ func New(workDir string, logger *logrus.Entry, opts ...Option) (*Executor, error
 		}
 	}
 
-	e.Log = logger.WithFields(logrus.Fields{"use-qemu": e.UseQemu})
+	e.Log = logger.WithFields(log.Fields{"use-qemu": e.UseQemu})
 
 	return e, nil
 }

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -16,16 +16,16 @@ package exec_test
 
 import (
 	"fmt"
+	"io"
 	"testing"
-
-	"github.com/sirupsen/logrus"
 
 	"chainguard.dev/apko/pkg/exec"
 	"chainguard.dev/apko/pkg/exec/execfakes"
+	"chainguard.dev/apko/pkg/log"
 )
 
-func testLogger() *logrus.Entry {
-	return logrus.NewEntry(&logrus.Logger{})
+func testLogger() log.Logger {
+	return &log.Adapter{Out: io.Discard}
 }
 
 func TestExecute(t *testing.T) {

--- a/pkg/exec/exec_unit_test.go
+++ b/pkg/exec/exec_unit_test.go
@@ -16,14 +16,16 @@ package exec
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/log"
 )
 
-func testLogger() *logrus.Entry {
-	return logrus.NewEntry(&logrus.Logger{})
+func testLogger() log.Logger {
+	return &log.Adapter{Out: io.Discard}
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/exec/execfakes/fake_executor_implementation.go
+++ b/pkg/exec/execfakes/fake_executor_implementation.go
@@ -5,16 +5,16 @@ import (
 	execa "os/exec"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"chainguard.dev/apko/pkg/log"
 )
 
 type FakeExecutorImplementation struct {
-	RunStub        func(*execa.Cmd, string, *logrus.Entry) error
+	RunStub        func(*execa.Cmd, string, log.Logger) error
 	runMutex       sync.RWMutex
 	runArgsForCall []struct {
 		arg1 *execa.Cmd
 		arg2 string
-		arg3 *logrus.Entry
+		arg3 log.Logger
 	}
 	runReturns struct {
 		result1 error
@@ -26,13 +26,13 @@ type FakeExecutorImplementation struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeExecutorImplementation) Run(arg1 *execa.Cmd, arg2 string, arg3 *logrus.Entry) error {
+func (fake *FakeExecutorImplementation) Run(arg1 *execa.Cmd, arg2 string, arg3 log.Logger) error {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 *execa.Cmd
 		arg2 string
-		arg3 *logrus.Entry
+		arg3 log.Logger
 	}{arg1, arg2, arg3})
 	stub := fake.RunStub
 	fakeReturns := fake.runReturns
@@ -53,13 +53,13 @@ func (fake *FakeExecutorImplementation) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakeExecutorImplementation) RunCalls(stub func(*execa.Cmd, string, *logrus.Entry) error) {
+func (fake *FakeExecutorImplementation) RunCalls(stub func(*execa.Cmd, string, log.Logger) error) {
 	fake.runMutex.Lock()
 	defer fake.runMutex.Unlock()
 	fake.RunStub = stub
 }
 
-func (fake *FakeExecutorImplementation) RunArgsForCall(i int) (*execa.Cmd, string, *logrus.Entry) {
+func (fake *FakeExecutorImplementation) RunArgsForCall(i int) (*execa.Cmd, string, log.Logger) {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
 	argsForCall := fake.runArgsForCall[i]

--- a/pkg/exec/implementation.go
+++ b/pkg/exec/implementation.go
@@ -19,17 +19,17 @@ import (
 	"io"
 	"os/exec"
 
-	"github.com/sirupsen/logrus"
+	"chainguard.dev/apko/pkg/log"
 )
 
 //counterfeiter:generate . executorImplementation
 type executorImplementation interface {
-	Run(cmd *exec.Cmd, logname string, logger *logrus.Entry) error
+	Run(cmd *exec.Cmd, logname string, logger log.Logger) error
 }
 
 type defaultBuildImplementation struct{}
 
-func monitorPipe(p io.ReadCloser, logger *logrus.Entry, finish chan struct{}) {
+func monitorPipe(p io.ReadCloser, logger log.Logger, finish chan struct{}) {
 	defer p.Close()
 
 	scanner := bufio.NewScanner(p)
@@ -42,9 +42,9 @@ func monitorPipe(p io.ReadCloser, logger *logrus.Entry, finish chan struct{}) {
 
 // Run
 func (di *defaultBuildImplementation) Run(
-	cmd *exec.Cmd, logname string, baseLogger *logrus.Entry,
+	cmd *exec.Cmd, logname string, baseLogger log.Logger,
 ) error {
-	logger := baseLogger.WithFields(logrus.Fields{"cmd": logname})
+	logger := baseLogger.WithFields(log.Fields{"cmd": logname})
 	logger.Infof("running: %s", cmd)
 
 	stdout, err := cmd.StdoutPipe()

--- a/pkg/exec/implementation_test.go
+++ b/pkg/exec/implementation_test.go
@@ -18,14 +18,12 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {
 	impl := defaultBuildImplementation{}
 	testCommand := "ls"
-	l := logrus.NewEntry(&logrus.Logger{})
 	for _, tc := range []struct {
 		cmd       *exec.Cmd
 		shouldErr bool
@@ -48,7 +46,7 @@ func TestRun(t *testing.T) {
 		if _, err := exec.LookPath(testCommand); err != nil {
 			t.Skipf("skipping Run test as %s executable not found", testCommand)
 		}
-		err := impl.Run(tc.cmd, "test", l)
+		err := impl.Run(tc.cmd, "test", testLogger())
 		if tc.shouldErr {
 			require.Error(t, err, tc.cmd.String())
 		}

--- a/pkg/log/adapter.go
+++ b/pkg/log/adapter.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Adapter struct {
+	Out    io.Writer
+	Fields Fields
+	Level  Level
+}
+
+var concreteLogger = &logrus.Logger{
+	Out:       os.Stderr,
+	Formatter: &Formatter{},
+	Hooks:     make(logrus.LevelHooks),
+	Level:     logrus.InfoLevel,
+}
+
+func (a *Adapter) logf(level logrus.Level, format string, args ...interface{}) {
+	e := concreteLogger.WithFields(logrus.Fields(a.Fields))
+	e.Logger.SetLevel(logrus.Level(a.Level))
+	e.Logger.Out = a.Out
+	e.Logf(level, format, args...)
+}
+
+func (a *Adapter) exit(exitCode int) {
+	cl := concreteLogger
+	cl.Exit(exitCode)
+}
+
+func (a *Adapter) Debugf(fmt string, args ...interface{}) {
+	a.logf(logrus.DebugLevel, fmt, args...)
+}
+
+func (a *Adapter) Fatalf(fmt string, args ...interface{}) {
+	a.logf(logrus.FatalLevel, fmt, args...)
+	a.exit(1)
+}
+
+func (a *Adapter) Infof(fmt string, args ...interface{}) {
+	a.logf(logrus.InfoLevel, fmt, args...)
+}
+
+func (a *Adapter) Printf(fmt string, args ...interface{}) {
+	a.logf(logrus.InfoLevel, fmt, args...)
+}
+
+func (a *Adapter) Warnf(fmt string, args ...interface{}) {
+	a.logf(logrus.WarnLevel, fmt, args...)
+}
+
+func (a *Adapter) Errorf(fmt string, args ...interface{}) {
+	a.logf(logrus.ErrorLevel, fmt, args...)
+}
+
+func (a *Adapter) SetLevel(level Level) {
+	a.Level = level
+}
+
+func (a *Adapter) WithFields(fields Fields) Logger {
+	out := *a
+	out.Fields = fields
+	return &out
+}
+
+func NewLogger() Logger {
+	return &Adapter{Out: os.Stderr}
+}

--- a/pkg/log/type.go
+++ b/pkg/log/type.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type Fields map[string]interface{}
+
+type Level uint32
+
+const (
+	DebugLevel = Level(logrus.DebugLevel)
+	ErrorLevel = Level(logrus.ErrorLevel)
+	InfoLevel  = Level(logrus.InfoLevel)
+	WarnLevel  = Level(logrus.WarnLevel)
+	FatalLevel = Level(logrus.FatalLevel)
+)
+
+type Logger interface {
+	Fatalf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Infof(string, ...interface{})
+	Printf(string, ...interface{})
+	Warnf(string, ...interface{})
+	Debugf(string, ...interface{})
+	SetLevel(level Level)
+	WithFields(fields Fields) Logger
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/log"
 )
@@ -39,7 +37,7 @@ type Options struct {
 	ExtraKeyFiles           []string
 	ExtraRepos              []string
 	Arch                    types.Architecture
-	Log                     *logrus.Logger
+	Log                     log.Logger
 	TempDirPath             string
 	PackageVersionTag       string
 	PackageVersionTagStem   bool
@@ -50,16 +48,11 @@ type Options struct {
 }
 
 var Default = Options{
-	Log: &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: &log.Formatter{},
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.InfoLevel,
-	},
+	Log:  &log.Adapter{Out: os.Stderr, Level: log.InfoLevel},
 	Arch: types.ParseArchitecture(runtime.GOARCH),
 }
 
-func (o *Options) Summarize(logger *logrus.Entry) {
+func (o *Options) Summarize(logger log.Logger) {
 	logger.Printf("  working directory: %s", o.WorkDir)
 	logger.Printf("  tarball path: %s", o.TarballPath)
 	logger.Printf("  source date: %s", o.SourceDateEpoch)
@@ -68,8 +61,8 @@ func (o *Options) Summarize(logger *logrus.Entry) {
 	logger.Printf("  arch: %v", o.Arch.ToAPK())
 }
 
-func (o *Options) Logger() *logrus.Entry {
-	fields := logrus.Fields{}
+func (o *Options) Logger() log.Logger {
+	fields := log.Fields{}
 	emptyArch := types.Architecture{}
 
 	if o.Arch != emptyArch {

--- a/pkg/s6/s6.go
+++ b/pkg/s6/s6.go
@@ -15,19 +15,18 @@
 package s6
 
 import (
-	"github.com/sirupsen/logrus"
-
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
+	"chainguard.dev/apko/pkg/log"
 )
 
 type Services map[interface{}]interface{}
 
 type Context struct {
 	fs  apkfs.FullFS
-	Log *logrus.Entry
+	Log log.Logger
 }
 
-func New(fs apkfs.FullFS, logger *logrus.Entry) *Context {
+func New(fs apkfs.FullFS, logger log.Logger) *Context {
 	return &Context{
 		fs:  fs,
 		Log: logger,


### PR DESCRIPTION
Instead of using `logrus` directly, make use of `log.Logger`, and extend it to be suitable for use everywhere.

Add a `log.Adapter` implementation which wraps the logrus-specific details.