### PR TITLE
Strip leading slash before sbom ownership check

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -322,11 +322,11 @@ func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}, 
 
 		done[f.ID] = struct{}{}
 
+		f.Name = strings.TrimPrefix(f.Name, "/") // Strip leading slashes, which SPDX doesn't like.
+
 		if _, ok := ownedFiles[f.Name]; !ok {
 			continue
 		}
-
-		f.Name = strings.TrimPrefix(f.Name, "/") // Strip leading slashes, which SPDX doesn't like.
 
 		targetDoc.Files = append(targetDoc.Files, f)
 	}


### PR DESCRIPTION
I didn't catch this in testing because newer versions of melange don't emit filenames with the leading slash, and I used a newer version of melange to generate the testdata.

Everything seemed to work except for APKs that haven't been rebuilt since melange was updated.