### PR TITLE
Support building OCI layout directories

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -142,7 +142,7 @@ bill of materials) describing the image contents.
 	return cmd
 }
 
-func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.Architecture, tags []string, wantSBOM bool, sbomPath string, logger log.Logger, opts ...build.Option) error {
+func BuildCmd(ctx context.Context, imageRef, outputTar string, archs []types.Architecture, tags []string, wantSBOM bool, sbomPath string, logger log.Logger, opts ...build.Option) error {
 	wd, err := os.MkdirTemp("", "apko-*")
 	if err != nil {
 		return fmt.Errorf("failed to create working directory: %w", err)
@@ -156,7 +156,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 	}
 
 	// bundle the parts of the image into a tarball
-	if _, err := oci.BuildIndex(outputTarGZ, idx, append([]string{imageRef}, tags...), logger); err != nil {
+	if _, err := oci.BuildIndex(outputTar, idx, append([]string{imageRef}, tags...), logger); err != nil {
 		return fmt.Errorf("bundling image: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func BuildCmd(ctx context.Context, imageRef, outputTarGZ string, archs []types.A
 	}
 
 	logrus.Infof(
-		"Final index tgz at: %s", outputTarGZ,
+		"Final image at: %s", outputTarOrLayoutDir,
 	)
 
 	return nil

--- a/pkg/build/oci/index.go
+++ b/pkg/build/oci/index.go
@@ -117,8 +117,8 @@ func generateIndexWithMediaType(mediaType ggcrtypes.MediaType, ic types.ImageCon
 	return digest, idx, err
 }
 
-// BuildIndex builds a self-contained tar.gz file containing the index and its individual images for all architectures.
-// Returns the digest and the path to the combined tar.gz.
+// BuildIndex builds a self-contained tar file containing the index and its individual images for all architectures.
+// Returns the digest.
 func BuildIndex(outfile string, idx oci.SignedImageIndex, tags []string, logger log.Logger) (name.Digest, error) {
 	tagsToImages := make(map[name.Tag]v1.Image)
 	var imgs = make([]oci.SignedImage, 0)
@@ -165,7 +165,7 @@ func BuildIndex(outfile string, idx oci.SignedImageIndex, tags []string, logger 
 		return name.Digest{}, err
 	}
 	if err := v1tar.MultiWrite(tagsToImages, f); err != nil {
-		return name.Digest{}, fmt.Errorf("failed to write index to tgz: %w", err)
+		return name.Digest{}, fmt.Errorf("failed to write index to tar: %w", err)
 	}
 
 	// to append to a tar archive, you need to find the last file in the archive


### PR DESCRIPTION
fixes #74 

I opted to overload the current output argument to detect if it's a directory, rather than adding a flag, since I'm not sure how we want the optional flag to interact with the required arg.