### PR TITLE
feat: improve local include

### DIFF
--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -215,23 +215,11 @@ The `paths` element contains the following children:
 the configuration data is layered on top of this base configuration.  By default, there is no
 base configuration used.
 
-The path can be either a local file, or a file in a remote git repository, in the same style as
-Go package names and Github Actions.  For example, the following include line would reference
+The path should be a local file.  For example, the following include line would reference
 `examples/alpine-base.yaml` in the apko git repository:
 
 ```
-include: github.com/chainguard-dev/apko/examples/alpine-base.yaml@main
-```
-
-At present, the path structure assumes that the git repository lives on a site similar to
-GitHub, GitLab or Gitea.  In other words, given an include path like the above, it will
-parse as:
-
-```
-host: github.com
-repository: chainguard-dev/apko
-path: examples/alpine-base.yaml
-reference: main
+include: examples/alpine-base.yaml
 ```
 
 Patches to improve the parsing to make it more flexible are welcome.

--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -212,8 +212,8 @@ The `paths` element contains the following children:
 ### Includes
 
 `include` defines a path to a configuration file which should be used as the base configuration,
-the configuration data is layered on top of this base configuration.  By default, there is no
-base configuration used.
+the configuration data is layered on top of this base configuration. By default, there is no
+base configuration used. Top image configurations have priority over base configurations.
 
 The path should be a local file.  For example, the following include line would reference
 `examples/alpine-base.yaml` in the apko git repository:

--- a/examples/remote-include.yaml
+++ b/examples/remote-include.yaml
@@ -1,1 +1,0 @@
-include: github.com/chainguard-dev/apko/examples/alpine-base.yaml@main

--- a/internal/cli/testdata/include/apko.yaml
+++ b/internal/cli/testdata/include/apko.yaml
@@ -1,0 +1,44 @@
+include: testdata/include/base.yaml
+
+contents:
+  keyring:
+    - ./testdata/melange.rsa.pub
+  repositories:
+    - ./testdata/packages
+  packages:
+    - replayout
+
+
+entrypoint:
+  command: /bin/bash -l
+
+cmd: ls
+
+environment:
+  LANG: en_US.utf8
+  LC_ALL: C.utf8
+
+accounts:
+  groups:
+    - groupname: apko
+      gid: 10001
+  users:
+    - username: apko
+      uid: 10001
+  run-as: apko
+
+paths:
+  - path: /home/apko
+    type: directory
+    uid: 10001
+    gid: 10001
+    permissions: 0o644
+  - path: /work
+    type: directory
+    uid: 10001
+    gid: 10001
+    permissions: 0o644
+
+archs:
+- x86_64
+- aarch64

--- a/internal/cli/testdata/include/base.yaml
+++ b/internal/cli/testdata/include/base.yaml
@@ -1,0 +1,49 @@
+contents:
+  keyring:
+    - ./testdata/melange.rsa.pub
+  repositories:
+    - ./testdata/packages
+  packages:
+    - pretend-baselayout
+
+environment:
+  LANG: en_US.utf8
+  LC_ALL: en_US.utf8
+
+entrypoint:
+  command: /bin/echo
+
+cmd: hello
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 10000
+    - groupname: sameid
+      gid: 10001
+    - groupname: apko
+      gid: 50000
+  users:
+    - username: nonroot
+      uid: 10000
+    - username: apko
+      uid: 5000
+    - username: sameid
+      uid: 10001
+  run-as: nonroot
+
+paths:
+  - path: /work
+    type: directory
+    uid: 1000
+    gid: 10000
+    permissions: 0o640
+  - path: /testdata
+    type: directory
+    uid: 10000
+    gid: 10000
+    permissions: 0o700
+
+archs:
+- x86_64
+- aarch64

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -102,3 +102,28 @@ func TestBuildImageFromTooOldResolvedFile(t *testing.T) {
 		"locked package pretend-baselayout has missing checksum (please regenerate the lock file with Apko >=0.13)",
 		err.Error())
 }
+
+func TestBuildImageWithLocalIncludeFile(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []build.Option{
+		build.WithConfig(filepath.Join("testdata/include", "apko.yaml")),
+	}
+
+	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bc.BuildImage(ctx)
+
+	installed, err := bc.InstalledPackages()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Len(t, installed, 2)
+	require.Equal(t, installed[0].Name, "pretend-baselayout")
+	require.Equal(t, installed[0].Version, "1.0.0-r0")
+	require.Equal(t, installed[1].Name, "replayout")
+	require.Equal(t, installed[1].Version, "1.0.0-r0")
+}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -114,7 +114,11 @@ func TestBuildImageWithLocalIncludeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	err = bc.BuildImage(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	installed, err := bc.InstalledPackages()
 	if err != nil {

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -24,8 +24,6 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/jinzhu/copier"
 	"gopkg.in/yaml.v3"
-
-	"chainguard.dev/apko/pkg/fetch"
 	"chainguard.dev/apko/pkg/vcs"
 )
 
@@ -103,35 +101,12 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, conf
 	return nil
 }
 
-func (ic *ImageConfiguration) maybeLoadRemote(ctx context.Context, imageConfigPath string, configHasher hash.Hash) error {
-	data, err := fetch.Fetch(imageConfigPath)
-	if err != nil {
-		return fmt.Errorf("unable to fetch remote include from git: %w", err)
-	}
-
-	return ic.parse(ctx, data, configHasher)
-}
-
 // Load - loads an image configuration given a configuration file path.
 // Populates configHasher with the configuration data loaded from the imageConfigPath and the other referenced files.
 // You can pass any dummy hasher (like fnv.New32()), if you don't care about the hash of the configuration.
 func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string, configHasher hash.Hash) error {
-	log := clog.FromContext(ctx)
-
 	data, err := os.ReadFile(imageConfigPath)
-
 	if err != nil {
-		log.Warnf("loading config file failed: %v", err)
-		log.Warnf("attempting to load remote configuration")
-		log.Warnf("NOTE: remote configurations are an experimental feature and subject to change.")
-
-		if err := ic.maybeLoadRemote(ctx, imageConfigPath, configHasher); err == nil {
-			return nil
-		} else {
-			// At this point, we're doing a remote config file.
-			log.Warnf("loading remote configuration failed: %v", err)
-		}
-
 		return err
 	}
 

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -1,0 +1,125 @@
+// Copyright 2022, 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	"crypto/sha256"
+	"path/filepath"
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncludeMergePackages(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, ic.Contents.Packages, []string{"pretend-baselayout", "replayout"})
+}
+
+func TestIncludeCmdTopImagePriority(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, ic.Cmd, "ls")
+}
+
+func TestIncludeEntrypointTopImagePriority(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, ic.Entrypoint.Command, "/bin/bash -l")
+}
+
+func TestIncludeMergedInheritAccounts(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, ic.Accounts.RunAs, "apko")
+	require.Equal(t, ic.Accounts.Users, []User{
+		{UserName: "apko", UID: uint32(10001), GID: uint32(0)},
+		{UserName: "nonroot", UID: uint32(10000), GID: uint32(0)},
+	})
+}
+
+func TestIncludeMergedInheritGroups(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, ic.Accounts.Groups, []Group{
+		{GroupName: "apko", GID: uint32(10001)},
+		{GroupName: "nonroot", GID: uint32(10000)},
+	})
+}
+
+func TestIncludeMergedEnvironment(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//inherit and overwrited environments
+	expected := make(map[string]string)
+	expected["LANG"] = "en_US.utf8"
+	expected["LC_ALL"] = "C.utf8"
+
+	require.Equal(t, ic.Environment, expected)
+}
+
+func TestIncludeMergedPathMutations(t *testing.T) {
+	var ic ImageConfiguration
+	hasher := sha256.New()
+	ctx := context.Background()
+	err := ic.Load(ctx, filepath.Join("testdata/include", "apko.yaml"), hasher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []PathMutation{
+		{Path: "/home/apko", UID: uint32(10001), GID: uint32(10001), Permissions: uint32(420), Type: "directory"},
+		{Path: "/work", UID: uint32(10001), GID: uint32(10001), Permissions: uint32(420), Type: "directory"},
+		{Path: "/testdata", UID: uint32(10000), GID: uint32(10000), Permissions: uint32(448), Type: "directory"},
+	}
+
+	require.Equal(t, ic.Paths, expected)
+}

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -98,7 +98,7 @@ func TestIncludeMergedEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//inherit and overwrited environments
+	// inherit and overwrited environments
 	expected := make(map[string]string)
 	expected["LANG"] = "en_US.utf8"
 	expected["LC_ALL"] = "C.utf8"

--- a/pkg/build/types/testdata
+++ b/pkg/build/types/testdata
@@ -1,0 +1,1 @@
+../../../internal/cli/testdata


### PR DESCRIPTION
- `include` in apko file now supports merge configurations for accounts, environments and path mutations.
- remove remote include
- add tests

related #1008