### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run cgr.dev/chainguard/apko version
 To use the examples, you'll generally want to mount your current directory into the container, e.g.:
 
 ```shell
-docker run -v "$PWD":/work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:edge apko-alpine.tar
+docker run -v "$PWD":/work -w /work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:edge apko-alpine.tar
 ```
 
 Alternatively, if you're on a Mac, you can use [Lima](./mac/README.md) to run an Alpine Linux VM.
@@ -77,7 +77,7 @@ apko build examples/alpine-base.yaml apko-alpine:test apko-alpine.tar
 or, with Docker:
 
 ```shell
-docker run -v "$PWD":/work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:test apko-alpine.tar
+docker run -v "$PWD":/work  -w /work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:test apko-alpine.tar
 ```
 
 You can then load the generated tar image into a Docker environment:


### PR DESCRIPTION
when using apko via docker, the provided samples fail with the following error:

```
$ docker run -v "$PWD":/work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:test apko-alpine.tar

ℹ️            | loading config file: alpine-base.yaml
⚠️            | remote configurations are an experimental feature and subject to change.
Error: failed to load image configuration: unable to fetch remote include from git: failed to parse git reference alpine-base.yaml: not enough path data available
2023/11/06 13:01:35 error during command execution: failed to load image configuration: unable to fetch remote include from git: failed to parse git reference alpine-base.yaml: not enough path data available
```

The reson is that the `cgr.dev/chainguard/apko` image has no workdir specified:
```
docker inspect cgr.dev/chainguard/apko | jq .[0].Config.WorkingDir
""
```
therefore the default working directory is the root "/".

workarounds:
- all path should be absolute, like: /work/examples/alpine-base.yaml (unconvenient)
- specify WORKDIR for the official apko image: this would be the nicest solution i'm not sure if you have any objections against that
- use `--workdir` or `-w` to specify the workdir at runtime

Right now the the 3 option is the quickest.