### PR TITLE
Update NEWS.md for 0.11.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Changes from 0.11.0 to 0.11.1
+
+* Add JSON tags to ImageConfiguration types: https://github.com/chainguard-dev/apko/pull/933
+
+* Pass UID and GID mapping to the tarball writer: https://github.com/chainguard-dev/apko/pull/932
+
+Full diff: https://github.com/chainguard-dev/apko/compare/v0.11.0..v0.11.1
+
 # Changes from 0.10.0 to 0.11.0
 
 * Improve error messages when modifying paths.


### PR DESCRIPTION
We should cut a release to facilitate a fix for chainguard-dev/melange#501 in downstream providers.