### PR TITLE
add optional support for self-package resolution

### DIFF
--- a/examples/alpine-python3.yaml
+++ b/examples/alpine-python3.yaml
@@ -1,0 +1,12 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - alpine-base
+    - python3
+
+cmd: /bin/sh -l
+
+# optional environment configuration
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/pkg/apk/impl/version.go
+++ b/pkg/apk/impl/version.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	versionRegex     = regexp.MustCompile(`^([0-9]+)((\.[0-9]+)*)([a-z]?)((_alpha|_beta|_pre|_rc)([0-9]*))?((_cvs|_svn|_git|_hg|_p)([0-9]*))?((-r)([0-9]+))?$`)
-	packageNameRegex = regexp.MustCompile(`^([^@=><~]+)(([=><]+)([^@]+))?(@([a-zA-Z0-9]+))?$`)
+	packageNameRegex = regexp.MustCompile(`^([^@=><~]+)(([=><~]+)([^@]+))?(@([a-zA-Z0-9]+))?$`)
 )
 
 func init() {


### PR DESCRIPTION
Fixes #627 

Since apk normally does allow self-package resolution (if I fulfill one of my dependencies, then look no further), but other places sometimes do not (e.g. wolfictl, as a policy choice, see [this comment](https://github.com/chainguard-dev/apko/issues/627#issuecomment-1517042175) by @kaniini), we make it optional in the resolver.

We always make it true here, but given the overlap between apko logic and wolfictl graph, and the plans for merging them going forward, making this optional only can help.