### PR TITLE
Add apko dot command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,10 @@ require (
 	github.com/package-url/packageurl-go v0.1.1
 	github.com/sigstore/cosign/v2 v2.2.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0
 	gitlab.alpinelinux.org/alpine/go v0.8.0
 	go.opentelemetry.io/otel v1.18.0
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.2.0 h1:h9r9cf0+u7wSE+M183ZtMGgOJKiL96brpaz5ekfJCpM=
 github.com/skeema/knownhosts v1.2.0/go.mod h1:g4fPeYpque7P0xefxtGzV81ihjC8sX2IqpAoNkjxbMo=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
@@ -409,6 +411,8 @@ github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
+github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0 h1:hwIpbdjckSFqmZ6hod7WZgGR7tVVrSUzZrBfNZl7AOg=
+github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0/go.mod h1:DV83s9TfD0rgoKcqvDmM+aYdz6BXmTkquwd+bI/8tlo=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -50,6 +50,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(showConfig())
 	cmd.AddCommand(publish())
 	cmd.AddCommand(showPackages())
+	cmd.AddCommand(dotcmd())
 	cmd.AddCommand(version.Version())
 
 	cmd.PersistentFlags().StringVarP(&workDir, "workdir", "C", cwd, "working dir (default is current dir where executed)")

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -1,0 +1,317 @@
+// Copyright 2022, 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+	"github.com/tmc/dot"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+
+	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+func dotcmd() *cobra.Command {
+	var extraKeys []string
+	var extraRepos []string
+	var archstrs []string
+	var web, span bool
+
+	cmd := &cobra.Command{
+		Use:   "dot",
+		Short: "Output a digraph showing the resolved dependencies of an apko config.",
+		Long: `Output a digraph showing the resolved dependencies of an apko config.
+
+# Render an svg of example.yaml
+apko dot example.yaml | dot -Tvsg > graph.svg
+
+# Open browser to explore example.yaml
+apko dot --web example.yaml
+
+# Open browser to explore example.yaml, rendering a (almost) minimum spanning tree
+apko dot --web -S example.yaml
+`,
+		Example: `  apko show-packages <config.yaml>`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			archs := types.ParseArchitectures(archstrs)
+			return DotCmd(cmd.Context(), args[0], archs, web, span,
+				build.WithConfig(args[0]),
+				build.WithExtraKeys(extraKeys),
+				build.WithExtraRepos(extraRepos),
+			)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
+	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
+	cmd.Flags().BoolVarP(&span, "spanning-tree", "S", false, "does something like a spanning tree to avoid a huge number of edges")
+	cmd.Flags().BoolVar(&web, "web", false, "launch a browser")
+
+	return cmd
+}
+
+func DotCmd(ctx context.Context, configFile string, archs []types.Architecture, web, span bool, opts ...build.Option) error {
+	wd, err := os.MkdirTemp("", "apko-*")
+	if err != nil {
+		return fmt.Errorf("failed to create working directory: %w", err)
+	}
+	defer os.RemoveAll(wd)
+
+	o, ic, err := build.NewOptions(opts...)
+	if err != nil {
+		return err
+	}
+
+	// cases:
+	// - archs set: use those archs
+	// - archs not set, bc.ImageConfiguration.Archs set: use Config archs
+	// - archs not set, bc.ImageConfiguration.Archs not set: use all archs
+	switch {
+	case len(archs) != 0:
+		ic.Archs = archs
+	case len(ic.Archs) != 0:
+		// do nothing
+	default:
+		ic.Archs = types.AllArchs
+	}
+	// save the final set we will build
+	archs = ic.Archs
+	o.Logger().Infof("Determining packages for %d architectures: %+v", len(ic.Archs), ic.Archs)
+
+	// The build context options is sometimes copied in the next functions. Ensure
+	// we have the directory defined and created by invoking the function early.
+	defer os.RemoveAll(o.TempDir())
+
+	// TODO: Perhaps we want to support multiple architectures?
+	arch := archs[0]
+
+	// working directory for this architecture
+	wd = filepath.Join(wd, arch.ToAPK())
+	bopts := slices.Clone(opts)
+	bopts = append(bopts, build.WithArch(arch))
+	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+	bc, err := build.New(ctx, fs, bopts...)
+	if err != nil {
+		return err
+	}
+	bc.Logger().Infof("using working directory %s", wd)
+
+	pkgs, _, err := bc.BuildPackageList(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get package list for image: %w", err)
+	}
+
+	dmap := map[string][]string{}
+	pmap := map[string][]string{}
+
+	for _, pkg := range pkgs {
+		dmap[pkg.Name] = pkg.Dependencies
+		pmap[pkg.Name] = pkg.Provides
+	}
+
+	args := []string{}
+
+	render := func(args []string) *dot.Graph {
+		edges := map[string]struct{}{}
+		deps := map[string]struct{}{}
+
+		out := dot.NewGraph("images")
+		if err := out.Set("rankdir", "LR"); err != nil {
+			panic(err)
+		}
+		out.SetType(dot.DIGRAPH)
+
+		file := dot.NewNode(configFile)
+		out.AddNode(file)
+
+		for _, pkg := range ic.Contents.Packages {
+			n := dot.NewNode(pkg)
+			out.AddNode(n)
+			out.AddEdge(dot.NewEdge(file, n))
+			deps[pkg] = struct{}{}
+		}
+
+		renderDeps := func(pkg string) {
+			n := dot.NewNode(pkg)
+			if web {
+				if err := n.Set("URL", link(args, pkg)); err != nil {
+					panic(err)
+				}
+			}
+			out.AddNode(n)
+
+			for _, dep := range dmap[pkg] {
+				d := dot.NewNode(dep)
+				if web {
+					if !strings.Contains(dep, ":") {
+						if err := d.Set("URL", link(args, dep)); err != nil {
+							panic(err)
+						}
+					}
+				}
+				out.AddNode(d)
+				if _, ok := edges[dep]; !ok || !span {
+					// This check is stupid but otherwise cycles render dumb.
+					if pkg != dep {
+						out.AddEdge(dot.NewEdge(n, d))
+						edges[dep] = struct{}{}
+					}
+				}
+				deps[dep] = struct{}{}
+			}
+		}
+
+		done := map[string]struct{}{}
+		for _, pkg := range args {
+			renderDeps(pkg)
+			done[pkg] = struct{}{}
+		}
+
+		for _, pkg := range pkgs {
+			if _, ok := done[pkg.Name]; ok {
+				continue
+			}
+			renderDeps(pkg.Name)
+		}
+
+		renderProvs := func(pkg string) {
+			n := dot.NewNode(pkg)
+			out.AddNode(n)
+
+			for _, prov := range pmap[pkg] {
+				if _, ok := deps[prov]; !ok {
+					if before, _, ok := strings.Cut(prov, "="); ok {
+						if _, ok := deps[before]; ok {
+							p := dot.NewNode(before)
+							if err := p.Set("shape", "rect"); err != nil {
+								panic(err)
+							}
+							out.AddNode(p)
+
+							out.AddEdge(dot.NewEdge(p, n))
+						}
+						continue
+					} else {
+						continue
+					}
+				}
+				p := dot.NewNode(prov)
+				out.AddNode(p)
+				if _, ok := edges[pkg]; !ok || !span {
+					out.AddEdge(dot.NewEdge(p, n))
+					edges[pkg] = struct{}{}
+				}
+			}
+		}
+
+		done = map[string]struct{}{}
+		for _, pkg := range args {
+			renderProvs(pkg)
+			done[pkg] = struct{}{}
+		}
+
+		for _, pkg := range pkgs {
+			if _, ok := done[pkg.Name]; ok {
+				continue
+			}
+			renderProvs(pkg.Name)
+		}
+
+		return out
+	}
+
+	if web {
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/" {
+				return
+			}
+			nodes := r.URL.Query()["node"]
+
+			if len(nodes) == 0 {
+				nodes = args
+			}
+
+			out := render(nodes)
+
+			log.Printf("%s: rendering %v", r.URL, nodes)
+			cmd := exec.Command("dot", "-Tsvg")
+			cmd.Stdin = strings.NewReader(out.String())
+			cmd.Stdout = w
+
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(w, "error rendering %v: %v", nodes, err)
+				log.Fatal(err)
+			}
+		})
+
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return err
+		}
+
+		server := &http.Server{
+			Addr:              l.Addr().String(),
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+
+		log.Printf("%s", l.Addr().String())
+
+		var g errgroup.Group
+		g.Go(func() error {
+			return server.Serve(l)
+		})
+
+		g.Go(func() error {
+			return open.Run(fmt.Sprintf("http://localhost:%d", l.Addr().(*net.TCPAddr).Port))
+		})
+
+		return g.Wait()
+	}
+
+	out := render(args)
+
+	fmt.Println(out.String())
+	return nil
+}
+
+func link(args []string, pkg string) string {
+	filtered := []string{}
+	for _, a := range args {
+		if a != pkg {
+			filtered = append(filtered, a)
+		}
+	}
+	ret := "/?node=" + pkg
+	if len(filtered) > 0 {
+		ret += "&node=" + strings.Join(filtered, "&node=")
+	}
+	return ret
+}


### PR DESCRIPTION
This is not 100% great because it relies on some pretty naive heuristics to figure out the dependency graph; however, it does produce some pretty useful graphs without touching any existing go-apk or apko code paths, so I think it's a reasonable place to start.

Ideally, we would have ResolveWorld (or something like it) return a graph with metadata about why things resolved the way they did, but that's a more invasive change.

As is, this is great for understanding what packages would get pulled in by apko and what they depend on and/or provide.