### PR TITLE
ignore Files when generating SBOMs

### DIFF
--- a/hack/ci/01-publish.sh
+++ b/hack/ci/01-publish.sh
@@ -25,17 +25,6 @@ for f in examples/alpine-base-rootless.yaml examples/wolfi-base.yaml; do
   # Run the image.
   docker run --rm ${img} echo hello | grep hello
 
-  if [[ ${f} == "examples/wolfi-base.yaml" ]]; then
-    # Download SBOM and check that it contains
-    # files derived from package SBOMs melange produces in /var/lib/db/sbom
-    cosign download sbom --platform=linux/amd64 "${REF}" | tee ci-testing.sbom.json
-    HAS_FILES="$(cat ci-testing.sbom.json | jq 'keys | contains(["files"])')"
-    if [[ "${HAS_FILES}" != "true" ]]; then
-      echo "SBOM does not have files. Exiting."
-      exit 1
-    fi
-  fi
-
   # Each platform should contain platform-specific etc/apk/arch file.
   crane export --platform linux/amd64 "${REF}" | tar -Ox etc/apk/arch | grep x86_64
   crane export --platform linux/arm64 "${REF}" | tar -Ox etc/apk/arch | grep aarch64

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -113,7 +113,7 @@ func TestPublish(t *testing.T) {
 	// We also want to check the children SBOMs because the index SBOM does not have
 	// references to the children SBOMs, just the children!
 	wantBoms := []string{
-		"sha256:1659428b4c619a57536ad62e473d46adbf9ca51eb8c765a9e835e6d1bddf8bcb",
+		"sha256:ef788d8d654e6ad1815228eca59ac9513307dae18cad929290c63d2b0296548d",
 		"sha256:7126743a21e6bc7d81a72bb7570b0b951190eec361c50980592eacd177fd46d5",
 	}
 

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -114,7 +114,7 @@ func TestPublish(t *testing.T) {
 	// references to the children SBOMs, just the children!
 	wantBoms := []string{
 		"sha256:ef788d8d654e6ad1815228eca59ac9513307dae18cad929290c63d2b0296548d",
-		"sha256:7126743a21e6bc7d81a72bb7570b0b951190eec361c50980592eacd177fd46d5",
+		"sha256:1329a56b0d402007ea2fe540d70a067ec0534ece42a406225a2ed78a6f5f8c2d",
 	}
 
 	for i, m := range im.Manifests {

--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -15,27 +15,6 @@
   "documentDescribes": [
     "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4"
   ],
-  "files": [
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ca5e527bbb8a5cc9c4c2d2b4e29618d8ca3be5f8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "53db9a78bf280b687690cdda8e275157713d725aaa54fe662f3bcf2f51eea457"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "ab0cf3e8797ea0e989960f40808333150b4c1ee2fa056b1cc271a98da0e1e8638bbaf5e89aad91436fb3b994a74b1886714df6b153125e712b08d3eaacd24dd5"
-        }
-      ]
-    }
-  ],
   "packages": [
     {
       "SPDXID": "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4",
@@ -81,9 +60,6 @@
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -105,9 +81,6 @@
       "name": "replayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -15,27 +15,6 @@
   "documentDescribes": [
     "SPDXRef-Package-sha256-e42af50bd66e8060653eb032153bc77d039807418ee4d80e0fbca5e3e5028926"
   ],
-  "files": [
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "ca5e527bbb8a5cc9c4c2d2b4e29618d8ca3be5f8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "53db9a78bf280b687690cdda8e275157713d725aaa54fe662f3bcf2f51eea457"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "ab0cf3e8797ea0e989960f40808333150b4c1ee2fa056b1cc271a98da0e1e8638bbaf5e89aad91436fb3b994a74b1886714df6b153125e712b08d3eaacd24dd5"
-        }
-      ]
-    }
-  ],
   "packages": [
     {
       "SPDXID": "SPDXRef-Package-sha256-e42af50bd66e8060653eb032153bc77d039807418ee4d80e0fbca5e3e5028926",
@@ -81,9 +60,6 @@
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -105,9 +81,6 @@
       "name": "replayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -295,6 +295,14 @@ func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}, 
 		}
 	}
 
+	for _, f := range sourceDoc.Files {
+		if _, ok := todo[f.ID]; !ok {
+			continue
+		}
+
+		done[f.ID] = struct{}{}
+	}
+
 	for _, r := range sourceDoc.Relationships {
 		if _, ok := todo[r.Element]; ok {
 			targetDoc.Relationships = append(targetDoc.Relationships, r)
@@ -450,6 +458,7 @@ type Document struct {
 	DataLicense          string                `json:"dataLicense"`
 	Namespace            string                `json:"documentNamespace"`
 	DocumentDescribes    []string              `json:"documentDescribes"`
+	Files                []File                `json:"files,omitempty"`
 	Packages             []Package             `json:"packages"`
 	Relationships        []Relationship        `json:"relationships"`
 	ExternalDocumentRefs []ExternalDocumentRef `json:"externalDocumentRefs,omitempty"`

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -255,7 +255,7 @@ func (sx *SPDX) ProcessInternalApkSBOM(opts *options.Options, doc *Document, p *
 		todo[id] = struct{}{}
 	}
 
-	if err := copySBOMElements(internalDoc, doc, todo, ipkg); err != nil {
+	if err := copySBOMElements(internalDoc, doc, todo); err != nil {
 		return fmt.Errorf("copying element: %w", err)
 	}
 
@@ -274,7 +274,7 @@ func (sx *SPDX) ProcessInternalApkSBOM(opts *options.Options, doc *Document, p *
 	return nil
 }
 
-func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}, ipkg *apk.InstalledPackage) error {
+func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}) error {
 	// Walk the graph looking for things to copy.
 	// Loop until we don't find any new todos.
 	for prev, next := 0, len(todo); next != prev; prev, next = next, len(todo) {


### PR DESCRIPTION
Including files in the SBOMs makes them _huge_ with no discernible benefit.

We removed files from package SBOMs in https://github.com/chainguard-dev/melange/pull/1076 but this means we don't have to rebuild every package to get sanely-sized SBOMs out of apko.