### PR TITLE
Store checksum of apko-config in the lock-file to detect changes in origin.

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -98,7 +98,6 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 	if err != nil {
 		return err
 	}
-
 	// cases:
 	// - archs set: use those archs
 	// - archs not set, bc.ImageConfiguration.Archs set: use Config archs
@@ -121,6 +120,10 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 
 	lock := pkglock.Lock{
 		Version: "v1",
+		Config: &pkglock.Config{
+			Name:         o.ImageConfigFile,
+			DeepChecksum: o.ImageConfigChecksum,
+		},
 		Contents: pkglock.LockContents{
 			Packages:     []pkglock.LockPkg{},
 			Repositories: []pkglock.LockRepo{},

--- a/internal/cli/testdata/apko.lock.json
+++ b/internal/cli/testdata/apko.lock.json
@@ -1,5 +1,9 @@
 {
   "version": "v1",
+  "config": {
+    "name": "testdata/apko.yaml",
+    "checksum": "sha256-eal7+HCFuOLz/8m3vNO5cYyNK0Zw7AphCcsc76TbTXg="
+  },
   "contents": {
     "keyring": [
       {

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -127,6 +127,13 @@ func (bc *Context) buildImage(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to load lock-file: %w", err)
 		}
+		if lock.Config == nil {
+			log.Warnf("The lock file does not contain checksum of the config. Please regenerate.")
+		} else if bc.o.ImageConfigChecksum != "" && bc.o.ImageConfigChecksum != lock.Config.DeepChecksum {
+			return fmt.Errorf("checksum in the lock file '%v' does not matches the original config: '%v' "+
+				"(maybe regenerate the lock file)",
+				bc.o.Lockfile, bc.o.ImageConfigFile)
+		}
 		allPkgs, err := installablePackagesForArch(lock, bc.Arch())
 		if err != nil {
 			return fmt.Errorf("failed getting packages for install from lockfile %s: %w", bc.o.Lockfile, err)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -16,6 +16,8 @@ package build
 
 import (
 	"context"
+	sha2562 "crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -38,12 +40,14 @@ func WithConfig(configFile string) Option {
 		log.Debugf("loading config file: %s", configFile)
 
 		var ic types.ImageConfiguration
-		if err := ic.Load(ctx, configFile); err != nil {
+		hasher := sha2562.New()
+		if err := ic.Load(ctx, configFile, hasher); err != nil {
 			return fmt.Errorf("failed to load image configuration: %w", err)
 		}
 
 		bc.ic = ic
 		bc.o.ImageConfigFile = configFile
+		bc.o.ImageConfigChecksum = "sha256-" + base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 
 		return nil
 	}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -17,6 +17,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"hash"
 	"os"
 	"strings"
 
@@ -45,8 +46,9 @@ func (ic *ImageConfiguration) ProbeVCSUrl(ctx context.Context, imageConfigPath s
 }
 
 // Parse a configuration blob into an ImageConfiguration struct.
-func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte) error {
+func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, configHasher hash.Hash) error {
 	log := clog.FromContext(ctx)
+	configHasher.Write(configData)
 	if err := yaml.Unmarshal(configData, ic); err != nil {
 		return fmt.Errorf("failed to parse image configuration: %w", err)
 	}
@@ -56,7 +58,7 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte) erro
 
 		baseIc := ImageConfiguration{}
 
-		if err := baseIc.Load(ctx, ic.Include); err != nil {
+		if err := baseIc.Load(ctx, ic.Include, configHasher); err != nil {
 			return fmt.Errorf("failed to read include file: %w", err)
 		}
 
@@ -101,25 +103,29 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte) erro
 	return nil
 }
 
-func (ic *ImageConfiguration) maybeLoadRemote(ctx context.Context, imageConfigPath string) error {
+func (ic *ImageConfiguration) maybeLoadRemote(ctx context.Context, imageConfigPath string, configHasher hash.Hash) error {
 	data, err := fetch.Fetch(imageConfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to fetch remote include from git: %w", err)
 	}
 
-	return ic.parse(ctx, data)
+	return ic.parse(ctx, data, configHasher)
 }
 
-// Loads an image configuration given a configuration file path.
-func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string) error {
+// Load - loads an image configuration given a configuration file path.
+// Populates configHasher with the configuration data loaded from the imageConfigPath and the other referenced files.
+// You can pass any dummy hasher (like fnv.New32()), if you don't care about the hash of the configuration.
+func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string, configHasher hash.Hash) error {
 	log := clog.FromContext(ctx)
+
 	data, err := os.ReadFile(imageConfigPath)
+
 	if err != nil {
 		log.Warnf("loading config file failed: %v", err)
 		log.Warnf("attempting to load remote configuration")
 		log.Warnf("NOTE: remote configurations are an experimental feature and subject to change.")
 
-		if err := ic.maybeLoadRemote(ctx, imageConfigPath); err == nil {
+		if err := ic.maybeLoadRemote(ctx, imageConfigPath, configHasher); err == nil {
 			return nil
 		} else {
 			// At this point, we're doing a remote config file.
@@ -129,7 +135,7 @@ func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string) 
 		return err
 	}
 
-	return ic.parse(ctx, data)
+	return ic.parse(ctx, data, configHasher)
 }
 
 // Do preflight checks and mutations on an image configuration.

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -8,7 +8,16 @@ import (
 
 type Lock struct {
 	Version  string       `json:"version"`
+	Config   *Config      `json:"config,omitempty"`
 	Contents LockContents `json:"contents"`
+}
+
+// Origin describes the source file used to generate the lock file.
+// Used to detect that the origin got changed without regenerating the lockfile.
+type Config struct {
+	Name string `json:"name,omitempty"`
+	// This checksum also covers included files and command-line settings that influence the artifacts resolution.
+	DeepChecksum string `json:"checksum,omitempty"`
 }
 
 type LockContents struct {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -25,8 +25,11 @@ import (
 )
 
 type Options struct {
-	WithVCS                 bool               `json:"withVCS,omitempty"`
-	ImageConfigFile         string             `json:"imageConfigFile,omitempty"`
+	WithVCS bool `json:"withVCS,omitempty"`
+	// ImageConfigFile might, but does not have to be a filename. It might be any abstract configuration identifier.
+	ImageConfigFile string `json:"imageConfigFile,omitempty"`
+	// ImageConfigChecksum (when set) allows to detect mismatch between configuration and the lockfile.
+	ImageConfigChecksum     string             `json:"configChecksum,omitempty"`
 	TarballPath             string             `json:"tarballPath,omitempty"`
 	Tags                    []string           `json:"tags,omitempty"`
 	SourceDateEpoch         time.Time          `json:"sourceDateEpoch,omitempty"`


### PR DESCRIPTION
Without this, it was easy to forgot updating lock-files, so got images based on the stale lock-file.

Now, if the `apko.yaml` (or one of the included files) is changed without refreshing the `apko.lock.json` file, the 
apko build will fail. 
The behavior is backward compatible, i.e. it triggers only when the new lock-files (with `config { deepChecksum: ...}} fields`) are used. 