### PR TITLE
Use idb to drive sbom file inclusion

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -113,8 +113,8 @@ func TestPublish(t *testing.T) {
 	// We also want to check the children SBOMs because the index SBOM does not have
 	// references to the children SBOMs, just the children!
 	wantBoms := []string{
-		"sha256:bef40bcaa24ff513c1add5e0133a663519081ed5fd770a67609089ebb1b4a5a3",
-		"sha256:c400175e8fb4d7b3e2eb0442b7991716b3f6a770539f5e0f9d47e52a426e5431",
+		"sha256:1659428b4c619a57536ad62e473d46adbf9ca51eb8c765a9e835e6d1bddf8bcb",
+		"sha256:7126743a21e6bc7d81a72bb7570b0b951190eec361c50980592eacd177fd46d5",
 	}
 
 	for i, m := range im.Manifests {

--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -23,25 +23,6 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a1171b49b2e3d59abad728c7b0480736ff792eb"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "1877864cb20a2a48b27fbae1dd33d90918a56c7e24e503976d0ceb3ab5c9eecd"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "2b2935e9103b1755bf0e4028528accd9f082548180e9e70d9a15383005603ce314ca89c8280a98dc9cc429c6bfe3596c0c6faaa7f6dc9a4d195ce3f560014876"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
           "checksumValue": "ca5e527bbb8a5cc9c4c2d2b4e29618d8ca3be5f8"
         },
         {

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -23,25 +23,6 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "2a1171b49b2e3d59abad728c7b0480736ff792eb"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "1877864cb20a2a48b27fbae1dd33d90918a56c7e24e503976d0ceb3ab5c9eecd"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "2b2935e9103b1755bf0e4028528accd9f082548180e9e70d9a15383005603ce314ca89c8280a98dc9cc429c6bfe3596c0c6faaa7f6dc9a4d195ce3f560014876"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
           "checksumValue": "ca5e527bbb8a5cc9c4c2d2b4e29618d8ca3be5f8"
         },
         {

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -103,10 +103,11 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 	s.OS.ID = info.ID
 	s.OS.Version = info.VersionID
 
-	pkgs, err := sbom.ReadPackageIndex(bc.fs)
+	pkgs, err := bc.apk.GetInstalled()
 	if err != nil {
 		return nil, fmt.Errorf("reading apk package index: %w", err)
 	}
+
 	s.Packages = pkgs
 
 	// Get the image digest

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -41,18 +41,20 @@ var testOpts = &options.Options{
 		Version: "3.0",
 	},
 	FileName: "sbom",
-	Packages: []*apk.Package{
+	Packages: []*apk.InstalledPackage{
 		{
-			Name:        "musl",
-			Version:     "1.2.2-r7",
-			Arch:        "x86_64",
-			Description: "the musl c library (libc) implementation",
-			License:     "MIT",
-			Origin:      "musl",
-			Maintainer:  "Pkg Author <user@domain.com>",
-			Checksum: []byte{
-				0xd, 0xe6, 0xf4, 0x8c, 0xdc, 0xad, 0x92, 0xb8, 0xcf, 0x5b,
-				0x83, 0x7f, 0x78, 0xa2, 0xd9, 0xe3, 0x70, 0x70, 0x3a, 0x5c,
+			Package: apk.Package{
+				Name:        "musl",
+				Version:     "1.2.2-r7",
+				Arch:        "x86_64",
+				Description: "the musl c library (libc) implementation",
+				License:     "MIT",
+				Origin:      "musl",
+				Maintainer:  "Pkg Author <user@domain.com>",
+				Checksum: []byte{
+					0xd, 0xe6, 0xf4, 0x8c, 0xdc, 0xad, 0x92, 0xb8, 0xcf, 0x5b,
+					0x83, 0x7f, 0x78, 0xa2, 0xd9, 0xe3, 0x70, 0x70, 0x3a, 0x5c,
+				},
 			},
 		},
 	},

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -52,7 +52,7 @@ type Options struct {
 	Formats []string
 
 	// Packages is alist of packages which will be listed in the SBOM
-	Packages []*apk.Package
+	Packages []*apk.InstalledPackage
 }
 
 type PurlQualifiers map[string]string


### PR DESCRIPTION
Note that the golden SBOMs were updated to drop the duplicate etc/os-release entries.