### PR TITLE
streamline release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ name: Create Release
 
 on:
   push:
-    branches:
-    - main
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
@@ -25,12 +23,10 @@ jobs:
       contents: write
 
     steps:
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v2.2.0
       with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-
-    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        go-version-file: 'go.mod'
 
     - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
@@ -43,87 +39,3 @@ jobs:
       run: make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  ko-build:
-    name: Release apko image
-    runs-on: ubuntu-latest
-
-    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
-    permissions:
-      id-token: write
-      packages: write
-      contents: read
-
-    env:
-      KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
-      COSIGN_YES: "true"
-
-    steps:
-    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v2.2.0
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-
-    - uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.4
-
-    - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
-
-    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
-    - name: Login to registry
-      run: |
-        echo ${{ github.token }} | go run ./ login ghcr.io --username=${{ github.repository_owner }} --password-stdin
-
-    - name: Publish/Sign apko image
-      run: |
-        # If not a tagged release, override image tag to "canary"
-        export IMAGE_TAG=${GITHUB_REF#refs/tags/}
-        if [[ $GITHUB_REF != refs/tags/* ]]; then
-          export IMAGE_TAG=canary
-        fi
-        make sign-image
-
-  tekton-task:
-    # Only release the Tekton Task after a CLI release has been created, since
-    # goreleaser creates a GitHub Release which the Tekton Task will be
-    # attached to.
-    needs: cli
-
-    name: Release the Tekton Task
-    runs-on: ubuntu-latest
-
-    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
-    steps:
-    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v2.2.0
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-
-    - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-
-    - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
-
-    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
-    - name: Login to registry
-      run: |
-        echo ${{ github.token }} | go run ./ login ghcr.io --username=${{ github.repository_owner }} --password-stdin
-
-    - name: Generate Tekton Task
-      run: |
-        # If not a tagged release, override image tag to "canary"
-        export IMAGE_TAG=${GITHUB_REF#refs/tags/}
-        if [[ $GITHUB_REF != refs/tags/* ]]; then
-          export IMAGE_TAG=canary
-        fi
-        make ko-resolve
-
-    - name: Attach to release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${GITHUB_REF#refs/tags/} task.yaml

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Chainguard, Inc.
+# Copyright 2023 Chainguard, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 baseImageOverrides:
-  # This self-hosts our own Alpine base image.
-  chainguard.dev/apko: cgr.dev/chainguard/alpine-base
+  chainguard.dev/apko: cgr.dev/chainguard/wolfi-base
 
 builds:
 - id: apko

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,7 @@ LDFLAGS=-buildid= -X $(PKG).gitVersion=$(GIT_VERSION) \
         -X $(PKG).gitTreeState=$(GIT_TREESTATE) \
         -X $(PKG).buildDate=$(BUILD_DATE)
 
-KO_DOCKER_REPO ?= ghcr.io/chainguard-dev/apko
 DIGEST ?=
-
-
-KOCACHE_PATH=/tmp/ko
 
 define create_kocache_path
   mkdir -p $(KOCACHE_PATH)


### PR DESCRIPTION
- remove image building from release process, we recommend cgr.dev/chainguard/apko instead
- don't build Tekton task, nobody uses it AFAIK
- since release.yaml only builds the CLI and only on v-tags, only trigger the workflow on new v-tags
- when building with `ko`, base on `wolfi-base` instead of defunct `alpine-base`

Folks can still use `ko` to build the image locally, but we don't need another apko image to confuse folks/ourselves with.