### PR TITLE
Make sure list of 'repositories' in the 'resolved.json.file' is complete.

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/chainguard-dev/go-apk/pkg/apk"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/chainguard-dev/go-apk/pkg/apk"
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"


### PR DESCRIPTION
Make sure list of 'repositories' in the 'resolved.json.file' is complete.

Prior to this PR, there were only listed used repositories used by any of the artifacts for given arch.
On the other hand the list was used to run APKO in offline environment -> and missing repos were leading to a failure
(in rules_apko).

Eventually repositories and indexes will not be needed for creation of image from resolved file, but, if we have the list in the file-format -> it should be complete.
