### PR TITLE
fix: incorrect arch tag equality detection

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -251,16 +251,18 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	// if the tags are not identical across arches, that is an error
 	allTagsMap := make(map[string]bool)
 	for arch, archTags := range tagsByArch {
+		tagSet := make(map[string]bool)
+		for _, tag := range archTags {
+			tagSet[tag] = true
+		}
 		if len(allTagsMap) == 0 {
-			for _, tag := range archTags {
-				allTagsMap[tag] = true
-			}
+			allTagsMap = tagSet
 			continue
 		}
-		if len(archTags) != len(allTagsMap) {
+		if len(tagSet) != len(allTagsMap) {
 			return fmt.Errorf("tags for arch %s are not identical to other arches", arch)
 		}
-		for _, tag := range archTags {
+		for tag := range tagSet {
 			if !allTagsMap[tag] {
 				return fmt.Errorf("tags for arch %s are not identical to other arches", arch)
 			}
@@ -297,7 +299,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	// If provided, this is the name of the file to write digest referenced into
 	if outputRefs != "" {
 		//nolint:gosec // Make image ref file readable by non-root
-		if err := os.WriteFile(outputRefs, []byte(strings.Join(builtReferences, "\n")+"\n"), 0666); err != nil {
+		if err := os.WriteFile(outputRefs, []byte(strings.Join(builtReferences, "\n")+"\n"), 0o666); err != nil {
 			return fmt.Errorf("failed to write digest: %w", err)
 		}
 	}
@@ -320,7 +322,7 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 		logger.Printf("Writing list of tags to %s (%d total)", stageTags, len(sortedUniqueTags))
 
 		//nolint:gosec // Make tags file readable by non-root
-		if err := os.WriteFile(stageTags, []byte(strings.Join(sortedUniqueTags, "\n")+"\n"), 0666); err != nil {
+		if err := os.WriteFile(stageTags, []byte(strings.Join(sortedUniqueTags, "\n")+"\n"), 0o666); err != nil {
 			return fmt.Errorf("failed to write tags: %w", err)
 		}
 	} else {


### PR DESCRIPTION
Given an `apko.yaml` such as the following:

```yaml
contents:
  keyring:
    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
  repositories:
    - https://packages.wolfi.dev/os
  packages:
    - ca-certificates-bundle
    - wolfi-base
    - wolfi-baselayout
    - tzdata
    - busybox
    - build-base
    - git
    - openssh
    - go-1.20

accounts:
  groups:
    - groupname: nonroot
      gid: 65532
  users:
    - username: nonroot
      uid: 65532
      gid: 65532
  run-as: 0

environment:
  GODEBUG: tarinsecurepath=0,zipinsecurepath=0

entrypoint:
  command: /usr/bin/go

cmd: help

archs:
  - x86_64
  - aarch64

annotations:
  "org.opencontainers.image.authors": "PlanetScale Infra https://planetscale.com/"
  "org.opencontainers.image.url": https://github.com/planetscale/wolfi-images/tree/main/images/go
  "org.opencontainers.image.source": https://github.com/planetscale/wolfi-images/tree/main/images/go
```

And a publish command:

```console
$ apko publish --debug --package-version-tag=go-1.20 --package-version-tag-stem ./apko.yaml localhost:5000/go:1.20

...
Error: tags for arch arm64 are not identical to other arches
```

This happens even if the tags are identical between the architectures because there will be duplicated tags in the `tagsByArch` map, eg:

```
tagsByArch: (map[types.Architecture][]string) (len=2) {
 (types.Architecture) (len=5) arm64: ([]string) (len=5 cap=8) {
  (string) (len=60) "localhost:5000/go:1.20",    # DUPE
  (string) (len=65) "localhost:5000/go:1.20.7-r1",
  (string) (len=62) "localhost:5000/go:1.20.7",
  (string) (len=60) "localhost:5000/go:1.20",    # DUPE
  (string) (len=57) "localhost:5000/go:1.
 },
 (types.Architecture) (len=5) amd64: ([]string) (len=5 cap=8) {
  (string) (len=60) "localhost:5000/go:1.20",    # DUPE
  (string) (len=65) "localhost:5000/go:1.20.7-r1",
  (string) (len=62) "localhost:5000/go:1.20.7",
  (string) (len=60) "localhost:5000/go:1.20",    # DUPE
  (string) (len=57) "localhost:5000/go:1.
 }
}
```

However the `allTagsMap` is a map and will not contain duplicated tags and so the comparison to the 2nd architecture in `tagsByArch` will fail the `if len(archTags) != len(allTagsMap)` check.

Fix this by tweaking the detection logic to convert each slice of tags into a set first so that duplicated tags are flattened.

I missed this while testing https://github.com/chainguard-dev/apko/pull/825 because I was using the `latest` tag on the publish command instead of using a tag that would be duplicated by stemming. But I have a use case where I do not want to use a tag like 'latest' and want to simply use the package base tag, eg: `1.20`, and also want to use stemming.
