### PR TITLE
report complete yaml when fail to build, if debug is enabled

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
 	"gitlab.alpinelinux.org/alpine/go/repository"
+	"gopkg.in/yaml.v3"
 
 	apkfs "chainguard.dev/apko/pkg/apk/impl/fs"
 	"chainguard.dev/apko/pkg/build/types"
@@ -85,6 +86,14 @@ func (bc *Context) GenerateSBOM() error {
 func (bc *Context) BuildImage() (fs.FS, error) {
 	// TODO(puerco): Point to final interface (see comment on buildImage fn)
 	if err := buildImage(bc.fs, bc.impl, &bc.Options, &bc.ImageConfiguration, bc.s6); err != nil {
+		logger := bc.Options.Logger()
+		logger.Debugf("buildImage failed: %v", err)
+		b, err2 := yaml.Marshal(bc.ImageConfiguration)
+		if err2 != nil {
+			logger.Debugf("failed to marshal image configuration: %v", err2)
+		} else {
+			logger.Debugf("image configuration:\n%s", string(b))
+		}
 		return nil, err
 	}
 	return bc.fs, nil


### PR DESCRIPTION
Whenever we use apko from a yaml file, the ability to reproduce a failure is easy: the yaml file is right there.

But we use apko as a library from other places, which makes a slower process to tease out how apko was invoked, with what config, and which options, etc.

This causes apko to print out the entire derived config, in the case of failure to `BuildImage()`, only if `--debug` is enabled.

For example:

```
ℹ️  x86_64    | setting apk world
ℹ️  x86_64    | synchronizing with desired apk world
ℹ️  x86_64    | determining desired apk world
❕ x86_64    | buildImage failed: installing apk packages: error getting package dependencies: could not find package, alias or a package that provides wolfi-base2aa in indexes
❕ x86_64    | image configuration:
contents:
    repositories:
        - https://packages.wolfi.dev/os
    keyring:
        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
    packages:
        - ca-certificates-bundle
        - wolfi-base2aa
entrypoint:
    type: ""
    command: /bin/sh -l
    shell-fragment: ""
    services: {}
archs:
    - {}
os-release:
    name: apko-generated image
    id: unknown
    version-id: unknown
    pretty-name: apko-generated image
    home-url: https://github.com/chainguard-dev/apko
    bug-report-url: ""
vcs-url: git+ssh://github.com/deitch/apko.git@7fb53ba4ec07248395a49da8b28ddd6e167281e4
⚠️  x86_64    | etc/passwd is missing
⚠️  x86_64    | etc/group is missing
```

This will make it much easier to debug upstream failures. 