### PR TITLE
add support for tilde matcher

### DIFF
--- a/pkg/apk/impl/version.go
+++ b/pkg/apk/impl/version.go
@@ -305,7 +305,7 @@ func includesVersion(actual, required packageVersion) bool {
 		return false
 	}
 
-	// was there post-suffi
+	// was there post-suffix
 	if required.postSuffix != packageVersionPostModifierNone && actual.postSuffix != required.postSuffix {
 		return false
 	}

--- a/pkg/apk/impl/version_test.go
+++ b/pkg/apk/impl/version_test.go
@@ -116,6 +116,10 @@ func TestResolveVersion(t *testing.T) {
 		{"2.1.0", versionEqual, "", "", "equal match but pinned"},
 		{"2.1.0", versionEqual, "pinA", "2.1.0", "equal match and pin match"},
 		{"", versionNone, "", "2.0.6-r0", "no requirement should get highest version"},
+		{"1.6", versionTilde, "", "", "no match"},
+		{"1.7", versionTilde, "", "1.7.1-r1", "fits within"},
+		{"1.7.1", versionTilde, "", "1.7.1-r1", "fits within"},
+		{"1.7.1-r2", versionTilde, "", "", "no match"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -131,7 +135,7 @@ func TestResolveVersion(t *testing.T) {
 	}
 }
 
-func TestResolverPackageNameVersionPing(t *testing.T) {
+func TestResolverPackageNameVersionPin(t *testing.T) {
 	tests := []struct {
 		input   string
 		name    string


### PR DESCRIPTION
If a package requirement is `foo~1.2`, we do not handle it correctly. This now adds support for it. Also adds a few unit tests.

Stage 1 of fixing #627 ; follow-on coming later.