### PR TITLE
Feature: Compute the default timestamp from installed APKs

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -59,8 +59,8 @@ jobs:
             ./apko build ${cfg} ${name}:build /tmp/${name}.tar --debug --arch amd64
           done
 
-  build-alpine-multi-arch-deterministically:
-    name: build-alpine-deterministically
+  build-alpine-source-date-epoch:
+    name: source-date-epoch
     runs-on: ubuntu-latest
 
     steps:
@@ -81,12 +81,54 @@ jobs:
         with:
           port: 5000
 
-      - name: build image
+      - name: build image (w/ source date epoch)
         shell: bash
         timeout-minutes: 15
         env:
           SOURCE_DATE_EPOCH: "0"
         run: |
+          FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+
+          for idx in {2..10}
+          do
+            NEXT=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+
+            if [ "${FIRST}" = "${NEXT}" ]; then
+              echo "Build ${idx} matches."
+            else
+              echo "Build ${idx} differs: ${FIRST} and ${NEXT}"
+              exit 1
+            fi
+          done
+
+  build-alpine-build-date-epoch:
+    name: build-date-epoch
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v2.4.0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v2.1.5
+        with:
+          go-version: 1.19
+          check-latest: true
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: build
+        run: |
+          make apko
+          ./apko version
+
+      - uses: chainguard-dev/actions/setup-registry@main
+        with:
+          port: 5000
+
+      - name: build image (w/ build date epoch)
+        shell: bash
+        timeout-minutes: 15
+        run: |
+          # Without SOURCE_DATE_EPOCH set, the timestamp of the image will be computed to be
+          # the maximum build date of the resolved APKs.
           FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
 
           for idx in {2..10}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -236,7 +236,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 			// This computation will only affect the timestamp of the image
 			// itself and its SBOMs, since the timestamps on files come from the
 			// APKs.
-			if err := bc.SetBuildDateEpoch(); err != nil {
+			if bc.Options.SourceDateEpoch, err = bc.GetBuildDateEpoch(); err != nil {
 				return fmt.Errorf("failed to determine build date epoch: %w", err)
 			}
 			if bc.Options.SourceDateEpoch.After(multiArchBDE) {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -252,7 +252,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			// This computation will only affect the timestamp of the image
 			// itself and its SBOMs, since the timestamps on files come from the
 			// APKs.
-			if err := bc.SetBuildDateEpoch(); err != nil {
+			if bc.Options.SourceDateEpoch, err = bc.GetBuildDateEpoch(); err != nil {
 				return fmt.Errorf("failed to determine build date epoch: %w", err)
 			}
 			if bc.Options.SourceDateEpoch.After(multiArchBDE) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -88,20 +88,21 @@ func (bc *Context) InstalledPackages() ([]*apkimpl.InstalledPackage, error) {
 	return bc.impl.InstalledPackages(bc.fs, &bc.Options)
 }
 
-func (bc *Context) SetBuildDateEpoch() error {
+func (bc *Context) GetBuildDateEpoch() (time.Time, error) {
 	if _, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); !ok {
-		return nil
+		return bc.Options.SourceDateEpoch, nil
 	}
 	pl, err := bc.InstalledPackages()
 	if err != nil {
-		return fmt.Errorf("failed to determine installed packages: %w", err)
+		return time.Time{}, fmt.Errorf("failed to determine installed packages: %w", err)
 	}
+	bde := bc.Options.SourceDateEpoch
 	for _, p := range pl {
-		if p.BuildTime.After(bc.Options.SourceDateEpoch) {
-			bc.Options.SourceDateEpoch = p.BuildTime
+		if p.BuildTime.After(bde) {
+			bde = p.BuildTime
 		}
 	}
-	return nil
+	return bde, nil
 }
 
 func (bc *Context) BuildImage() (fs.FS, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	apkimpl "github.com/chainguard-dev/go-apk/pkg/apk"
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/hashicorp/go-multierror"
@@ -81,6 +82,10 @@ func (bc *Context) GenerateIndexSBOM(indexDigest name.Digest, imgs map[types.Arc
 
 func (bc *Context) GenerateSBOM() error {
 	return bc.impl.GenerateSBOM(&bc.Options, &bc.ImageConfiguration)
+}
+
+func (bc *Context) InstalledPackages() ([]*apkimpl.InstalledPackage, error) {
+	return bc.impl.InstalledPackages(bc.fs, &bc.Options)
 }
 
 func (bc *Context) BuildImage() (fs.FS, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -88,6 +88,22 @@ func (bc *Context) InstalledPackages() ([]*apkimpl.InstalledPackage, error) {
 	return bc.impl.InstalledPackages(bc.fs, &bc.Options)
 }
 
+func (bc *Context) SetBuildDateEpoch() error {
+	if _, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); !ok {
+		return nil
+	}
+	pl, err := bc.InstalledPackages()
+	if err != nil {
+		return fmt.Errorf("failed to determine installed packages: %w", err)
+	}
+	for _, p := range pl {
+		if p.BuildTime.After(bc.Options.SourceDateEpoch) {
+			bc.Options.SourceDateEpoch = p.BuildTime
+		}
+	}
+	return nil
+}
+
 func (bc *Context) BuildImage() (fs.FS, error) {
 	// TODO(puerco): Point to final interface (see comment on buildImage fn)
 	if err := buildImage(bc.fs, bc.impl, &bc.Options, &bc.ImageConfiguration, bc.s6); err != nil {

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	apkimpl "github.com/chainguard-dev/go-apk/pkg/apk"
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -53,6 +54,8 @@ type buildImplementation interface {
 	InitializeApk(apkfs.FullFS, *options.Options, *types.ImageConfiguration) error
 	// InstallPackages install the packages
 	InstallPackages(apkfs.FullFS, *options.Options, *types.ImageConfiguration) error
+	// InstalledPackages fetches the installed package list
+	InstalledPackages(fsys apkfs.FullFS, o *options.Options) ([]*apkimpl.InstalledPackage, error)
 	// ResolvePackages resolve the names and versions of packages to be installed
 	ResolvePackages(apkfs.FullFS, *options.Options, *types.ImageConfiguration) ([]*repository.RepositoryPackage, []string, error)
 	// MutateAccounts set up the user accounts and groups in the working directory
@@ -214,6 +217,14 @@ func (di *defaultBuildImplementation) InstallPackages(fsys apkfs.FullFS, o *opti
 		return err
 	}
 	return apk.Install()
+}
+
+func (di *defaultBuildImplementation) InstalledPackages(fsys apkfs.FullFS, o *options.Options) ([]*apkimpl.InstalledPackage, error) {
+	apk, err := chainguardAPK.NewWithOptions(fsys, *o)
+	if err != nil {
+		return nil, err
+	}
+	return apk.GetInstalled()
 }
 
 func (di *defaultBuildImplementation) ResolvePackages(fsys apkfs.FullFS, o *options.Options, ic *types.ImageConfiguration) (toInstall []*repository.RepositoryPackage, conflicts []string, err error) {

--- a/pkg/build/buildfakes/fake_build_implementation.go
+++ b/pkg/build/buildfakes/fake_build_implementation.go
@@ -9,6 +9,7 @@ import (
 	"chainguard.dev/apko/pkg/exec"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/s6"
+	"github.com/chainguard-dev/go-apk/pkg/apk"
 	"github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/v2/pkg/oci"
@@ -169,6 +170,20 @@ type FakeBuildImplementation struct {
 	}
 	installPackagesReturnsOnCall map[int]struct {
 		result1 error
+	}
+	InstalledPackagesStub        func(fs.FullFS, *options.Options) ([]*apk.InstalledPackage, error)
+	installedPackagesMutex       sync.RWMutex
+	installedPackagesArgsForCall []struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+	}
+	installedPackagesReturns struct {
+		result1 []*apk.InstalledPackage
+		result2 error
+	}
+	installedPackagesReturnsOnCall map[int]struct {
+		result1 []*apk.InstalledPackage
+		result2 error
 	}
 	MutateAccountsStub        func(fs.FullFS, *options.Options, *types.ImageConfiguration) error
 	mutateAccountsMutex       sync.RWMutex
@@ -1011,6 +1026,71 @@ func (fake *FakeBuildImplementation) InstallPackagesReturnsOnCall(i int, result1
 	}{result1}
 }
 
+func (fake *FakeBuildImplementation) InstalledPackages(arg1 fs.FullFS, arg2 *options.Options) ([]*apk.InstalledPackage, error) {
+	fake.installedPackagesMutex.Lock()
+	ret, specificReturn := fake.installedPackagesReturnsOnCall[len(fake.installedPackagesArgsForCall)]
+	fake.installedPackagesArgsForCall = append(fake.installedPackagesArgsForCall, struct {
+		arg1 fs.FullFS
+		arg2 *options.Options
+	}{arg1, arg2})
+	stub := fake.InstalledPackagesStub
+	fakeReturns := fake.installedPackagesReturns
+	fake.recordInvocation("InstalledPackages", []interface{}{arg1, arg2})
+	fake.installedPackagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBuildImplementation) InstalledPackagesCallCount() int {
+	fake.installedPackagesMutex.RLock()
+	defer fake.installedPackagesMutex.RUnlock()
+	return len(fake.installedPackagesArgsForCall)
+}
+
+func (fake *FakeBuildImplementation) InstalledPackagesCalls(stub func(fs.FullFS, *options.Options) ([]*apk.InstalledPackage, error)) {
+	fake.installedPackagesMutex.Lock()
+	defer fake.installedPackagesMutex.Unlock()
+	fake.InstalledPackagesStub = stub
+}
+
+func (fake *FakeBuildImplementation) InstalledPackagesArgsForCall(i int) (fs.FullFS, *options.Options) {
+	fake.installedPackagesMutex.RLock()
+	defer fake.installedPackagesMutex.RUnlock()
+	argsForCall := fake.installedPackagesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBuildImplementation) InstalledPackagesReturns(result1 []*apk.InstalledPackage, result2 error) {
+	fake.installedPackagesMutex.Lock()
+	defer fake.installedPackagesMutex.Unlock()
+	fake.InstalledPackagesStub = nil
+	fake.installedPackagesReturns = struct {
+		result1 []*apk.InstalledPackage
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBuildImplementation) InstalledPackagesReturnsOnCall(i int, result1 []*apk.InstalledPackage, result2 error) {
+	fake.installedPackagesMutex.Lock()
+	defer fake.installedPackagesMutex.Unlock()
+	fake.InstalledPackagesStub = nil
+	if fake.installedPackagesReturnsOnCall == nil {
+		fake.installedPackagesReturnsOnCall = make(map[int]struct {
+			result1 []*apk.InstalledPackage
+			result2 error
+		})
+	}
+	fake.installedPackagesReturnsOnCall[i] = struct {
+		result1 []*apk.InstalledPackage
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeBuildImplementation) MutateAccounts(arg1 fs.FullFS, arg2 *options.Options, arg3 *types.ImageConfiguration) error {
 	fake.mutateAccountsMutex.Lock()
 	ret, specificReturn := fake.mutateAccountsReturnsOnCall[len(fake.mutateAccountsArgsForCall)]
@@ -1423,6 +1503,8 @@ func (fake *FakeBuildImplementation) Invocations() map[string][][]interface{} {
 	defer fake.installLdconfigLinksMutex.RUnlock()
 	fake.installPackagesMutex.RLock()
 	defer fake.installPackagesMutex.RUnlock()
+	fake.installedPackagesMutex.RLock()
+	defer fake.installedPackagesMutex.RUnlock()
 	fake.mutateAccountsMutex.RLock()
 	defer fake.mutateAccountsMutex.RUnlock()
 	fake.mutatePathsMutex.RLock()


### PR DESCRIPTION
:gift: When `SOURCE_DATE_EPOCH` is not specified, this change infers the timestamp to assign the image from the build date of the oldest installed APK.

/kind feature