### PR TITLE
add comment about index SBOMs to SPDX document

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -104,7 +104,7 @@ func TestPublish(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the SBOM.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	swant := "sha256:2cbdb42a7b4160cdcd44836a583fa23985532e1641f026365f653006545ad90c"
+	swant := "sha256:80f7f856106465999bbd2d6d4eb3772120a2158e3f1726a166072348369ed7ad"
 	require.Equal(t, swant, got)
 
 	im, err := idx.IndexManifest()

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -475,7 +475,8 @@ type ExternalDocumentRef struct {
 type CreationInfo struct {
 	Created            string   `json:"created"` // Date
 	Creators           []string `json:"creators"`
-	LicenseListVersion string   `json:"licenseListVersion"`
+	LicenseListVersion string   `json:"licenseListVersion,omitempty"`
+	CreatorComment     string   `json:"comment,omitempty"`
 }
 
 type File struct {
@@ -552,6 +553,11 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 				"Organization: Chainguard, Inc",
 			},
 			LicenseListVersion: "3.16",
+			CreatorComment: `This SPDX document describes a multi-architecture container image index, containing one or more architecture-specific images.
+
+The packages described in this document refer to the images contained in the index, and not the contents of the images themselves.
+
+You can find the documents for the individual images in the index, containing the packages present in those images, by consulting the "VARIANT_OF" relationships in this document.`,
 		},
 		DataLicense:   "CC0-1.0",
 		Namespace:     "https://spdx.org/spdxdocs/apko/",
@@ -602,22 +608,18 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 			FilesAnalyzed:    false,
 			DownloadLocation: NOASSERTION,
 			PrimaryPurpose:   "CONTAINER",
-			Checksums: []Checksum{
-				{
-					Algorithm: "SHA256",
-					Value:     info.Digest.DeepCopy().Hex,
-				},
-			},
-			ExternalRefs: []ExternalRef{
-				{
-					Category: ExtRefPackageManager,
-					Type:     ExtRefTypePurl,
-					Locator: purl.NewPackageURL(
-						purl.TypeOCI, "", opts.ImagePurlName(), info.Digest.DeepCopy().String(),
-						nil, "",
-					).String() + "?" + opts.ArchImagePurlQualifiers(&opts.ImageInfo.Images[i]).String(),
-				},
-			},
+			Checksums: []Checksum{{
+				Algorithm: "SHA256",
+				Value:     info.Digest.DeepCopy().Hex,
+			}},
+			ExternalRefs: []ExternalRef{{
+				Category: ExtRefPackageManager,
+				Type:     ExtRefTypePurl,
+				Locator: purl.NewPackageURL(
+					purl.TypeOCI, "", opts.ImagePurlName(), info.Digest.DeepCopy().String(),
+					nil, "",
+				).String() + "?" + opts.ArchImagePurlQualifiers(&opts.ImageInfo.Images[i]).String(),
+			}},
 		})
 
 		doc.Relationships = append(doc.Relationships, Relationship{

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -557,7 +557,10 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 
 The packages described in this document refer to the images contained in the index, and not the contents of the images themselves.
 
-You can find the documents for the individual images in the index, containing the packages present in those images, by consulting the "VARIANT_OF" relationships in this document.`,
+You can find the documents for the individual images in the index, containing the packages present in those images, by consulting the "VARIANT_OF" relationships in this document.
+
+For more info refer to https://github.com/spdx/spdx-examples/blob/master/semantics/oci-multiarch-index.md
+`,
 		},
 		DataLicense:   "CC0-1.0",
 		Namespace:     "https://spdx.org/spdxdocs/apko/",


### PR DESCRIPTION
Users often find it confusing that `cosign download attestation <index>` returns an SBOM without much useful data, or that it's unclear where to go to find the data they're looking for (typically, packages).

This is an attempt to fix that by adding a guiding comment to the document pointing them toward the platform-specific image SBOMs, which contain the good stuff.