### PR TITLE
bump go-apk dep to stop fetching alpine keys all the time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220920003936-cd2dbcbbab49
-	github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c
+	github.com/chainguard-dev/go-apk v0.0.0-20230628205940-516bb829d27b
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-git/go-git/v5 v5.6.1

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c h1:VHivcT15SPM1LIfluh9A4X2mNUj3zT/YvZ7qnmRLJ+I=
 github.com/chainguard-dev/go-apk v0.0.0-20230624211543-feec2b17ac2c/go.mod h1:koN42sGqNZ9A37tc2/yFVKPpT9c5nDIcOjjxG0AWMls=
+github.com/chainguard-dev/go-apk v0.0.0-20230628205940-516bb829d27b h1:jv/YNXoeInATk+I5J66GbjntwRn36uyJYakuivV8KHc=
+github.com/chainguard-dev/go-apk v0.0.0-20230628205940-516bb829d27b/go.mod h1:koN42sGqNZ9A37tc2/yFVKPpT9c5nDIcOjjxG0AWMls=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08 h1:9Qh4lJ/KMr5iS1zfZ8I97+3MDpiKjl+0lZVUNBhdvRs=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08/go.mod h1:MAuu1uDJNOS3T3ui0qmKdPUwm59+bO19BbTph2wZafE=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=


### PR DESCRIPTION
Picks up https://github.com/chainguard-dev/go-apk/pull/70

#766 