### PR TITLE
Support onbuild instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ entrypoint:
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
+
+# optional on build configuration
+on_build:
+  - COPY . /usr/src/app
 ```
 We can build this with apko from any environment with apk tooling:
 

--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -22,6 +22,10 @@ entrypoint:
 # optional environment configuration
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
+
+# optional on build configuration
+on_build:
+  - COPY . /usr/src/app
 ```
 
 Running `apko build` on this file will produce a tar file containing an Alpine base container image.

--- a/pkg/build/oci/oci.go
+++ b/pkg/build/oci/oci.go
@@ -188,6 +188,10 @@ func buildImageFromLayerWithMediaType(mediaType ggcrtypes.MediaType, layerTarGZ 
 		}
 	}
 
+	if len(ic.OnBuild) > 0 {
+		cfg.Config.OnBuild = ic.OnBuild
+	}
+
 	if ic.Accounts.RunAs != "" {
 		cfg.Config.User = ic.Accounts.RunAs
 	}

--- a/pkg/build/types/build_option.go
+++ b/pkg/build/types/build_option.go
@@ -41,6 +41,7 @@ type BuildOption struct {
 	Environment map[string]string `yaml:"environment,omitempty"`
 
 	Entrypoint ImageEntrypoint `yaml:"entrypoint,omitempty"`
+	OnBuild    []string        `yaml:"on_build,omitempty"`
 }
 
 // Apply applies a patch described by a BuildOption to an apko environment.
@@ -68,6 +69,8 @@ func (bo BuildOption) Apply(ic *ImageConfiguration) error {
 	for k, v := range bo.Environment {
 		ic.Environment[k] = v
 	}
+
+	ic.OnBuild = append(ic.OnBuild, bo.OnBuild...)
 
 	if bo.Entrypoint.Type != "" {
 		ic.Entrypoint = bo.Entrypoint

--- a/pkg/build/types/build_option.go
+++ b/pkg/build/types/build_option.go
@@ -41,7 +41,7 @@ type BuildOption struct {
 	Environment map[string]string `yaml:"environment,omitempty"`
 
 	Entrypoint ImageEntrypoint `yaml:"entrypoint,omitempty"`
-	OnBuild    []string        `yaml:"on_build,omitempty"`
+	OnBuild    []string        `yaml:"on-build,omitempty"`
 }
 
 // Apply applies a patch described by a BuildOption to an apko environment.

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -208,7 +208,7 @@ func (ic *ImageConfiguration) Summarize(logger log.Logger) {
 
 	if len(ic.OnBuild) > 0 {
 		logger.Printf("  on_build:")
-		for _, onBuildInstruccion := range ic.OnBuild {
+		for _, onBuildInstruction := range ic.OnBuild {
 			logger.Printf("    - %s", onBuildInstruction)
 		}
 	}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -207,7 +207,7 @@ func (ic *ImageConfiguration) Summarize(logger log.Logger) {
 	}
 
 	if len(ic.OnBuild) > 0 {
-		logger.Printf("  on_build:")
+		logger.Printf("  on-build:")
 		for _, onBuildInstruction := range ic.OnBuild {
 			logger.Printf("    - %s", onBuildInstruction)
 		}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -205,4 +205,11 @@ func (ic *ImageConfiguration) Summarize(logger log.Logger) {
 			logger.Printf("      %s: %s", k, v)
 		}
 	}
+
+	if len(ic.OnBuild) > 0 {
+		logger.Printf("  on_build:")
+		for _, onBuildInstruccion := range ic.OnBuild {
+			logger.Printf("    - %s", onBuildInstruccion)
+		}
+	}
 }

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -209,7 +209,7 @@ func (ic *ImageConfiguration) Summarize(logger log.Logger) {
 	if len(ic.OnBuild) > 0 {
 		logger.Printf("  on_build:")
 		for _, onBuildInstruccion := range ic.OnBuild {
-			logger.Printf("    - %s", onBuildInstruccion)
+			logger.Printf("    - %s", onBuildInstruction)
 		}
 	}
 }

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -83,6 +83,7 @@ type ImageConfiguration struct {
 	Accounts    ImageAccounts     `yaml:"accounts,omitempty"`
 	Archs       []Architecture    `yaml:"archs,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
+	OnBuild     []string          `yaml:"on_build,omitempty"`
 	Paths       []PathMutation    `yaml:"paths,omitempty"`
 	OSRelease   OSRelease         `yaml:"os-release,omitempty"`
 	VCSUrl      string            `yaml:"vcs-url,omitempty"`


### PR DESCRIPTION
Hi!

With this [onbuild instruction](https://docs.docker.com/engine/reference/builder/#onbuild) support we can add behavior to the apko images when we use them as base images.