### PR TITLE
Fix packages with multiple Replaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module chainguard.dev/apko
 go 1.21
 
 require (
-	github.com/chainguard-dev/go-apk v0.0.0-20231113174935-f86aaf233502
+	github.com/chainguard-dev/go-apk v0.0.0-20231120201550-7b08e8f3b0fc
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-git/go-git/v5 v5.10.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chainguard-dev/go-apk v0.0.0-20231113174935-f86aaf233502 h1:xYYl90jArqY6gFWTNA+6hRlrtKqHJ0lsWPluieS/xO8=
-github.com/chainguard-dev/go-apk v0.0.0-20231113174935-f86aaf233502/go.mod h1:y0BbOQALsoi1T2Lt5KmFNn92G+fRFSUuogQI2171HS8=
+github.com/chainguard-dev/go-apk v0.0.0-20231120201550-7b08e8f3b0fc h1:Car7PYrE9RD5qBN7ScGuTnDyzg6s6HFFDeUf8cFHlVI=
+github.com/chainguard-dev/go-apk v0.0.0-20231120201550-7b08e8f3b0fc/go.mod h1:y0BbOQALsoi1T2Lt5KmFNn92G+fRFSUuogQI2171HS8=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.5 h1:g+wWynZqVALYAlpSQFAa7TscDnUK8mKYtrxMpw6AUKo=
 github.com/cloudflare/circl v1.3.5/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=

--- a/pkg/build/busybox_test.go
+++ b/pkg/build/busybox_test.go
@@ -41,7 +41,7 @@ func TestInstallBusyboxSymlinks(t *testing.T) {
 		require.NoError(t, err)
 		err = fsys.MkdirAll("/lib/apk/db", 0755)
 		require.NoError(t, err)
-		pkgLines := apk.PackageToIndex(pkg)
+		pkgLines := apk.PackageToInstalled(pkg)
 		err = fsys.WriteFile("/lib/apk/db/installed", []byte(strings.Join(pkgLines, "\n")+"\n\n"), 0755)
 		require.NoError(t, err)
 	}

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -491,7 +491,14 @@ func (m *memFS) writeHeader(name string, te tarEntry) error {
 	}
 
 	sameOrigin := got.pkg.Origin == want.pkg.Origin
-	replaces := got.pkg.Name == want.pkg.Replaces
+
+	replaces := false
+	for _, replace := range want.pkg.Replaces {
+		if got.pkg.Name == replace {
+			replaces = true
+			break
+		}
+	}
 
 	// At this point we know the files conflict, but it's okay if this file replaces that one.
 	if !sameOrigin && !replaces {

--- a/pkg/tarfs/fs_test.go
+++ b/pkg/tarfs/fs_test.go
@@ -99,7 +99,7 @@ func TestTarFS(t *testing.T) {
 		t.Errorf("wanted conflicting checksum err, got nil")
 	}
 
-	pkg.Replaces = pkg.Name
+	pkg.Replaces = []string{pkg.Name}
 	if err := tfs.WriteHeader(*file, tfs, &pkg.Package); err != nil {
 		t.Errorf("pkg replaces file, got %v", err)
 	}


### PR DESCRIPTION
We were ignoring multiple Replaces when installing files, which broke any packages that relied on replacing multiple packages. This fixes things for those packages, but also fixes the installed db file to include the replaces line that was missing.