### PR TITLE
Pass a whole fs instead of a workdir to build

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"runtime"
 
+	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/spf13/cobra"
 
 	"chainguard.dev/apko/pkg/build"
@@ -86,7 +87,8 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 	}
 	defer os.RemoveAll(wd)
 
-	bc, err := build.New(ctx, wd, opts...)
+	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+	bc, err := build.New(ctx, fs, opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -62,7 +63,9 @@ func ShowConfigCmd(ctx context.Context, opts ...build.Option) error {
 	}
 	defer os.RemoveAll(wd)
 
-	bc, err := build.New(ctx, wd, opts...)
+	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+
+	bc, err := build.New(ctx, fs, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -176,11 +176,10 @@ func (bc *Context) runAssertions() error {
 }
 
 // NewOptions evaluates the build.Options in the same way as New().
-func NewOptions(workDir string, opts ...Option) (*options.Options, *types.ImageConfiguration, error) {
+func NewOptions(opts ...Option) (*options.Options, *types.ImageConfiguration, error) {
 	bc := Context{
 		o: options.Default,
 	}
-	bc.o.WorkDir = workDir
 
 	for _, opt := range opts {
 		if err := opt(&bc); err != nil {
@@ -194,13 +193,11 @@ func NewOptions(workDir string, opts ...Option) (*options.Options, *types.ImageC
 // New creates a build context.
 // The SOURCE_DATE_EPOCH env variable is supported and will
 // overwrite the provided timestamp if present.
-func New(ctx context.Context, workDir string, opts ...Option) (*Context, error) {
-	fs := apkfs.DirFS(workDir, apkfs.WithCreateDir())
+func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error) {
 	bc := Context{
 		o:  options.Default,
 		fs: fs,
 	}
-	bc.o.WorkDir = workDir
 
 	for _, opt := range opts {
 		if err := opt(&bc); err != nil {
@@ -268,7 +265,6 @@ func New(ctx context.Context, workDir string, opts ...Option) (*Context, error) 
 		return nil, fmt.Errorf("failed to validate configuration: %w", err)
 	}
 
-	bc.Logger().Infof("building apk info in %s", bc.o.WorkDir)
 	if err := bc.initializeApk(ctx); err != nil {
 		return nil, fmt.Errorf("initializing apk: %w", err)
 	}

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -156,7 +156,7 @@ func (bc *Context) buildImage(ctx context.Context) error {
 		return err
 	}
 
-	bc.Logger().Infof("finished building filesystem in %s", bc.o.WorkDir)
+	bc.Logger().Infof("finished building filesystem")
 
 	return nil
 }
@@ -181,7 +181,7 @@ func (bc *Context) BuildPackageList(ctx context.Context) (toInstall []*repositor
 	if toInstall, conflicts, err = bc.apk.ResolveWorld(ctx); err != nil {
 		return toInstall, conflicts, fmt.Errorf("resolving apk packages: %w", err)
 	}
-	bc.Logger().Infof("finished gathering apk info in %s", bc.o.WorkDir)
+	bc.Logger().Infof("finished gathering apk info")
 
 	return toInstall, conflicts, err
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,6 @@ import (
 type Options struct {
 	UseDockerMediaTypes     bool               `json:"useDockerMediaTypes,omitempty"`
 	WithVCS                 bool               `json:"withVCS,omitempty"`
-	WorkDir                 string             `json:"workDir,omitempty"`
 	TarballPath             string             `json:"tarballPath,omitempty"`
 	Tags                    []string           `json:"tags,omitempty"`
 	SourceDateEpoch         time.Time          `json:"sourceDateEpoch,omitempty"`


### PR DESCRIPTION
This makes it possible to use a different (forthcoming) FullFS implementation instead of assuming we're writing to a local directory.

This is breaking, but it's a straightforward fix (just construct the dirfs as per the rest of the PR).

Some logs are different, but that's arguably a good thing.