### PR TITLE
Stop exposing build.Context fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	gitlab.alpinelinux.org/alpine/go v0.7.1-0.20230613043312-f696350aabb4
 	go.opentelemetry.io/otel v1.16.0
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.9.0
 	golang.org/x/term v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,8 @@ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
 golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -95,11 +95,13 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 		return err
 	}
 
-	if len(bc.ImageConfiguration.Archs) != 0 {
-		bc.Logger().Printf("WARNING: ignoring archs in config, only building for current arch (%s)", bc.Options.Arch)
+	ic := bc.ImageConfiguration()
+
+	if len(ic.Archs) != 0 {
+		bc.Logger().Printf("WARNING: ignoring archs in config, only building for current arch (%s)", bc.Arch())
 	}
 
-	bc.Logger().Printf("building minirootfs '%s'", bc.Options.TarballPath)
+	bc.Logger().Printf("building minirootfs '%s'", bc.TarballPath())
 
 	layerTarGZ, _, err := bc.BuildLayer(ctx)
 	if err != nil {

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -95,7 +95,7 @@ type Option func(*APK) error
 
 // Initialize sets the image in Context.WorkDir according to the image configuration,
 // and does everything short of installing the packages.
-func (a *APK) Initialize(ctx context.Context, ic *types.ImageConfiguration) error {
+func (a *APK) Initialize(ctx context.Context, ic types.ImageConfiguration) error {
 	// initialize apk
 	alpineVersions := parseOptionsFromRepositories(ic.Contents.Repositories)
 	if err := a.impl.InitDB(ctx, alpineVersions...); err != nil {


### PR DESCRIPTION
I'm not opposed to exposing fields like this in general, but reusing and mutating a build.Context externally has led to me breaking prod, so I'm making these private.