### PR TITLE
handle versioning in provides

### DIFF
--- a/pkg/apk/impl/version_test.go
+++ b/pkg/apk/impl/version_test.go
@@ -124,7 +124,7 @@ func TestResolveVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			found := filterPackages(pkgs, withVersion(tt.version, tt.compare), withPreferPin(tt.pin))
-			sortPackages(found, nil, nil, tt.pin)
+			sortPackages(found, nil, "", nil, tt.pin)
 			if tt.want == "" {
 				require.Nil(t, found, "version resolver should not find a package")
 			} else {


### PR DESCRIPTION
Fixes #632 

As described in #632, the solver found all packages that either were named with the target (e.g. `a`) and then sorted them. The sorting algorithm, when it came to version order, used the _package_ version. But if the package is there just because it provides something, it should use the _provides_ version.

This fixes it.