### PR TITLE
adds warning in case of unknown distro in etc/os-release

### DIFF
--- a/pkg/build/os-release.go
+++ b/pkg/build/os-release.go
@@ -79,6 +79,9 @@ func (bc *Context) GenerateOSRelease() error {
 	defer w.Close()
 
 	if osr.ID != "" {
+		if osr.ID == "unknown" {
+			bc.Logger().Warnf("distro ID not specified and /etc/os-release does not already exist")
+		}
 		_, err := fmt.Fprintf(w, "ID=%s\n", osr.ID)
 		if err != nil {
 			return err


### PR DESCRIPTION
Tries to fix #447 

Currently, with my little knowledge of the code being a new contributor here, I could find that mutation of `/etc/os-release` files happens while validation and `ID` tells distro name usually in most `/etc/os-release` files. 

Therefore while checking for `ID`, if it is `""`, we set it to `unknown` in the generated file, this happens in the [Validate function](https://github.com/chainguard-dev/apko/blob/main/pkg/build/types/image_configuration.go#L111). Therefore I added a warning for this there in the check for empty ID. This should probably support what we desired. Thanks!