### PR TITLE
Increase gzip compression level to 9 (BestCompression)

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -89,7 +89,7 @@ func (bc *Context) BuildTarball(ctx context.Context) (string, hash.Hash, hash.Ha
 	digest := sha256.New()
 
 	buf := bufio.NewWriterSize(outfile, 1<<22)
-	gzw := gzip.NewWriter(io.MultiWriter(digest, buf))
+	gzw := gzip.NewWriterLevel(io.MultiWriter(digest, buf), gzip.BestCompression)
 	if err := gzw.SetConcurrency(1<<20, pgzipThreads); err != nil {
 		return "", nil, nil, 0, fmt.Errorf("tried to set pgzip concurrency to %d: %w", pgzipThreads, err)
 	}

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -89,7 +89,10 @@ func (bc *Context) BuildTarball(ctx context.Context) (string, hash.Hash, hash.Ha
 	digest := sha256.New()
 
 	buf := bufio.NewWriterSize(outfile, 1<<22)
-	gzw := gzip.NewWriterLevel(io.MultiWriter(digest, buf), gzip.BestCompression)
+	gzw, err := gzip.NewWriterLevel(io.MultiWriter(digest, buf), gzip.BestCompression)
+	if err != nil {
+		return "", nil, nil, 0, fmt.Errorf("failed to create gzip writer: %w", err)
+	}
 	if err := gzw.SetConcurrency(1<<20, pgzipThreads); err != nil {
 		return "", nil, nil, 0, fmt.Errorf("tried to set pgzip concurrency to %d: %w", pgzipThreads, err)
 	}


### PR DESCRIPTION
Currently when building an image apko uses `pgzip.NewWriter` which will use the `DefaultCompression` constant (`-1`) which is [becomes a compression level of 5](https://github.com/klauspost/compress/blob/1e2b27500c4eae851ba753ad116dc5a6524d2366/flate/deflate.go#L822). We can decrease the final image/layer size at the cost of small amount of additional CPU during build time by instead opting into the `BestCompression` level (9) via `pgzip.NewWriterLevel` instead. 

This won't necessarily result in a huge change in image size for most images, for example using `examples/alpine-base.yaml` it decreases from `27691520` bytes to `26865152` bytes (~3%). 