### PR TITLE
add annotations to index manifest

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -142,3 +142,30 @@ jobs:
               exit 1
             fi
           done
+
+  annotations:
+    name: annotations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v2.4.0
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v2.1.5
+        with:
+          go-version: 1.19
+          check-latest: true
+      - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
+      - uses: chainguard-dev/actions/setup-registry@main
+        with:
+          port: 5000
+      - name: build
+        run: |
+          make apko
+          ./apko version
+
+          # Build image with annotations.
+          ref=$(./apko publish ./examples/nginx.yaml localhost:5000/nginx)
+
+          # Check index annotations.
+          crane manifest $ref | jq -r '.annotations.foo' | grep bar
+
+          # Check per-image annotations.
+          crane manifest --platform=linux/arm64 $ref | jq -r '.annotations.foo' | grep bar

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -39,3 +39,5 @@ paths:
 
 work-dir: /usr/share/nginx
 
+annotations:
+  foo: bar

--- a/pkg/build/oci/publish.go
+++ b/pkg/build/oci/publish.go
@@ -82,11 +82,6 @@ func PublishImageFromLayer(ctx context.Context, layer v1.Layer, ic types.ImageCo
 // platform, defaulting to the one on which the docker daemon is running.
 // PublishIndex will determine that platform and use it to publish the updated index.
 func PublishIndex(ctx context.Context, idx oci.SignedImageIndex, logger log.Logger, local bool, shouldPushTags bool, tags []string, remoteOpts ...remote.Option) (name.Digest, oci.SignedImageIndex, error) {
-	// TODO(jason): Also set annotations on the index. ggcr's
-	// pkg/v1/mutate.Annotations will drop the interface methods from
-	// oci.SignedImageIndex, so we may need to reimplement
-	// mutate.Annotations in ocimutate to keep it for now.
-
 	// If attempting to save locally, pick the native architecture
 	// and use that cached image for local tags
 	// Ported from https://github.com/ko-build/ko/blob/main/pkg/publish/daemon.go#L92-L168


### PR DESCRIPTION
This adds any annotations specified in the config file, or determined from VCS info if enabled, to the index manifest in addition to constituent image manifests.

This has always worked, and still does:
```
crane manifest --platform=linux/amd64 $(go run ./ publish examples/nginx.yaml ttl.sh/jason) | jq .annotations
{
  "org.opencontainers.image.revision": "d16c9050918e6a5da5bf575d625be7f615b3b966",
  "org.opencontainers.image.source": "git+ssh://github.com/chainguard-dev/apko.git"
}
```

This didn't work, but does now:
```
crane manifest $(go run ./ publish examples/nginx.yaml ttl.sh/jason) | jq .annotations
{
  "org.opencontainers.image.revision": "d16c9050918e6a5da5bf575d625be7f615b3b966",
  "org.opencontainers.image.source": "git+ssh://github.com/chainguard-dev/apko.git"
}
```

(previously the annotations were empty and `jq` would return `null`)

I'm not proud of all I had to do to get this wired up.

#481 
Fixes https://github.com/chainguard-dev/apko/issues/692