### PR TITLE
cleanup: remove unused flags

### DIFF
--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -3,63 +3,18 @@ package cli
 import "chainguard.dev/apko/pkg/log"
 
 type publishOpt struct {
-	packageVersionTag       string
-	packageVersionTagStem   bool
-	packageVersionTagPrefix string
-	tagSuffix               string
-	local                   bool
-	stageTags               string
-	tags                    []string
-	logger                  log.Logger
+	local  bool
+	tags   []string
+	logger log.Logger
 }
 
 // PublishOption is an option for publishing
 type PublishOption func(*publishOpt) error
 
-// WithPackageVersionTag sets a tag to use, e.g. `glibc-2.31`.
-func WithPackageVersionTag(pvt string) PublishOption {
-	return func(p *publishOpt) error {
-		p.packageVersionTag = pvt
-		return nil
-	}
-}
-
-// WithPackageVersionTagStem sets whether to use the package version tag stem, e.g. `glibc`.
-func WithPackageVersionTagStem(packageVersionTagStem bool) PublishOption {
-	return func(p *publishOpt) error {
-		p.packageVersionTagStem = packageVersionTagStem
-		return nil
-	}
-}
-
-// WithPackageVersionTagPrefix sets a tag prefix to use, e.g. `glibc-`.
-func WithPackageVersionTagPrefix(packageVersionTagPrefix string) PublishOption {
-	return func(p *publishOpt) error {
-		p.packageVersionTagPrefix = packageVersionTagPrefix
-		return nil
-	}
-}
-
-// WithTagSuffix sets a tag suffix to use, e.g. `-glibc`.
-func WithTagSuffix(tagSuffix string) PublishOption {
-	return func(p *publishOpt) error {
-		p.tagSuffix = tagSuffix
-		return nil
-	}
-}
-
 // WithLocal sets whether to publish image to local Docker daemon.
 func WithLocal(local bool) PublishOption {
 	return func(p *publishOpt) error {
 		p.local = local
-		return nil
-	}
-}
-
-// WithStageTags prevents tagging, and innstead writes all tags to the filename provided.
-func WithStageTags(stageTags string) PublishOption {
-	return func(p *publishOpt) error {
-		p.stageTags = stageTags
 		return nil
 	}
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -143,17 +143,12 @@ func (bc *Context) ImageLayoutToLayer(ctx context.Context) (string, v1.Layer, er
 		Hex:       hex.EncodeToString(digest.Sum(make([]byte, 0, digest.Size()))),
 	}
 
-	mt := v1types.OCILayer
-	if bc.o.UseDockerMediaTypes {
-		mt = v1types.DockerLayer
-	}
-
 	l := &layer{
 		filename: layerTarGZ,
 		desc: &v1.Descriptor{
 			Digest:    h,
 			Size:      size,
-			MediaType: mt,
+			MediaType: v1types.OCILayer,
 		},
 		diffid: &v1.Hash{
 			Algorithm: "sha256",

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -129,12 +129,10 @@ func (bc *Context) buildImage(ctx context.Context) error {
 		return fmt.Errorf("failed to mutate paths: %w", err)
 	}
 
-	if err := GenerateOSRelease(bc.fs, &bc.o, &bc.ic); err != nil {
-		if errors.Is(err, ErrOSReleaseAlreadyPresent) {
-			bc.Logger().Warnf("did not generate /etc/os-release: %v", err)
-		} else {
-			return fmt.Errorf("failed to generate /etc/os-release: %w", err)
-		}
+	if err := generateOSRelease(bc.fs, &bc.o, &bc.ic); errors.Is(err, ErrOSReleaseAlreadyPresent) {
+		bc.Logger().Infof("did not generate /etc/os-release: %v", err)
+	} else if err != nil {
+		return fmt.Errorf("failed to generate /etc/os-release: %w", err)
 	}
 
 	if err := bc.s6.WriteSupervisionTree(bc.ic.Entrypoint.Services); err != nil {

--- a/pkg/build/oci/publish.go
+++ b/pkg/build/oci/publish.go
@@ -128,7 +128,7 @@ func LoadImage(ctx context.Context, image oci.SignedImage, logger log.Logger, ta
 // Note that docker, when provided with a multi-architecture index, will load just the image inside for the provided
 // platform, defaulting to the one on which the docker daemon is running.
 // PublishIndex will determine that platform and use it to publish the updated index.
-func PublishIndex(ctx context.Context, idx oci.SignedImageIndex, logger log.Logger, shouldPushTags bool, tags []string, remoteOpts ...remote.Option) (name.Digest, error) {
+func PublishIndex(ctx context.Context, idx oci.SignedImageIndex, logger log.Logger, tags []string, remoteOpts ...remote.Option) (name.Digest, error) {
 	// TODO(jason): Also set annotations on the index. ggcr's
 	// pkg/v1/mutate.Annotations will drop the interface methods from
 	// oci.SignedImageIndex, so we may need to reimplement
@@ -147,16 +147,10 @@ func PublishIndex(ctx context.Context, idx oci.SignedImageIndex, logger log.Logg
 	dig := ref.Context().Digest(h.String())
 
 	toPublish := tags
-	msg := "publishing index tag"
-
-	if !shouldPushTags {
-		toPublish = []string{dig.String()}
-		msg = "publishing index without tag (digest only)"
-	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, tag := range toPublish {
-		logger.Printf("%s %v", msg, tag)
+		logger.Printf("publishing index tag %v", tag)
 
 		ref, err := name.ParseReference(tag)
 		if err != nil {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -153,14 +153,6 @@ func WithArch(arch types.Architecture) Option {
 	}
 }
 
-// WithDockerMediatypes determine whether to use Docker mediatypes for the build context.
-func WithDockerMediatypes(useDockerMediaTypes bool) Option {
-	return func(bc *Context) error {
-		bc.o.UseDockerMediaTypes = useDockerMediaTypes
-		return nil
-	}
-}
-
 // WithLogger sets the log.Logger implementation to be used by the build context.
 func WithLogger(logger log.Logger) Option {
 	return func(bc *Context) error {

--- a/pkg/build/os-release.go
+++ b/pkg/build/os-release.go
@@ -52,7 +52,7 @@ func maybeGenerateVendorReleaseFile(fsys apkfs.FullFS, ic *types.ImageConfigurat
 	return nil
 }
 
-func GenerateOSRelease(fsys apkfs.FullFS, o *options.Options, ic *types.ImageConfiguration) error {
+func generateOSRelease(fsys apkfs.FullFS, o *options.Options, ic *types.ImageConfiguration) error {
 	path := filepath.Join("etc", "os-release")
 
 	osReleaseExists := true

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -56,12 +56,7 @@ func newSBOM(fsys apkfs.FullFS, o options.Options, ic types.ImageConfiguration, 
 	sopt.ImageInfo.SourceDateEpoch = bde
 	sopt.Formats = o.SBOMFormats
 	sopt.ImageInfo.VCSUrl = ic.VCSUrl
-
-	if o.UseDockerMediaTypes {
-		sopt.ImageInfo.ImageMediaType = ggcrtypes.DockerManifestSchema2
-	} else {
-		sopt.ImageInfo.ImageMediaType = ggcrtypes.OCIManifestSchema1
-	}
+	sopt.ImageInfo.ImageMediaType = ggcrtypes.OCIManifestSchema1
 
 	sopt.OutputDir = o.TempDir()
 	if o.SBOMPath != "" {
@@ -165,9 +160,6 @@ func GenerateIndexSBOM(ctx context.Context, o options.Options, ic types.ImageCon
 	s.ImageInfo.IndexDigest = h
 
 	s.ImageInfo.IndexMediaType = ggcrtypes.OCIImageIndex
-	if o.UseDockerMediaTypes {
-		s.ImageInfo.IndexMediaType = ggcrtypes.DockerManifestList
-	}
 
 	// Make sure we have a determinstic for iterating over imgs.
 	archs := make([]types.Architecture, 0, len(imgs))

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -27,7 +27,6 @@ import (
 )
 
 type Options struct {
-	UseDockerMediaTypes     bool               `json:"useDockerMediaTypes,omitempty"`
 	WithVCS                 bool               `json:"withVCS,omitempty"`
 	TarballPath             string             `json:"tarballPath,omitempty"`
 	Tags                    []string           `json:"tags,omitempty"`
@@ -44,7 +43,6 @@ type Options struct {
 	PackageVersionTagPrefix string             `json:"packageVersionTagPrefix,omitempty"`
 	TagSuffix               string             `json:"tagSuffix,omitempty"`
 	Local                   bool               `json:"local,omitempty"`
-	StageTags               string             `json:"stageTags,omitempty"`
 	CacheDir                string             `json:"cacheDir,omitempty"`
 	Offline                 bool               `json:"offline,omitempty"`
 


### PR DESCRIPTION
In our move toward Terraform-based image builds, we no longer use a number of flags we had previously used -- mainly around tagging.

This PR drops some flags we don't use anymore, in an attempt to delay the implacable advance of entropy that lies at the heart of the human experience.

- `--stage-tags` used to skip tagging -- now we just invoke the build and tag later with [`oci_tag`](https://registry.terraform.io/providers/chainguard-dev/oci/latest/docs/resources/tag)
- `--use-docker-mediatypes` used to use Docker-style media types -- now we just always publish OCI images
- `--package-version-tag`, `--package-version-tag-stem`, `--package-version-tag-prefix`, `--tag-suffix` all used to control version-tagging logic in apko; now we do this version string extraction and tagging in [`apko_tags`](https://registry.terraform.io/providers/chainguard-dev/apko/latest/docs/data-sources/tags) and `oci_tag`

This also unexports `GenerateOSRelease` which was only ever called from the same package.

No tests were harmed in the removal of this behavior. 🙃 