### PR TITLE
Stop using tarball.LayerFromFile

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -101,7 +101,7 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 
 	bc.Logger().Printf("building minirootfs '%s'", bc.Options.TarballPath)
 
-	layerTarGZ, err := bc.BuildLayer()
+	_, layerTarGZ, err := bc.BuildLayer(bc.Options.UseDockerMediaTypes)
 	if err != nil {
 		return fmt.Errorf("failed to build layer image: %w", err)
 	}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -231,7 +231,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 				return fmt.Errorf("failed to update build context for %q: %w", arch, err)
 			}
 
-			layerTarGZ, err := bc.BuildLayer()
+			layer, layerTarGZ, err := bc.BuildLayer(bc.Options.UseDockerMediaTypes)
 			if err != nil {
 				return fmt.Errorf("failed to build layer image: %w", err)
 			}
@@ -251,8 +251,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 			}
 
 			imageTars[arch] = layerTarGZ
-			img, err := oci.BuildImageFromLayer(
-				layerTarGZ, bc.ImageConfiguration, bc.Logger(), bc.Options)
+			img, err := oci.BuildImageFromLayer(layer, bc.ImageConfiguration, bc.Logger(), bc.Options)
 			if err != nil {
 				return fmt.Errorf("failed to build OCI image: %w", err)
 			}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -237,7 +238,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 				return fmt.Errorf("failed to update build context for %q: %w", arch, err)
 			}
 
-			layerTarGZ, err := bc.BuildLayer()
+			layer, layerTarGZ, err := bc.BuildLayer(bc.Options.UseDockerMediaTypes)
 			if err != nil {
 				return fmt.Errorf("failed to build layer image for %q: %w", arch, err)
 			}
@@ -260,7 +261,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 			}
 
 			var img coci.SignedImage
-			finalDigest, img, err = publishImage(ctx, bc, layerTarGZ, arch)
+			finalDigest, img, err = publishImage(ctx, bc, layer, arch)
 			if err != nil {
 				return fmt.Errorf("publishing %s image: %w", arch, err)
 			}
@@ -398,24 +399,14 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 }
 
 // publishImage publishes a specific architecture image
-func publishImage(ctx context.Context, bc *build.Context, layerTarGZ string, arch types.Architecture) (imgDigest name.Digest, img coci.SignedImage, err error) {
+func publishImage(ctx context.Context, bc *build.Context, layer v1.Layer, arch types.Architecture) (imgDigest name.Digest, img coci.SignedImage, err error) {
 	shouldPushTags := bc.Options.StageTags == ""
-	if bc.Options.UseDockerMediaTypes {
-		imgDigest, img, err = oci.PublishDockerImageFromLayer(ctx,
-			layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(),
-			bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Local, shouldPushTags, bc.Options.Tags...,
-		)
-		if err != nil {
-			return name.Digest{}, nil, fmt.Errorf("failed to build Docker image for %q: %w", arch, err)
-		}
-	} else {
-		imgDigest, img, err = oci.PublishImageFromLayer(ctx,
-			layerTarGZ, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(),
-			bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Local, shouldPushTags, bc.Options.Tags...,
-		)
-		if err != nil {
-			return name.Digest{}, nil, fmt.Errorf("failed to build OCI image for %q: %w", arch, err)
-		}
+	imgDigest, img, err = oci.PublishImageFromLayer(ctx,
+		layer, bc.ImageConfiguration, bc.Options.SourceDateEpoch, arch, bc.Logger(),
+		bc.Options.SBOMPath, bc.Options.SBOMFormats, bc.Options.Local, shouldPushTags, bc.Options.Tags...,
+	)
+	if err != nil {
+		return name.Digest{}, nil, fmt.Errorf("failed to build image for %q: %w", arch, err)
 	}
 	return imgDigest, img, nil
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -47,7 +47,7 @@ func TestBuildLayer(t *testing.T) {
 		},
 		{ // BuildTarball fails
 			prepare: func(fbi *buildfakes.FakeBuildImplementation) {
-				fbi.BuildTarballReturns("", fakeErr)
+				fbi.BuildTarballReturns("", nil, nil, fakeErr)
 			},
 			msg:         "buildtarball fails",
 			shouldError: true,
@@ -67,7 +67,7 @@ func TestBuildLayer(t *testing.T) {
 		sut.Options.WantSBOM = true
 		require.NoError(t, err)
 		sut.SetImplementation(&mock)
-		_, err = sut.BuildLayer()
+		_, _, err = sut.BuildLayer(false)
 		if tc.shouldError {
 			require.Error(t, err, tc.msg)
 		} else {

--- a/pkg/build/buildfakes/fake_build_implementation.go
+++ b/pkg/build/buildfakes/fake_build_implementation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chainguard-dev/go-apk/pkg/apk"
 	"github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 )
@@ -45,7 +46,7 @@ type FakeBuildImplementation struct {
 		result1 fsa.FS
 		result2 error
 	}
-	BuildTarballStub        func(*options.Options, fsa.FS) (string, error)
+	BuildTarballStub        func(*options.Options, fsa.FS) (string, *v1.Hash, *v1.Descriptor, error)
 	buildTarballMutex       sync.RWMutex
 	buildTarballArgsForCall []struct {
 		arg1 *options.Options
@@ -53,11 +54,15 @@ type FakeBuildImplementation struct {
 	}
 	buildTarballReturns struct {
 		result1 string
-		result2 error
+		result2 *v1.Hash
+		result3 *v1.Descriptor
+		result4 error
 	}
 	buildTarballReturnsOnCall map[int]struct {
 		result1 string
-		result2 error
+		result2 *v1.Hash
+		result3 *v1.Descriptor
+		result4 error
 	}
 	GenerateImageSBOMStub        func(*options.Options, *types.ImageConfiguration, oci.SignedImage) error
 	generateImageSBOMMutex       sync.RWMutex
@@ -399,7 +404,7 @@ func (fake *FakeBuildImplementation) BuildImageReturnsOnCall(i int, result1 fsa.
 	}{result1, result2}
 }
 
-func (fake *FakeBuildImplementation) BuildTarball(arg1 *options.Options, arg2 fsa.FS) (string, error) {
+func (fake *FakeBuildImplementation) BuildTarball(arg1 *options.Options, arg2 fsa.FS) (string, *v1.Hash, *v1.Descriptor, error) {
 	fake.buildTarballMutex.Lock()
 	ret, specificReturn := fake.buildTarballReturnsOnCall[len(fake.buildTarballArgsForCall)]
 	fake.buildTarballArgsForCall = append(fake.buildTarballArgsForCall, struct {
@@ -414,9 +419,9 @@ func (fake *FakeBuildImplementation) BuildTarball(arg1 *options.Options, arg2 fs
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
 func (fake *FakeBuildImplementation) BuildTarballCallCount() int {
@@ -425,7 +430,7 @@ func (fake *FakeBuildImplementation) BuildTarballCallCount() int {
 	return len(fake.buildTarballArgsForCall)
 }
 
-func (fake *FakeBuildImplementation) BuildTarballCalls(stub func(*options.Options, fsa.FS) (string, error)) {
+func (fake *FakeBuildImplementation) BuildTarballCalls(stub func(*options.Options, fsa.FS) (string, *v1.Hash, *v1.Descriptor, error)) {
 	fake.buildTarballMutex.Lock()
 	defer fake.buildTarballMutex.Unlock()
 	fake.BuildTarballStub = stub
@@ -438,30 +443,36 @@ func (fake *FakeBuildImplementation) BuildTarballArgsForCall(i int) (*options.Op
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeBuildImplementation) BuildTarballReturns(result1 string, result2 error) {
+func (fake *FakeBuildImplementation) BuildTarballReturns(result1 string, result2 *v1.Hash, result3 *v1.Descriptor, result4 error) {
 	fake.buildTarballMutex.Lock()
 	defer fake.buildTarballMutex.Unlock()
 	fake.BuildTarballStub = nil
 	fake.buildTarballReturns = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 *v1.Hash
+		result3 *v1.Descriptor
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
-func (fake *FakeBuildImplementation) BuildTarballReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeBuildImplementation) BuildTarballReturnsOnCall(i int, result1 string, result2 *v1.Hash, result3 *v1.Descriptor, result4 error) {
 	fake.buildTarballMutex.Lock()
 	defer fake.buildTarballMutex.Unlock()
 	fake.BuildTarballStub = nil
 	if fake.buildTarballReturnsOnCall == nil {
 		fake.buildTarballReturnsOnCall = make(map[int]struct {
 			result1 string
-			result2 error
+			result2 *v1.Hash
+			result3 *v1.Descriptor
+			result4 error
 		})
 	}
 	fake.buildTarballReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 *v1.Hash
+		result3 *v1.Descriptor
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
 func (fake *FakeBuildImplementation) GenerateImageSBOM(arg1 *options.Options, arg2 *types.ImageConfiguration, arg3 oci.SignedImage) error {

--- a/pkg/tarball/append_test.go
+++ b/pkg/tarball/append_test.go
@@ -45,7 +45,8 @@ func TestMultiTar(t *testing.T) {
 	m.Close()
 
 	var expected bytes.Buffer
-	require.NoError(t, ctx.WriteArchive(&expected, testdataFS))
+	_, err = ctx.WriteArchive(&expected, testdataFS)
+	require.NoError(t, err)
 
 	require.Equal(t, expected, got)
 }
@@ -64,8 +65,10 @@ func TestExtraWriter(t *testing.T) {
 
 	var expectedFoo bytes.Buffer
 	var expectedBar bytes.Buffer
-	require.NoError(t, ctx.WriteArchive(&expectedBar, barFS))
-	require.NoError(t, ctx.WriteArchive(&expectedFoo, fooFS))
+	_, err = ctx.WriteArchive(&expectedBar, barFS)
+	require.NoError(t, err)
+	_, err = ctx.WriteArchive(&expectedFoo, fooFS)
+	require.NoError(t, err)
 
 	require.Equal(t, expectedFoo, gotFoo)
 	require.Equal(t, expectedBar, gotBar)


### PR DESCRIPTION
We spend a ton of CPU compressing a targz, then immediately hand it over to tarball.LayerFromFile to gunzip it in order to compute its sha256.

Instead, compute the diffid and digest when we generate the targz so we can avoid recomputing it and go a bit faster.