### PR TITLE
Plumb --offline flag

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -57,6 +57,7 @@ func buildCmd() *cobra.Command {
 	var logPolicy []string
 	var rawAnnotations []string
 	var cacheDir string
+	var offline bool
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -118,7 +119,7 @@ bill of materials) describing the image contents.
 				build.WithDebugLogging(debugEnabled),
 				build.WithVCS(withVCS),
 				build.WithAnnotations(annotations),
-				build.WithCacheDir(cacheDir),
+				build.WithCacheDir(cacheDir, offline),
 			)
 		},
 	}
@@ -139,6 +140,7 @@ bill of materials) describing the image contents.
 	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{}, "logging policy to use")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
+	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 
 	return cmd
 }

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -67,6 +67,7 @@ func publish() *cobra.Command {
 	var local bool
 	var stageTags string
 	var cacheDir string
+	var offline bool
 
 	cmd := &cobra.Command{
 		Use:   "publish",
@@ -139,7 +140,7 @@ in a keychain.`,
 					build.WithDebugLogging(debugEnabled),
 					build.WithVCS(withVCS),
 					build.WithAnnotations(annotations),
-					build.WithCacheDir(cacheDir),
+					build.WithCacheDir(cacheDir, offline),
 				},
 				[]PublishOption{
 					// these are extra here just for publish; everything before is the same for BuildCmd as PublishCmd
@@ -175,6 +176,7 @@ in a keychain.`,
 	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{}, "logging policy to use")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
+	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 
 	// these are extra here just for publish; everything before is the same for BuildCmd as PublishCmd
 	cmd.Flags().StringVar(&packageVersionTag, "package-version-tag", "", "Tag the final image with the version of the package passed in")

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -246,9 +246,9 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 	// note that this is not easy to do in a switch statement, because of the second
 	// condition, if err := ...; err == nil {}
 	if bc.o.CacheDir != "" {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, false))
+		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline))
 	} else if _, err := os.UserCacheDir(); err == nil {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, false))
+		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline))
 	} else {
 		bc.Logger().Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -202,9 +202,10 @@ func WithAnnotations(annotations map[string]string) Option {
 }
 
 // WithCacheDir set the cache directory to use
-func WithCacheDir(cacheDir string) Option {
+func WithCacheDir(cacheDir string, offline bool) Option {
 	return func(bc *Context) error {
 		bc.o.CacheDir = cacheDir
+		bc.o.Offline = offline
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	Local                   bool               `json:"local,omitempty"`
 	StageTags               string             `json:"stageTags,omitempty"`
 	CacheDir                string             `json:"cacheDir,omitempty"`
+	Offline                 bool               `json:"offline,omitempty"`
 
 	Log log.Logger
 }


### PR DESCRIPTION
Using this flag will avoid the network and only use what is available in the cache.

Fixes https://github.com/chainguard-dev/apko/issues/854