### PR TITLE
Remove WantSBOM and GenerateSBOM

### DIFF
--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -171,11 +171,6 @@ func ShowPackagesCmd(ctx context.Context, format string, archs []types.Architect
 			return err
 		}
 
-		// we do not generate SBOMs for each arch, only possibly for final image
-		bc.Options.SBOMFormats = []string{}
-		bc.Options.WantSBOM = false
-		bc.ImageConfiguration.Archs = archs
-
 		bc.Options.Arch = arch
 		bc.Options.WorkDir = wd
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -143,15 +143,6 @@ func (bc *Context) ImageLayoutToLayer(ctx context.Context) (string, v1.Layer, er
 		Hex:       hex.EncodeToString(digest.Sum(make([]byte, 0, digest.Size()))),
 	}
 
-	// generate SBOM
-	if bc.Options.WantSBOM {
-		if err := bc.GenerateSBOM(ctx, h); err != nil {
-			return "", nil, fmt.Errorf("generating SBOMs: %w", err)
-		}
-	} else {
-		bc.Logger().Debugf("Not generating SBOMs (WantSBOM = false)")
-	}
-
 	mt := v1types.OCILayer
 	if bc.Options.UseDockerMediaTypes {
 		mt = v1types.DockerLayer

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -163,42 +163,6 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 	return sboms, nil
 }
 
-// GenerateSBOM generates an SBOM for an apko layer
-func (bc *Context) GenerateSBOM(ctx context.Context, digest v1.Hash) error {
-	ctx, span := otel.Tracer("apko").Start(ctx, "GenerateSBOM")
-	defer span.End()
-
-	o := bc.Options
-	ic := bc.ImageConfiguration
-
-	if len(o.SBOMFormats) == 0 {
-		o.Logger().Warnf("skipping SBOM generation")
-		return nil
-	}
-
-	s := newSBOM(bc.fs, &o, &ic)
-
-	if err := s.SetLayerDigest(ctx, digest); err != nil {
-		return fmt.Errorf("reading layer tar: %w", err)
-	}
-
-	if err := s.ReadReleaseData(); err != nil {
-		return fmt.Errorf("getting os-release: %w", err)
-	}
-
-	if err := s.ReadPackageIndex(); err != nil {
-		return fmt.Errorf("getting installed packages from sbom: %w", err)
-	}
-
-	s.Options.ImageInfo.Arch = o.Arch
-
-	if _, err := s.Generate(); err != nil {
-		return fmt.Errorf("generating SBOMs: %w", err)
-	}
-
-	return nil
-}
-
 func (bc *Context) InstalledPackages() ([]*apkimpl.InstalledPackage, error) {
 	apk, err := chainguardAPK.NewWithOptions(bc.fs, bc.Options)
 	if err != nil {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -103,9 +103,6 @@ func WithSBOM(path string) Option {
 func WithSBOMFormats(formats []string) Option {
 	return func(bc *Context) error {
 		bc.Options.SBOMFormats = formats
-		if len(formats) > 0 {
-			bc.Options.WantSBOM = true
-		}
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -28,7 +28,6 @@ import (
 
 type Options struct {
 	UseDockerMediaTypes     bool               `json:"useDockerMediaTypes,omitempty"`
-	WantSBOM                bool               `json:"wantSBOM,omitempty"`
 	WithVCS                 bool               `json:"withVCS,omitempty"`
 	WorkDir                 string             `json:"workDir,omitempty"`
 	TarballPath             string             `json:"tarballPath,omitempty"`


### PR DESCRIPTION
This disables implicit SBOM generation and instead requires build.Context callers to explicitly call a method to generate an SBOM (which is what is already happening today).

WantSBOM is (seemingly) redundant with SBOMFormats.

GenerateSBOM got duplicated into GenerateImageSBOM.

The only place we could possibly be calling GenerateSBOM is in build-minirootfs, but because it doesn't set SBOMFormats, it doesn't get built.