### PR TITLE
Allow apko dot to be cancelled

### DIFF
--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -345,6 +345,12 @@ func DotCmd(ctx context.Context, configFile string, archs []types.Architecture, 
 			return open.Run(fmt.Sprintf("http://localhost:%d", l.Addr().(*net.TCPAddr).Port))
 		})
 
+		g.Go(func() error {
+			<-ctx.Done()
+			server.Close()
+			return ctx.Err()
+		})
+
 		return g.Wait()
 	}
 


### PR DESCRIPTION
Listen() is hanging so we never exit.