### PR TITLE
Remove Trailing `/` from the repository path

### DIFF
--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jinzhu/copier"
 	"gopkg.in/yaml.v3"
@@ -85,6 +86,13 @@ func (ic *ImageConfiguration) parse(configData []byte, logger log.Logger) error 
 		pkgs = append(pkgs, mergedIc.Contents.Packages...)
 		ic.Contents.Packages = pkgs
 	}
+
+	repos := make([]string, 0, len(ic.Contents.Repositories))
+	for _, repo := range ic.Contents.Repositories {
+		repo = strings.TrimRight(repo, "/")
+		repos = append(repos, repo)
+	}
+	ic.Contents.Repositories = repos
 
 	return nil
 }


### PR DESCRIPTION
Fix #667

For me the error message was really clear Saying 
```bash
Error: failed to build layer image for "amd64": installing apk packages: error getting package dependencies: error getting repository indexes: repository index not found for architecture x86_64 at https://packages.wolfi.dev/os//x86_64/APKINDEX.tar.gz
2023/10/01 17:40:30 error during command execution: failed to build layer image for "amd64": installing apk packages: error getting package dependencies: error getting repository indexes: repository index not found for architecture x86_64 at https://packages.wolfi.dev/os//x86_64/APKINDEX.tar.gz
```

And yes, This is an easy mistake to make when adding custom package repos.
> This issue did not exist in previous versions of apko (roughly March-April), so is a regression that could unexpectedly break existing YAML files.

I am not sure about that but Here is the PR that removes Trailing `/` from the repository path