### PR TITLE
Provide abstract logger implementation to apko build context

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -295,7 +295,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	}
 
 	if wantSBOM {
-		log.NewLogger().Infof("Generating arch image SBOMs")
+		log.DefaultLogger().Infof("Generating arch image SBOMs")
 		for arch, img := range imgs {
 			bc := contexts[arch]
 

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -212,7 +212,7 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 }
 
 func Copy(src, dst string) error {
-	log.NewLogger().Infof("Copying %s to %s", src, dst)
+	log.DefaultLogger().Infof("Copying %s to %s", src, dst)
 	if err := crane.Copy(src, dst, crane.WithAuthFromKeychain(keychain)); err != nil {
 		return fmt.Errorf("tagging %s with tag %s: %w", src, dst, err)
 	}
@@ -248,7 +248,7 @@ func attachSBOM(
 	// Attach the SBOM, e.g.
 	// TODO(kaniini): Allow all SBOM types to be uploaded.
 	if len(sbomFormats) == 0 {
-		log.NewLogger().Debugf("Not building sboms, no formats requested")
+		log.DefaultLogger().Debugf("Not building sboms, no formats requested")
 		return si, nil
 	}
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -170,6 +170,14 @@ func WithDockerMediatypes(useDockerMediaTypes bool) Option {
 	}
 }
 
+// WithLogger sets the log.Logger implementation to be used by the build context.
+func WithLogger(logger log.Logger) Option {
+	return func(bc *Context) error {
+		bc.Options.Log = logger
+		return nil
+	}
+}
+
 // WithDebugLogging sets the debug log level for the build context.
 func WithDebugLogging(enable bool) Option {
 	return func(bc *Context) error {

--- a/pkg/log/adapter.go
+++ b/pkg/log/adapter.go
@@ -82,7 +82,7 @@ func (a *Adapter) WithFields(fields Fields) Logger {
 }
 
 func NewLogger(out io.Writer) Logger {
-	return &Adapter{Out: out}
+	return &Adapter{Out: out, Level: InfoLevel}
 }
 
 func DefaultLogger() Logger {

--- a/pkg/log/adapter.go
+++ b/pkg/log/adapter.go
@@ -81,6 +81,10 @@ func (a *Adapter) WithFields(fields Fields) Logger {
 	return &out
 }
 
-func NewLogger() Logger {
-	return &Adapter{Out: os.Stderr}
+func NewLogger(out io.Writer) Logger {
+	return &Adapter{Out: out}
+}
+
+func DefaultLogger() Logger {
+	return NewLogger(os.Stderr)
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -16,6 +16,7 @@ package options
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"time"
@@ -48,7 +49,7 @@ type Options struct {
 }
 
 var Default = Options{
-	Log:  &log.Adapter{Out: os.Stderr, Level: log.InfoLevel},
+	Log:  &log.Adapter{Out: io.Discard, Level: log.InfoLevel},
 	Arch: types.ParseArchitecture(runtime.GOARCH),
 }
 


### PR DESCRIPTION
Instead of generating a logger implementation while constructing the build context, accept a pre-existing logger implementation.