### PR TITLE
add overlay-file path mutation

### DIFF
--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -191,7 +191,7 @@ will set the environment variable named "FOO" to the value "bar".
 ### Paths
 
 `paths` defines filesystem operations that can be applied to the image. This includes
-setting permissions on files or directories as well as creating empty files, directories and links.
+setting permissions on files or directories as well as creating empty files, directories, links and copy configuration files.
 
 The `paths` element contains the following children:
 
@@ -199,6 +199,7 @@ The `paths` element contains the following children:
  - `type`: The type of file operation to perform. This can be:
    - `directory`: create an empty directory at the path
    - `empty-file`: create an empty file at the path
+   - `overlay-file`: add file at the path, copied from specified in host `source`
    - `hardlink`: create a hardlink (`ln`) at the path, linking to the value specified in `source`
    - `symlink`: create a symbolic link (`ln -s`) at the path, linking to the value specified in
      `source`
@@ -206,7 +207,7 @@ The `paths` element contains the following children:
  - `uid`: UID to associate with the file
  - `gid`: GID to associate with the file
  - `permissions`: file permissions to set. Permissions should be specified in octal e.g. 0o755 (see `man chmod` for details).
- - `source`: used in `hardlink` and `symlink`, this represents the path to link to.
+ - `source`: used in `hardlink` and `symlink`, this represents the path to link to. In `overlay-file` is used for specify the host path to copy.
 
 
 ### Includes

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -36,6 +36,12 @@ paths:
     uid: 10000
     gid: 10000
     permissions: 0o644
+  - path: /var/lib/nginx/html/index.html
+    source: nginx/my-index.html
+    type: overlay-file
+    uid: 10000
+    gid: 10000
+    permissions: 0o644
 
 work-dir: /usr/share/nginx
 

--- a/examples/nginx/my-index.html
+++ b/examples/nginx/my-index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to my custom nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to my custom nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -45,7 +45,7 @@ type PathMutation struct {
 	Path string
 	// The type of mutation to perform
 	//
-	// This can be one of: directory, empty-file, hardlink, symlink, permissions
+	// This can be one of: directory, empty-file, overlay-file, hardlink, symlink, permissions
 	Type string
 	// The mutation's desired user ID
 	UID uint32


### PR DESCRIPTION
`overlay-file` path mutation allows add files to images.

- Some times we need to copy scripts or files inside images to use in CI.
- Exclude ELF files, because these must be provisioned by apks.