### PR TITLE
Allow run_as field to be a string or int for json/yaml validation.

### DIFF
--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -81,7 +81,14 @@
     "ImageAccounts": {
       "properties": {
         "run-as": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "int"
+            }
+          ],
           "description": "Required: The user to run the container as. This can be a username or UID."
         },
         "users": {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -96,7 +96,7 @@ type ImageEntrypoint struct {
 
 type ImageAccounts struct {
 	// Required: The user to run the container as. This can be a username or UID.
-	RunAs string `json:"run-as,omitempty" yaml:"run-as"`
+	RunAs string `json:"run-as,omitempty" yaml:"run-as" jsonschema:"oneof_type=string;int"`
 	// Required: List of users to populate the image with
 	Users []User `json:"users,omitempty"`
 	// Required: List of groups to populate the image with


### PR DESCRIPTION
To appease the linters