### PR TITLE
add optional oci volumes field to resulting image config

### DIFF
--- a/pkg/build/oci/image.go
+++ b/pkg/build/oci/image.go
@@ -132,6 +132,13 @@ func BuildImageFromLayer(layer v1.Layer, ic types.ImageConfiguration, created ti
 		cfg.Config.WorkingDir = ic.WorkDir
 	}
 
+	if ic.Volumes != nil {
+		cfg.Config.Volumes = make(map[string]struct{})
+		for _, v := range ic.Volumes {
+			cfg.Config.Volumes[v] = struct{}{}
+		}
+	}
+
 	// Set these environment variables if they are not already set.
 	if ic.Environment == nil {
 		ic.Environment = map[string]string{}

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -144,6 +144,14 @@ type ImageConfiguration struct {
 	//
 	// Deprecated: Use WithExtraPackages.
 	Options map[string]BuildOption `yaml:"options,omitempty"`
+	// Optional: A list of volumes to configure
+	//
+	// This is _not_ the same as Paths, but refers to the OCI spec "volumes"
+	// field used by some container runtimes (docker) to create volumes at
+	// runtime. For most use cases, this is not needed, but consider using this
+	// when the image requires special volume configuration at runtime for
+	// supported container runtimes.
+	Volumes []string `yaml:"volumes,omitempty"`
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
this is to support images that leverage a container runtime that uses the OCI spec `volumes` field ([ref](https://github.com/opencontainers/image-spec/blob/main/config.md#properties)) to set up runtime volume mounts. it is a noop for all other runtimes

this supports the relatively small subset of cases where an image is built to run with `docker`, and needs certain mount configs to function. more concretely, the `k3s` container running in docker (ie: `k3d`). this runs `containerd` in docker by default with the `overlayfs` snapshotter, and requires a non `overlayfs` mount point to work. this is achieved upstream with a host volume mount ([ref](https://github.com/k3s-io/k3s/blob/master/package/Dockerfile#LL16C1-L17C1)).

this change lets us mimic this behavior with something like:

```yaml
...
volumes:
  - /var/lib/rancher/k3s
```

this only affects runtimes that actually parse the `Volumes` field (like docker).

related: https://github.com/wolfi-dev/os/pull/2970 https://github.com/chainguard-images/images/pull/877