### PR TITLE
fix: publish --stage-tags missing generated tags

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -302,8 +302,6 @@ func PublishCmd(ctx context.Context, outputRefs string, archs []types.Architectu
 	}
 
 	if !shouldPushTags {
-		allTags := tags
-		allTags = append(allTags, additionalTags...)
 		tmp := map[string]bool{}
 		for _, tag := range allTags {
 			if !strings.Contains(tag, ":") {


### PR DESCRIPTION
The `--stage-tags FILE` flag is only including the tags explicitly set as positional args to `apko publish`. Any tags generated by `--package-version-tag/stem` are not included.

The `additionalTags` slice is empty when this code is reached. Instead we can use the `allTags` slice generated just before this step instead of shadowing it. `allTags` includes a de-duped set of tags that includes both explicit tags from the command line and any generated/discovered tags that come from package-version and stemming.