### PR TITLE
Bug Fix: calling the function in `show-config` cmd

### DIFF
--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -73,7 +73,7 @@ func ShowConfigCmd(ctx context.Context, opts ...build.Option) error {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 
-	if err := enc.Encode(bc.ImageConfiguration); err != nil {
+	if err := enc.Encode(bc.ImageConfiguration()); err != nil {
 		return fmt.Errorf("failed to encode YAML document: %w", err)
 	}
 


### PR DESCRIPTION
Looks like we have some missing parenthesis here😅 and never calling the function. 