### PR TITLE
Drop dependency on deleted packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220920003936-cd2dbcbbab49
-	github.com/chainguard-dev/go-apk v0.0.0-20230830232041-24f27d33fced
+	github.com/chainguard-dev/go-apk v0.0.0-20230905210805-b6ab4d3019de
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-git/go-git/v5 v5.6.1

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220920003936-
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/chainguard-dev/go-apk v0.0.0-20230830232041-24f27d33fced h1:3FPKsvRFzRwDJ58Gbxt7Cjiz8eec4rtlf4uEsBqX/LA=
-github.com/chainguard-dev/go-apk v0.0.0-20230830232041-24f27d33fced/go.mod h1:I7uFl3LBMG1UQONJRQN+3lzZE4tw8myh87FzkDEztHg=
+github.com/chainguard-dev/go-apk v0.0.0-20230905210805-b6ab4d3019de h1:H5BaInXUXayEUej/xyFbCKeNinojtTLa2tSA3fyeGPU=
+github.com/chainguard-dev/go-apk v0.0.0-20230905210805-b6ab4d3019de/go.mod h1:I7uFl3LBMG1UQONJRQN+3lzZE4tw8myh87FzkDEztHg=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08 h1:9Qh4lJ/KMr5iS1zfZ8I97+3MDpiKjl+0lZVUNBhdvRs=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20220327082430-c57b701bfc08/go.mod h1:MAuu1uDJNOS3T3ui0qmKdPUwm59+bO19BbTph2wZafE=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -26,7 +26,7 @@ import (
 
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	purl "github.com/package-url/packageurl-go"
-	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 	"sigs.k8s.io/release-utils/version"
 
 	"chainguard.dev/apko/pkg/sbom/options"

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -24,7 +24,7 @@ import (
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 	"sigs.k8s.io/release-utils/command"
 
 	"chainguard.dev/apko/pkg/sbom/options"

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -26,7 +26,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	purl "github.com/package-url/packageurl-go"
-	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 
 	"chainguard.dev/apko/pkg/build/types"
 )

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	osr "github.com/dominodatalab/os-release"
-	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 
 	"chainguard.dev/apko/pkg/sbom/options"
 )

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
-	"gitlab.alpinelinux.org/alpine/go/pkg/repository"
+	"gitlab.alpinelinux.org/alpine/go/repository"
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
This is confusing go's module resolution for some reason. These were recently deleted upstream.

https://gitlab.alpinelinux.org/alpine/go/-/commit/c77a506e8657a0209c6e187f50bdd5af57abb646