### PR TITLE
feat: allow creating new files

### DIFF
--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -45,7 +45,7 @@ type PathMutation struct {
 	Path string `json:"path,omitempty"`
 	// The type of mutation to perform
 	//
-	// This can be one of: directory, empty-file, hardlink, symlink, permissions
+	// This can be one of: directory, empty-file, hardlink, symlink, permissions, new-file
 	Type string `json:"type,omitempty"`
 	// The mutation's desired user ID
 	UID uint32 `json:"uid,omitempty"`
@@ -57,6 +57,8 @@ type PathMutation struct {
 	Source string `json:"source,omitempty"`
 	// Toggle whether to mutate recursively
 	Recursive bool `json:"recursive,omitempty"`
+	// The content to write to the path
+	Content string `json:"content,omitempty"`
 }
 
 type OSRelease struct {


### PR DESCRIPTION
Allow creating new files like config files when building an image with apko.

example config:

```
contents:
  repositories:
    - https://dl-cdn.alpinelinux.org/alpine/edge/main
    - https://dl-cdn.alpinelinux.org/alpine/edge/community
  packages:
    - alpine-base
    - php83

paths:
  - type: new-file
    path: /etc/php83/conf.d/memory.ini
    content: |
      memory_limit=2G

entrypoint:
  command: /usr/bin/php83 -i
```

and then run:

```
go run . build apko.yaml php-test php.tar
docker load < php.tar

docker run --rm php-test:latest-amd64 | grep memory
```

and you see:
```
Additional .ini files parsed => /etc/php83/conf.d/memory.ini
memory_limit => 2G => 2G
```

