### PR TITLE
base ci tests on examples

### DIFF
--- a/examples/wolfi-base.yaml
+++ b/examples/wolfi-base.yaml
@@ -4,11 +4,10 @@ contents:
   repositories:
     - https://packages.wolfi.dev/os
   packages:
-    - ca-certificates-bundle
     - wolfi-base
 
-entrypoint:
-  command: /bin/sh -l
+cmd: /bin/sh -l
 
 archs:
 - x86_64
+- aarch64

--- a/hack/ci/00-build.sh
+++ b/hack/ci/00-build.sh
@@ -5,37 +5,20 @@
 
 set -ex
 
-APKO_CONFIG="ci-testing.apko.yaml"
 OUTPUT_TAR="output.tar"
-REF="localhost:5000/ci-testing:test"
+REF="apko.local/ci-testing:test"
 
-trap "rm -f ${APKO_CONFIG} ${OUTPUT_TAR}" EXIT
+trap "rm -f ${OUTPUT_TAR}" EXIT
 
-cat > "${APKO_CONFIG}" << EOF
-contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  packages:
-    - ca-certificates-bundle
-    - glibc-locale-en
-    - busybox
-    - bash
-    - openjdk-17
-    - openjdk-17-default-jvm
-    - maven
-    - wolfi-baselayout
-archs:
-  - x86_64
-  - aarch64
-EOF
+for f in examples/alpine-base-rootless.yaml examples/wolfi-base.yaml; do
+  echo "=== building $f"
 
-# Build image
-"${APKO}" build --debug "${APKO_CONFIG}" "${REF}" "${OUTPUT_TAR}"
+  REF="apko.local/ci-testing:$(basename ${f})"
+  "${APKO}" build --debug "${f}" "${REF}" "${OUTPUT_TAR}"
 
-# Subtest #1: Does it load
-ARCH_REF="$(docker load < output.tar | grep "Loaded image" | sed 's/^Loaded image: //' | head -1)"
+  # Subtest #1: Does it load?
+  ARCH_REF="$(docker load < output.tar | grep "Loaded image" | sed 's/^Loaded image: //' | head -1)"
 
-# Subtest #2: Can we run it
-docker run --entrypoint mvn --rm "${ARCH_REF}" --version
+  # Subtest #2: Can we run it?
+  docker run --rm "${ARCH_REF}" echo hello | grep hello
+done

--- a/hack/ci/01-publish.sh
+++ b/hack/ci/01-publish.sh
@@ -7,54 +7,36 @@ set -ex
 
 REGISTRY_BASE_IMAGE="index.docker.io/library/registry:2.8.1"
 REGISTRY_CONTAINER_NAME="ci-testing-registry"
-REF="localhost:5000/ci-testing:test"
-APKO_CONFIG="ci-testing.apko.yaml"
-SBOM_FILENAME="ci-testing.sbom.json"
+PORT=${PORT:-${RANDOM}}
 
-trap "rm -f ${APKO_CONFIG} &&
-rm -f ${SBOM_FILENAME} && \
+trap "rm -f *.sbom.json && \
 docker rm -f ${REGISTRY_CONTAINER_NAME}" EXIT
 
 docker rm -f "${REGISTRY_CONTAINER_NAME}"
 docker run --name "${REGISTRY_CONTAINER_NAME}" \
-  -d -p 5000:5000 "${REGISTRY_BASE_IMAGE}"
+  -d -p ${PORT}:5000 "${REGISTRY_BASE_IMAGE}"
 
-cat > "${APKO_CONFIG}" << EOF
-contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  packages:
-    - ca-certificates-bundle
-    - glibc-locale-en
-    - busybox
-    - bash
-    - openjdk-17
-    - openjdk-17-default-jvm
-    - maven
-    - wolfi-baselayout
-archs:
-  - x86_64
-  - aarch64
-EOF
+for f in examples/alpine-base-rootless.yaml examples/wolfi-base.yaml; do
+  echo "=== building $f"
 
-# Publish image to registry
-"${APKO}" publish --debug "${APKO_CONFIG}" "${REF}"
+  REF="localhost:${PORT}/ci-testing:$(basename ${f})"
+  img=$("${APKO}" publish --debug "${f}" "${REF}")
 
-# Subtest #1: Can we run it
-docker pull "${REF}"
-docker run --entrypoint mvn --rm "${REF}" --version
+  # Run the image.
+  docker run --rm ${img} echo hello | grep hello
 
-# Subtest #2: Dowload SBOM and check that it contains
-# files derived from package SBOMs melange produces in /var/lib/db/sbom
-cosign download sbom --platform=linux/amd64 "${REF}" | tee ci-testing.sbom.json
-HAS_FILES="$(cat ci-testing.sbom.json | jq 'keys | contains(["files"])')"
-if [[ "${HAS_FILES}" != "true" ]]; then
-  echo "SBOM does not have files. Exiting."
-  exit 1
-fi
+  if [[ ${f} == "examples/wolfi-base.yaml" ]]; then
+    # Download SBOM and check that it contains
+    # files derived from package SBOMs melange produces in /var/lib/db/sbom
+    cosign download sbom --platform=linux/amd64 "${REF}" | tee ci-testing.sbom.json
+    HAS_FILES="$(cat ci-testing.sbom.json | jq 'keys | contains(["files"])')"
+    if [[ "${HAS_FILES}" != "true" ]]; then
+      echo "SBOM does not have files. Exiting."
+      exit 1
+    fi
+  fi
 
-# Subtest #3: Each platform should contain platform-specific etc/apk/arch file.
-crane export --platform linux/amd64 "${REF}" | tar -Ox etc/apk/arch | grep x86_64
-crane export --platform linux/arm64 "${REF}" | tar -Ox etc/apk/arch | grep aarch64
+  # Each platform should contain platform-specific etc/apk/arch file.
+  crane export --platform linux/amd64 "${REF}" | tar -Ox etc/apk/arch | grep x86_64
+  crane export --platform linux/arm64 "${REF}" | tar -Ox etc/apk/arch | grep aarch64
+done


### PR DESCRIPTION
This changes `make ci` tests to use example configs from `examples/`, instead of a newly invented config

It builds/publishes and runs an alpine-based and a wolfi-based image

This also updates our wolfi-base.yaml example to more closely match the [Chainguard image equivalent](https://github.com/chainguard-images/images/blob/1d3537fa0a782d6a1bf5766a7b6b3741ff5eb221/images/wolfi-base/configs/latest.apko.yaml#L5).