### PR TITLE
remove build options

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -53,7 +53,6 @@ func buildCmd() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var extraPackages []string
-	var buildOptions []string
 	var logPolicy []string
 	var rawAnnotations []string
 	var cacheDir string
@@ -118,7 +117,6 @@ bill of materials) describing the image contents.
 				build.WithDebugLogging(debugEnabled),
 				build.WithVCS(withVCS),
 				build.WithAnnotations(annotations),
-				build.WithBuildOptions(buildOptions),
 				build.WithCacheDir(cacheDir),
 			)
 		},
@@ -135,7 +133,6 @@ bill of materials) describing the image contents.
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVar(&buildOptions, "build-option", []string{}, "build options to enable")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	_ = cmd.Flags().MarkDeprecated("build-option", "use --package-append instead")
 	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{}, "logging policy to use")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -57,7 +57,6 @@ func publish() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var extraPackages []string
-	var buildOptions []string
 	var rawAnnotations []string
 	var logPolicy []string
 	var debugEnabled bool
@@ -138,7 +137,6 @@ in a keychain.`,
 					build.WithDebugLogging(debugEnabled),
 					build.WithVCS(withVCS),
 					build.WithAnnotations(annotations),
-					build.WithBuildOptions(buildOptions),
 					build.WithCacheDir(cacheDir),
 				},
 				[]PublishOption{
@@ -170,7 +168,6 @@ in a keychain.`,
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVar(&buildOptions, "build-option", []string{}, "build options to enable")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	_ = cmd.Flags().MarkDeprecated("build-option", "use --package-append instead")
 	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{}, "logging policy to use")

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -205,19 +205,3 @@ func WithCacheDir(cacheDir string) Option {
 		return nil
 	}
 }
-
-// WithBuildOptions applies configured patches which have been requested to the ImageConfiguration.
-// Deprecated: Use WithExtraPackages.
-func WithBuildOptions(buildOptions []string) Option {
-	return func(bc *Context) error {
-		for _, opt := range buildOptions {
-			if bo, ok := bc.ic.Options[opt]; ok { //nolint:staticcheck
-				if err := bo.Apply(&bc.ic); err != nil {
-					return err
-				}
-			}
-		}
-
-		return nil
-	}
-}


### PR DESCRIPTION
Build options were only ever used to control appending packages to the list, and multiple options were never used. The functionality was deprecated in https://github.com/chainguard-dev/apko/pull/703 with the introduction of `--package-append` (`extra_packages` in TF-apko)

The PR was merged May 30, released in 0.9 June 30, and build options have been deprecated for two releases now.