### PR TITLE
move some logs to debug, avoid duplicate work/logs

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -74,16 +74,15 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 	ic := bc.ImageConfiguration()
 
 	if len(ic.Archs) != 0 {
-		log.Infof("WARNING: ignoring archs in config, only building for current arch (%s)", bc.Arch())
+		log.Warnf("ignoring archs in config, only building for current arch (%s)", bc.Arch())
 	}
 
-	log.Infof("building minirootfs '%s'", bc.TarballPath())
-
+	log.Debugf("building minirootfs %s", bc.TarballPath())
 	layerTarGZ, _, err := bc.BuildLayer(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to build layer image: %w", err)
 	}
-	log.Infof("wrote minirootfs to %s\n", layerTarGZ)
+	log.Debugf("wrote minirootfs to %s", layerTarGZ)
 
 	return nil
 }

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -150,7 +150,7 @@ func (bc *Context) buildImage(ctx context.Context) error {
 	}
 
 	if err := generateOSRelease(ctx, bc.fs, &bc.ic); errors.Is(err, ErrOSReleaseAlreadyPresent) {
-		log.Infof("did not generate /etc/os-release: %v", err)
+		log.Debugf("did not generate /etc/os-release: %v", err)
 	} else if err != nil {
 		return fmt.Errorf("failed to generate /etc/os-release: %w", err)
 	}
@@ -174,7 +174,7 @@ func (bc *Context) buildImage(ctx context.Context) error {
 		return err
 	}
 
-	log.Infof("finished building filesystem")
+	log.Debug("finished building filesystem")
 
 	return nil
 }

--- a/pkg/build/oci/image.go
+++ b/pkg/build/oci/image.go
@@ -46,7 +46,7 @@ func BuildImageFromLayer(ctx context.Context, layer v1.Layer, ic types.ImageConf
 		return nil, fmt.Errorf("accessing layer MediaType: %w", err)
 	}
 	imageType := humanReadableImageType(mediaType)
-	log.Infof("building image from layer")
+	log.Debug("building image from layer")
 
 	digest, err := layer.Digest()
 	if err != nil {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -35,7 +35,7 @@ func WithConfig(configFile string) Option {
 	return func(bc *Context) error {
 		ctx := context.Background()
 		log := clog.FromContext(ctx)
-		log.Infof("loading config file: %s", configFile)
+		log.Debugf("loading config file: %s", configFile)
 
 		var ic types.ImageConfiguration
 		if err := ic.Load(ctx, configFile); err != nil {
@@ -43,7 +43,7 @@ func WithConfig(configFile string) Option {
 		}
 
 		bc.ic = ic
-		bc.imageConfigFile = configFile
+		bc.o.ImageConfigFile = configFile
 
 		return nil
 	}

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -96,7 +96,7 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 	}
 
 	s := newSBOM(ctx, bc.fs, bc.o, bc.ic, bde)
-	log.Infof("Generating image SBOM")
+	log.Debug("Generating image SBOM")
 
 	s.ImageInfo.LayerDigest = m.Layers[0].Digest.String()
 
@@ -153,12 +153,12 @@ func GenerateIndexSBOM(ctx context.Context, o options.Options, ic types.ImageCon
 	defer span.End()
 
 	if len(o.SBOMFormats) == 0 {
-		log.Warnf("skipping SBOM generation")
+		log.Warn("skipping SBOM generation")
 		return nil, nil
 	}
 
 	s := newSBOM(ctx, nil, o, ic, o.SourceDateEpoch)
-	log.Infof("Generating index SBOM")
+	log.Debug("Generating index SBOM")
 
 	// Add the image digest
 	h, err := v1.NewHash(indexDigest.DigestStr())

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -26,6 +26,7 @@ import (
 
 type Options struct {
 	WithVCS                 bool               `json:"withVCS,omitempty"`
+	ImageConfigFile         string             `json:"imageConfigFile,omitempty"`
 	TarballPath             string             `json:"tarballPath,omitempty"`
 	Tags                    []string           `json:"tags,omitempty"`
 	SourceDateEpoch         time.Time          `json:"sourceDateEpoch,omitempty"`

--- a/pkg/s6/supervision_tree.go
+++ b/pkg/s6/supervision_tree.go
@@ -67,7 +67,7 @@ func (sc *Context) WriteSupervisionServiceSimple(ctx context.Context, name strin
 
 func (sc *Context) WriteSupervisionTree(ctx context.Context, services Services) error {
 	log := clog.FromContext(ctx)
-	log.Infof("generating supervision tree")
+	log.Debug("generating supervision tree")
 
 	// generate the leaves
 	for service, svccmd := range services {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -32,16 +32,11 @@ var (
 )
 
 var DefaultOptions = options.Options{
-	OS: options.OSInfo{
-		ID:      "unknown",
-		Name:    "Alpine Linux",
-		Version: "Unknown",
-	},
 	ImageInfo: options.ImageInfo{
 		Images: []options.ArchImageInfo{},
 	},
 	FileName: "sbom",
-	Formats:  []string{"spdx", "cyclonedx"},
+	Formats:  []string{"spdx"},
 }
 
 // readReleaseDataInternal reads the information from /etc/os-release


### PR DESCRIPTION
We were probing VCS URLs for each arch, which meant we were also logging it for each arch.

(In our own usage via tf-apko we don't use this at all, but it seemed silly to do it multiple times unnecessarily even for CLI users)

This also changes the default SBOM formats to SPDX only, since `apko publish` kept warning that we were only going to publish SPDX anyway, and it seemed silly for the default to warn you.