### PR TITLE
fix: assignment to nil map when using annotations via CLI flag

### DIFF
--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -191,6 +191,9 @@ func WithVCS(enable bool) Option {
 // Commandline annotations take precedence.
 func WithAnnotations(annotations map[string]string) Option {
 	return func(bc *Context) error {
+		if bc.ic.Annotations == nil {
+			bc.ic.Annotations = make(map[string]string)
+		}
 		for k, v := range annotations {
 			bc.ic.Annotations[k] = v
 		}


### PR DESCRIPTION
When using the `--annotations` flag on a config that does not already/also include an `annotations` YAML key the CLI will panic:
```
panic: assignment to entry in nil map

goroutine 1 [running]:
chainguard.dev/apko/internal/cli.buildCmd.func1.func11(0xc0001a8380)
	chainguard.dev/apko/pkg/build/options.go:195 +0xb3
chainguard.dev/apko/pkg/build.NewOptions({0xc000711880, 0x3f}, {0xc00079fca0, 0x10, 0x11f320e?})
	chainguard.dev/apko/pkg/build/build.go:186 +0x163
chainguard.dev/apko/internal/cli.buildImageComponents({0x21196d0, 0xc00019a018}, {0xc000711880, 0x3f}, {0x29acab0, 0x0, 0x0}, {0xc00079fca0, 0x10, 0x10})
	chainguard.dev/apko/internal/cli/build.go:185 +0x1e8
chainguard.dev/apko/internal/cli.BuildCmd({0x21196d0, 0xc00019a018}, {0x7ff7bfeff6d3, 0x2e}, {0x7ff7bfeff702, 0xf}, {0x29acab0, 0x0, 0x0}, {0xc00079fc80, ...}, ...)
	chainguard.dev/apko/internal/cli/build.go:156 +0x1b4
chainguard.dev/apko/internal/cli.buildCmd.func1(0xc0004f5200, {0xc0001c99d0, 0x3, 0x7?})
	chainguard.dev/apko/internal/cli/build.go:102 +0xbc5
github.com/spf13/cobra.(*Command).execute(0xc0004f5200, {0xc0001c9960, 0x7, 0x7})
	github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004f4c00)
	github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(0x1006459?)
	github.com/spf13/cobra@v1.7.0/command.go:992 +0x19
main.main()
	chainguard.dev/apko/main.go:24 +0x1e
make: *** [build/image.tar] Error 2
```