### PR TITLE
ensure propagated logger is used

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -67,6 +67,9 @@ func (o *Options) Summarize(logger log.Logger) {
 }
 
 func (o *Options) Logger() log.Logger {
+	if o.Log != nil {
+		return o.Log
+	}
 	fields := log.Fields{}
 	emptyArch := types.Architecture("")
 


### PR DESCRIPTION
we were correctly [passing](https://github.com/chainguard-dev/apko/blob/29bca7ce2b8f67909055ee5b9995ae231ee998d7/internal/cli/build.go#L109) and [setting](https://github.com/chainguard-dev/apko/blob/29bca7ce2b8f67909055ee5b9995ae231ee998d7/pkg/build/options.go#L165) any loggers to new builders, but we weren't actually using it because of how `(*Options).Logger()` was being used.