### PR TITLE
Cleanup: Make the Services type more concrete.

### DIFF
--- a/pkg/build/image_builder.go
+++ b/pkg/build/image_builder.go
@@ -32,7 +32,11 @@ func (di *defaultBuildImplementation) WriteSupervisionTree(
 	s6context *s6.Context, imageConfig *types.ImageConfiguration,
 ) error {
 	// write service supervision tree
-	if err := s6context.WriteSupervisionTree(imageConfig.Entrypoint.Services); err != nil {
+	s6m := make(map[interface{}]interface{}, len(imageConfig.Entrypoint.Services))
+	for k, v := range imageConfig.Entrypoint.Services {
+		s6m[k] = v
+	}
+	if err := s6context.WriteSupervisionTree(s6m); err != nil {
 		return fmt.Errorf("failed to write supervision tree: %w", err)
 	}
 	return nil

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -91,8 +91,7 @@ type ImageEntrypoint struct {
 	// Optional: The shell fragment of the entrypoint command
 	ShellFragment string `yaml:"shell-fragment"`
 
-	// TBD: presently a map of service names and the command to run
-	Services map[interface{}]interface{}
+	Services map[string]string
 }
 
 type ImageAccounts struct {


### PR DESCRIPTION
:broom: This cleans up the `map[interface{}]interface{}` currently used for `Services` to match `s6`.

If you look inside of the implementation of the method we pass this to, any path where the key or value aren't strings are errors, so this should be a safe change for any case that is passing today.

/kind cleanup