### PR TITLE
Fix: add timeouts to several actions legs.

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -28,6 +28,7 @@ jobs:
           ./apko version
 
       - name: build image
+        timeout-minutes: 15
         run: |
           ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx-${{ matrix.arch }}.tar --debug --arch ${{ matrix.arch }}
 
@@ -51,6 +52,7 @@ jobs:
           ./apko version
 
       - name: build images
+        timeout-minutes: 15
         run: |
           for cfg in $(find ./examples/ -name '*.yaml'); do
             name=$(basename ${cfg} .yaml)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
           install-only: true
 
       - name: snapshot
+        timeout-minutes: 30
         run: |
           make snapshot
           ./dist/apko-build_linux_amd64_v1/apko version


### PR DESCRIPTION
:bug: In a PR with deadlocking we saw things hanging for >60m when thing usually take <10m. This adds generous timeouts much lower than the default of 6h.

/kind bug