### PR TITLE
Don't buffer everything

### DIFF
--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -411,7 +411,8 @@ func (m *memFS) openFile(name string, flag int, perm fs.FileMode, linkCount int)
 		}
 
 		// For read-only opens, we just defer to the tarfs.
-		if flag&os.O_RDONLY != 0 {
+		write := flag&os.O_APPEND != 0 || flag&os.O_RDWR != 0 || flag&os.O_WRONLY != 0
+		if !write {
 			mf := newMemFile(anode, name, m, flag)
 
 			// rc gets used in Read() if it's set


### PR DESCRIPTION
I'm a fool and assumed that os.O_RDONLY worked very differently.