### PR TITLE
spdx: remove more mentions of files

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -113,8 +113,8 @@ func TestPublish(t *testing.T) {
 	// We also want to check the children SBOMs because the index SBOM does not have
 	// references to the children SBOMs, just the children!
 	wantBoms := []string{
-		"sha256:ef788d8d654e6ad1815228eca59ac9513307dae18cad929290c63d2b0296548d",
-		"sha256:1329a56b0d402007ea2fe540d70a067ec0534ece42a406225a2ed78a6f5f8c2d",
+		"sha256:3b499c0e0a0cc77d812057233db2b3277ec84617387526c6db158a3c0cb6f522",
+		"sha256:b581d950944c0106e251a53d9f8dd77bda7ae53f8ed0fc32fe338590fc8238a0",
 	}
 
 	for i, m := range im.Manifests {

--- a/internal/cli/testdata/base_image/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/base_image/sboms/sbom-aarch64.spdx.json
@@ -15,65 +15,7 @@
   "documentDescribes": [
     "SPDXRef-Package-sha256-5a99438a9ced8193f1d71209d0b558fdc0b184aee5cf258e5f7aa9a6ab0f0671"
   ],
-  "files": [
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a1171b49b2e3d59abad728c7b0480736ff792eb"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "1877864cb20a2a48b27fbae1dd33d90918a56c7e24e503976d0ceb3ab5c9eecd"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "2b2935e9103b1755bf0e4028528accd9f082548180e9e70d9a15383005603ce314ca89c8280a98dc9cc429c6bfe3596c0c6faaa7f6dc9a4d195ce3f560014876"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--x-hello.txt",
-      "fileName": "x/hello.txt",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a8eec30a5b2d71bc890175f5b361ebb28d7c54a8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "dec5b5e130d1694e65b1bf3f915024d51e87817248ab625e8732e183c321a9aaa09f92c04ed3d1d3a5b173838bd40ff5b1c8bb6318bcea70f4f72a8bff0ec2a1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--y-hello.txt",
-      "fileName": "y/hello.txt",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a8eec30a5b2d71bc890175f5b361ebb28d7c54a8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "dec5b5e130d1694e65b1bf3f915024d51e87817248ab625e8732e183c321a9aaa09f92c04ed3d1d3a5b173838bd40ff5b1c8bb6318bcea70f4f72a8bff0ec2a1"
-        }
-      ]
-    }
-  ],
+  "files": [],
   "packages": [
     {
       "SPDXID": "SPDXRef-Package-sha256-5a99438a9ced8193f1d71209d0b558fdc0b184aee5cf258e5f7aa9a6ab0f0671",
@@ -119,9 +61,7 @@
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -143,9 +83,7 @@
       "name": "package-x",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--x-hello.txt"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -167,9 +105,7 @@
       "name": "package-y",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--y-hello.txt"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -199,29 +135,14 @@
       "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
     },
     {
-      "spdxElementId": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-sha256-583625b6164fff3b017f62b9fcd60cb53fff18a7e89ee538212134a13fc29fb1",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-Package-package-x-1.0.0-r0"
     },
     {
-      "spdxElementId": "SPDXRef-Package-package-x-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--x-hello.txt"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-sha256-583625b6164fff3b017f62b9fcd60cb53fff18a7e89ee538212134a13fc29fb1",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-Package-package-y-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-package-y-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--y-hello.txt"
     }
   ]
 }

--- a/internal/cli/testdata/base_image/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/base_image/sboms/sbom-x86_64.spdx.json
@@ -15,65 +15,7 @@
   "documentDescribes": [
     "SPDXRef-Package-sha256-2ef91a9967f2e1759ea49a8c01cf6a45dd9f9af71fe09bcf2b86175bc4a71314"
   ],
-  "files": [
-    {
-      "SPDXID": "SPDXRef-File--etc-os-release",
-      "fileName": "etc/os-release",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "2a1171b49b2e3d59abad728c7b0480736ff792eb"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "1877864cb20a2a48b27fbae1dd33d90918a56c7e24e503976d0ceb3ab5c9eecd"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "2b2935e9103b1755bf0e4028528accd9f082548180e9e70d9a15383005603ce314ca89c8280a98dc9cc429c6bfe3596c0c6faaa7f6dc9a4d195ce3f560014876"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--x-hello.txt",
-      "fileName": "x/hello.txt",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a8eec30a5b2d71bc890175f5b361ebb28d7c54a8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "dec5b5e130d1694e65b1bf3f915024d51e87817248ab625e8732e183c321a9aaa09f92c04ed3d1d3a5b173838bd40ff5b1c8bb6318bcea70f4f72a8bff0ec2a1"
-        }
-      ]
-    },
-    {
-      "SPDXID": "SPDXRef-File--y-hello.txt",
-      "fileName": "y/hello.txt",
-      "licenseConcluded": "NOASSERTION",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "a8eec30a5b2d71bc890175f5b361ebb28d7c54a8"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4"
-        },
-        {
-          "algorithm": "SHA512",
-          "checksumValue": "dec5b5e130d1694e65b1bf3f915024d51e87817248ab625e8732e183c321a9aaa09f92c04ed3d1d3a5b173838bd40ff5b1c8bb6318bcea70f4f72a8bff0ec2a1"
-        }
-      ]
-    }
-  ],
+  "files": [],
   "packages": [
     {
       "SPDXID": "SPDXRef-Package-sha256-2ef91a9967f2e1759ea49a8c01cf6a45dd9f9af71fe09bcf2b86175bc4a71314",
@@ -119,9 +61,7 @@
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--etc-os-release"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -143,9 +83,7 @@
       "name": "package-x",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--x-hello.txt"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -167,9 +105,7 @@
       "name": "package-y",
       "versionInfo": "1.0.0-r0",
       "filesAnalyzed": true,
-      "hasFiles": [
-        "SPDXRef-File--y-hello.txt"
-      ],
+      "hasFiles": [],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "downloadLocation": "NOASSERTION",
@@ -199,29 +135,14 @@
       "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
     },
     {
-      "spdxElementId": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-sha256-bf74ddaf55d32ec9672a0a40efc6cb1bf0a167763c18fc22586c8a301167822f",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-Package-package-x-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-package-x-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--x-hello.txt"
     },
     {
       "spdxElementId": "SPDXRef-Package-sha256-bf74ddaf55d32ec9672a0a40efc6cb1bf0a167763c18fc22586c8a301167822f",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-Package-package-y-1.0.0-r0"
     },
-    {
-      "spdxElementId": "SPDXRef-Package-package-y-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--y-hello.txt"
-    }
   ]
 }

--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -100,9 +100,9 @@
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d",
+      "spdxElementId": "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4",
       "relationshipType": "CONTAINS",
-      "spdxElementId": "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4"
+      "relatedSpdxElement": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d"
     }
   ]
 }

--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -100,29 +100,9 @@
   ],
   "relationships": [
     {
-      "spdxElementId": "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4",
+      "relatedSpdxElement": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d",
       "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-sha256-6e6ffbcf153baa74794a66c87760f8d393ad82b51770b2c3b6ae5211ee5d7b6d",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-Package-replayout-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-replayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
+      "spdxElementId": "SPDXRef-Package-sha256-7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4"
     }
   ]
 }

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -103,26 +103,6 @@
       "spdxElementId": "SPDXRef-Package-sha256-e42af50bd66e8060653eb032153bc77d039807418ee4d80e0fbca5e3e5028926",
       "relationshipType": "CONTAINS",
       "relatedSpdxElement": "SPDXRef-Package-sha256-16e741f38ee9768330001d0b12b34006d5bdf90bc2dd72716bca4446e66b6ac6"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-sha256-16e741f38ee9768330001d0b12b34006d5bdf90bc2dd72716bca4446e66b6ac6",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-sha256-16e741f38ee9768330001d0b12b34006d5bdf90bc2dd72716bca4446e66b6ac6",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-Package-replayout-1.0.0-r0"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-replayout-1.0.0-r0",
-      "relationshipType": "CONTAINS",
-      "relatedSpdxElement": "SPDXRef-File--etc-os-release"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/chainguard-dev/apko/pull/1073 removed `files` from SBOMs, but didn't remove enough.

It turns out, if `references` mention an `SPDXRef-File--` then that object must also exist in the graph, and we removed those.

This change further expunges files information from references, so that SBOMs are SPDX-valid.