### PR TITLE
fix: tag-suffix not applied to package version stems

### DIFF
--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -47,10 +47,6 @@ func AdditionalTags(fsys fs.FS, opts options.Options) ([]string, error) {
 			opts.Log.Warnf("Version for package %s is empty", pkg.Name)
 			continue
 		}
-		if opts.TagSuffix != "" {
-			version += opts.TagSuffix
-		}
-		opts.Log.Debugf("Found version, images will be tagged with %s", version)
 
 		additionalTags, err := appendTag(opts, fmt.Sprintf("%s%s", opts.PackageVersionTagPrefix, version))
 		if err != nil {
@@ -64,6 +60,12 @@ func AdditionalTags(fsys fs.FS, opts options.Options) ([]string, error) {
 				return nil, err
 			}
 			additionalTags = append(additionalTags, stemmedTags...)
+		}
+
+		if opts.TagSuffix != "" {
+			for i, t := range additionalTags {
+				additionalTags[i] = t + opts.TagSuffix
+			}
 		}
 
 		opts.Log.Infof("Returning additional tags %v", additionalTags)

--- a/pkg/apk/apk_test.go
+++ b/pkg/apk/apk_test.go
@@ -45,10 +45,10 @@ V:10.45.6-r5
 A:bop
 
 `
-	if err := os.MkdirAll(filepath.Join(td, "lib/apk/db/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(td, "lib/apk/db/"), 0o755); err != nil {
 		require.Error(t, err, "mkdir all dirs failed")
 	}
-	if err := os.WriteFile(filepath.Join(td, "lib/apk/db/installed"), []byte(contents), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(td, "lib/apk/db/installed"), []byte(contents), 0o755); err != nil {
 		require.Error(t, err, "write file failed")
 	}
 	tests := []struct {
@@ -56,6 +56,7 @@ A:bop
 		packageVersionTag       string
 		packageVersionTagStem   bool
 		packageVersionTagPrefix string
+		tagSuffix               string
 		tags                    []string
 		expectedTags            []string
 	}{
@@ -64,7 +65,8 @@ A:bop
 			packageVersionTag: "go",
 			tags:              []string{"gcr.io/myimage/go:latest"},
 			expectedTags:      []string{"gcr.io/myimage/go:1.18"},
-		}, {
+		},
+		{
 			description:       "nginx has no version",
 			packageVersionTag: "nginx",
 			tags:              []string{"gcr.io/myimage/nginx:latest"},
@@ -76,6 +78,14 @@ A:bop
 			packageVersionTagStem: false,
 			tags:                  []string{"gcr.io/myimage/boop:latest"},
 			expectedTags:          []string{"gcr.io/myimage/boop:10.45.6-r5"},
+		},
+		{
+			description:           "tag with boop (suffixed)",
+			packageVersionTag:     "boop",
+			packageVersionTagStem: false,
+			tagSuffix:             "-boom",
+			tags:                  []string{"gcr.io/myimage/boop:latest"},
+			expectedTags:          []string{"gcr.io/myimage/boop:10.45.6-r5-boom"},
 		},
 		{
 			description:           "tag with boop (stemmed)",
@@ -102,6 +112,33 @@ A:bop
 				"gcr.io/myimage/boop:bam-10",
 			},
 		},
+		{
+			description:           "tag with boop (stemmed and suffixed)",
+			packageVersionTag:     "boop",
+			packageVersionTagStem: true,
+			tagSuffix:             "-boom",
+			tags:                  []string{"gcr.io/myimage/boop:latest"},
+			expectedTags: []string{
+				"gcr.io/myimage/boop:10.45.6-r5-boom",
+				"gcr.io/myimage/boop:10.45.6-boom",
+				"gcr.io/myimage/boop:10.45-boom",
+				"gcr.io/myimage/boop:10-boom",
+			},
+		},
+		{
+			description:             "tag with boop (stemmed, prefixed, and suffixed)",
+			packageVersionTag:       "boop",
+			packageVersionTagStem:   true,
+			packageVersionTagPrefix: "bam-",
+			tagSuffix:               "-boom",
+			tags:                    []string{"gcr.io/myimage/boop:latest"},
+			expectedTags: []string{
+				"gcr.io/myimage/boop:bam-10.45.6-r5-boom",
+				"gcr.io/myimage/boop:bam-10.45.6-boom",
+				"gcr.io/myimage/boop:bam-10.45-boom",
+				"gcr.io/myimage/boop:bam-10-boom",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(tt *testing.T) {
@@ -109,6 +146,7 @@ A:bop
 				PackageVersionTag:       test.packageVersionTag,
 				PackageVersionTagStem:   test.packageVersionTagStem,
 				PackageVersionTagPrefix: test.packageVersionTagPrefix,
+				TagSuffix:               test.tagSuffix,
 				Tags:                    test.tags,
 				WorkDir:                 td,
 				Log:                     &log.Adapter{Out: io.Discard},


### PR DESCRIPTION
Apply `--tag-suffix` to versions discovered through package-version-stemming (`--package-version-tag-stem true`).

`--tag-suffix string : suffix to use for automatically generated tags`

I am assuming that the `--tag-suffix` flag to `publish` is meant to apply to stemmed tags but the suffix is not being applied. It is only being applied to the full package version tag discovered via `--package-version-tag`.

Fix: apply suffix-tag to stemmed tagas. This is particularly useful with multiple flavors of a package. Consider a case of two variants of a ruby image, regular (no suffix) and `-dev`:

```console
$ apk publish --package-version-tag ruby-3.2 --package-version-tag-stem ./apko.yaml reg/ruby:latest
```
Would produce tags:
- `reg/ruby:3.2.2-r1`
- `reg/ruby:3.2.2`
- `reg/ruby:3.2`
- `reg/ruby:3`

And the `-dev` variant:
```console
$ apk publish --package-version-tag ruby-3.2 --package-version-tag-stem --tag-suffix "-dev" ./dev.apko.yaml reg/ruby:latest-dev
```
Would produce tags:
- `reg/ruby:3.2.2-r1-dev`
- `reg/ruby:3.2.2-r1`
- `reg/ruby:3.2`
- `reg/ruby:3`

This is not ideal because the -dev variant's tags such as `ruby:3` would overwrite the non-dev variant's tag.

With this patch all of the stemmed tags are suffixed, eg:

- `reg/ruby:3.2.2-r1-dev`
- `reg/ruby:3.2.2-dev`
- `reg/ruby:3.2-dev`
- `reg/ruby:3-dev`
