### PR TITLE
document the fields in types/

### DIFF
--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -23,45 +23,72 @@ import (
 )
 
 type User struct {
+	// Required: The name of the user
 	UserName string
-	UID      uint32
-	GID      uint32
+	// Required: The user ID
+	UID uint32
+	// Required: The user's group ID
+	GID uint32
 }
 
 type Group struct {
+	// Required: The name of the group
 	GroupName string
-	GID       uint32
-	Members   []string
+	// Required: The group ID
+	GID uint32
+	// Required: The list of members of the group
+	Members []string
 }
 
 type PathMutation struct {
-	Path        string
-	Type        string
-	UID         uint32
-	GID         uint32
+	// The target path to mutate
+	Path string
+	// The type of mutation to perform
+	//
+	// This can be one of: directory, empty-file, hardlink, symlink, permissions
+	Type string
+	// The mutation's desired user ID
+	UID uint32
+	// The mutation's desired group ID
+	GID uint32
+	// The permission bits for the path
 	Permissions uint32
-	Source      string
-	Recursive   bool
+	// The source path to mutate
+	Source string
+	// Toggle whether to mutate recursively
+	Recursive bool
 }
 
 type OSRelease struct {
-	Name         string
-	ID           string
-	VersionID    string `yaml:"version-id"`
-	PrettyName   string `yaml:"pretty-name"`
-	HomeURL      string `yaml:"home-url"`
+	// Optional: The name of the OS
+	Name string
+	// Optional: The unique identifier for the OS
+	ID string
+	// Optional: The unique identifier for the version of the OS
+	VersionID string `yaml:"version-id"`
+	// Optional: The human readable description of the OS
+	PrettyName string `yaml:"pretty-name"`
+	// Optional: The URL of the homepage for the OS
+	HomeURL string `yaml:"home-url"`
+	// Optional: The URL of the bug reporting website for the OS
 	BugReportURL string `yaml:"bug-report-url"`
 }
 
 type ImageContents struct {
+	// A list of apk repositories to use for pulling packages
 	Repositories []string `yaml:"repositories,omitempty"`
-	Keyring      []string `yaml:"keyring,omitempty"`
-	Packages     []string `yaml:"packages,omitempty"`
+	// A list of public keys used to verify the desired repositories
+	Keyring []string `yaml:"keyring,omitempty"`
+	// A list of packages to include in the image
+	Packages []string `yaml:"packages,omitempty"`
 }
 
 type ImageEntrypoint struct {
-	Type          string
-	Command       string
+	// Optional: The type of entrypoint. Only "service-bundle" is supported.
+	Type string
+	// Required: The command of the entrypoint
+	Command string
+	// Optional: The shell fragment of the entrypoint command
 	ShellFragment string `yaml:"shell-fragment"`
 
 	// TBD: presently a map of service names and the command to run
@@ -69,26 +96,52 @@ type ImageEntrypoint struct {
 }
 
 type ImageAccounts struct {
-	RunAs  string `yaml:"run-as"`
-	Users  []User
+	// Required: The user to run the container as. This can be a username or UID.
+	RunAs string `yaml:"run-as"`
+	// Required: List of users to populate the image with
+	Users []User
+	// Required: List of groups to populate the image with
 	Groups []Group
 }
 
 type ImageConfiguration struct {
-	Contents    ImageContents     `yaml:"contents,omitempty"`
-	Entrypoint  ImageEntrypoint   `yaml:"entrypoint,omitempty"`
-	Cmd         string            `yaml:"cmd,omitempty"`
-	StopSignal  string            `yaml:"stop-signal,omitempty"`
-	WorkDir     string            `yaml:"work-dir,omitempty"`
-	Accounts    ImageAccounts     `yaml:"accounts,omitempty"`
-	Archs       []Architecture    `yaml:"archs,omitempty"`
+	// Required: The apk packages in the container image
+	Contents ImageContents `yaml:"contents,omitempty"`
+	// Required: The entrypoint of the container image
+	//
+	// This typically is the path to the executable to run. Since many of
+	// Chainguard Images do not include a shell, this should be the full path
+	// to the executable.
+	Entrypoint ImageEntrypoint `yaml:"entrypoint,omitempty"`
+	// Optional: The command of the container image
+	//
+	// These are the additional arguments to pass to the entrypoint.
+	Cmd string `yaml:"cmd,omitempty"`
+	// Optional: The stop signal used to suspend the execution of the containers process
+	StopSignal string `yaml:"stop-signal,omitempty"`
+	// Optional: The working directory of the container
+	WorkDir string `yaml:"work-dir,omitempty"`
+	// Optional: Account configuration for the container image
+	Accounts ImageAccounts `yaml:"accounts,omitempty"`
+	// Optional: List of CPU architectures to build the container image for
+	//
+	// The list of supported architectures is: 386, amd64, arm64, arm/v6, arm/v7, ppc64le, riscv64, s390x
+	Archs []Architecture `yaml:"archs,omitempty"`
+	// Optional: Envionment variables to set in the container image
 	Environment map[string]string `yaml:"environment,omitempty"`
-	Paths       []PathMutation    `yaml:"paths,omitempty"`
-	OSRelease   OSRelease         `yaml:"os-release,omitempty"`
-	VCSUrl      string            `yaml:"vcs-url,omitempty"`
+	// Optional: List of paths mutations
+	Paths []PathMutation `yaml:"paths,omitempty"`
+	// Optional: The /etc/os-release configuration for the container image
+	OSRelease OSRelease `yaml:"os-release,omitempty"`
+	// Optional: The link to version control system for this container's source code
+	VCSUrl string `yaml:"vcs-url,omitempty"`
+	// Optional: Annotations to apply to the images manifests
 	Annotations map[string]string `yaml:"annotations,omitempty"`
-	Include     string            `yaml:"include,omitempty"`
-
+	// Optional: Path to a local file containing additional image configuration
+	//
+	// The included configuration is deep merged with the parent configuration
+	Include string `yaml:"include,omitempty"`
+	// Optional: A map of named build option deviations
 	Options map[string]BuildOption `yaml:"options,omitempty"`
 }
 

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -110,7 +110,7 @@ type ImageConfiguration struct {
 	// Required: The entrypoint of the container image
 	//
 	// This typically is the path to the executable to run. Since many of
-	// Chainguard Images do not include a shell, this should be the full path
+	// images do not include a shell, this should be the full path
 	// to the executable.
 	Entrypoint ImageEntrypoint `yaml:"entrypoint,omitempty"`
 	// Optional: The command of the container image


### PR DESCRIPTION
first stab at documenting the fields for apko's public config surface. I best efforted the required/optional fields, knowing that these aren't codegen'd to actually mean anything, but I still think they are useful for an end user.

this will be used by external parsers (like [this](https://github.com/wolfi-dev/wolfictl/pull/193) one) to generate various external documentation that should hopefully improve the devx onboarding/overall experience.