### PR TITLE
Cancel context on interrupt signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,13 +15,23 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
 
 	"chainguard.dev/apko/internal/cli"
 )
 
 func main() {
-	if err := cli.New().Execute(); err != nil {
+	if err := mainE(); err != nil {
 		log.Fatalf("error during command execution: %v", err)
 	}
+}
+
+func mainE() error {
+	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer done()
+
+	return cli.New().ExecuteContext(ctx)
 }


### PR DESCRIPTION
This gives apko a chance to clean up after itself.