### PR TITLE
Fix: Explicitly default the `SourceDateEpoch`

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -49,8 +49,9 @@ type Options struct {
 }
 
 var Default = Options{
-	Log:  &log.Adapter{Out: io.Discard, Level: log.InfoLevel},
-	Arch: types.ParseArchitecture(runtime.GOARCH),
+	Log:             &log.Adapter{Out: io.Discard, Level: log.InfoLevel},
+	Arch:            types.ParseArchitecture(runtime.GOARCH),
+	SourceDateEpoch: time.Unix(0, 0),
 }
 
 func (o *Options) Summarize(logger log.Logger) {


### PR DESCRIPTION
:bug: Without this we get Go's funky zero value which shows as like `0001-01-01` in our SBOMs.

/kind bug