### PR TITLE
fix: remove default supplier for index SBOMs

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -104,7 +104,7 @@ func TestPublish(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the SBOM.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	swant := "sha256:89c0c452eab526bebac6d4e4ed8c14a3f9bfdf1e828438add5276a73fb657ae1"
+	swant := "sha256:5f38dba02ec6708366025c8693c04d67a21cd8a00f3adcbe40116433c9e1e1e2"
 	require.Equal(t, swant, got)
 
 	im, err := idx.IndexManifest()

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -104,7 +104,7 @@ func TestPublish(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the SBOM.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	swant := "sha256:5f38dba02ec6708366025c8693c04d67a21cd8a00f3adcbe40116433c9e1e1e2"
+	swant := "sha256:6ed334e76657dd2297b575dfcca7430d5b0982f7d07d3f1645ba26ed8904e46f"
 	require.Equal(t, swant, got)
 
 	im, err := idx.IndexManifest()

--- a/internal/cli/testdata/base_image/sboms/sbom-index.spdx.json
+++ b/internal/cli/testdata/base_image/sboms/sbom-index.spdx.json
@@ -23,7 +23,7 @@
       "filesAnalyzed": false,
       "description": "Multi-arch image index",
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "sourceInfo": "Generated at image build time by apko",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
@@ -46,7 +46,7 @@
       "versionInfo": "sha256:2ef91a9967f2e1759ea49a8c01cf6a45dd9f9af71fe09bcf2b86175bc4a71314",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {
@@ -68,7 +68,7 @@
       "versionInfo": "sha256:5a99438a9ced8193f1d71209d0b558fdc0b184aee5cf258e5f7aa9a6ab0f0671",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {

--- a/internal/cli/testdata/base_image/sboms/sbom-index.spdx.json
+++ b/internal/cli/testdata/base_image/sboms/sbom-index.spdx.json
@@ -23,7 +23,7 @@
       "filesAnalyzed": false,
       "description": "Multi-arch image index",
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "sourceInfo": "Generated at image build time by apko",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
@@ -46,7 +46,7 @@
       "versionInfo": "sha256:2ef91a9967f2e1759ea49a8c01cf6a45dd9f9af71fe09bcf2b86175bc4a71314",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {
@@ -68,7 +68,7 @@
       "versionInfo": "sha256:5a99438a9ced8193f1d71209d0b558fdc0b184aee5cf258e5f7aa9a6ab0f0671",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {

--- a/internal/cli/testdata/golden/sboms/sbom-index.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-index.spdx.json
@@ -23,7 +23,7 @@
       "filesAnalyzed": false,
       "description": "Multi-arch image index",
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "sourceInfo": "Generated at image build time by apko",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
@@ -46,7 +46,7 @@
       "versionInfo": "sha256:e42af50bd66e8060653eb032153bc77d039807418ee4d80e0fbca5e3e5028926",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {
@@ -68,7 +68,7 @@
       "versionInfo": "sha256:7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "Organization: Alpine Linux",
+      "supplier": "NOASSERTION",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {

--- a/internal/cli/testdata/golden/sboms/sbom-index.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-index.spdx.json
@@ -23,7 +23,7 @@
       "filesAnalyzed": false,
       "description": "Multi-arch image index",
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "sourceInfo": "Generated at image build time by apko",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
@@ -46,7 +46,7 @@
       "versionInfo": "sha256:e42af50bd66e8060653eb032153bc77d039807418ee4d80e0fbca5e3e5028926",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {
@@ -68,7 +68,7 @@
       "versionInfo": "sha256:7e3a7384fe0243cc4b498cd54be2455fdcbb7aebd5eb94566926a5088868eef4",
       "filesAnalyzed": false,
       "downloadLocation": "NOASSERTION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: Chainguard, Inc.",
       "primaryPackagePurpose": "CONTAINER",
       "checksums": [
         {

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -347,6 +347,13 @@ func renderDoc(doc *Document, path string) error {
 	return nil
 }
 
+func supplier(opts *options.Options) string {
+	if opts.OS.Name == "" {
+		return NOASSERTION
+	}
+	return "Organization: " + opts.OS.Name
+}
+
 func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
 	return &Package{
 		ID: stringToIdentifier(fmt.Sprintf(
@@ -354,7 +361,7 @@ func (sx *SPDX) imagePackage(opts *options.Options) (p *Package) {
 		)),
 		Name:             opts.ImageInfo.ImageDigest,
 		Version:          opts.ImageInfo.ImageDigest,
-		Supplier:         "Organization: " + opts.OS.Name,
+		Supplier:         supplier(opts),
 		DownloadLocation: NOASSERTION,
 		PrimaryPurpose:   "CONTAINER",
 		FilesAnalyzed:    false,
@@ -386,7 +393,7 @@ func (sx *SPDX) apkPackage(opts *options.Options, pkg *apk.InstalledPackage) Pac
 		)),
 		Name:             pkg.Name,
 		Version:          pkg.Version,
-		Supplier:         "Organization: " + opts.OS.Name,
+		Supplier:         supplier(opts),
 		FilesAnalyzed:    false,
 		LicenseConcluded: pkg.License,
 		Description:      pkg.Description,
@@ -426,7 +433,7 @@ func (sx *SPDX) layerPackage(opts *options.Options) *Package {
 		Description:      "apko operating system layer",
 		DownloadLocation: NOASSERTION,
 		Originator:       "",
-		Supplier:         "Organization: " + opts.OS.Name,
+		Supplier:         supplier(opts),
 		Checksums:        []Checksum{},
 		ExternalRefs: []ExternalRef{
 			{
@@ -549,7 +556,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 		ID:               "SPDXRef-Package-" + stringToIdentifier(opts.ImageInfo.IndexDigest.DeepCopy().String()),
 		Name:             opts.ImageInfo.IndexDigest.DeepCopy().String(),
 		Version:          opts.ImageInfo.IndexDigest.DeepCopy().String(),
-		Supplier:         "Organization: " + opts.OS.Name,
+		Supplier:         supplier(opts),
 		FilesAnalyzed:    false,
 		Description:      "Multi-arch image index",
 		SourceInfo:       "Generated at image build time by apko",
@@ -583,7 +590,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 			ID:               imagePackageID,
 			Name:             fmt.Sprintf("sha256:%s", info.Digest.DeepCopy().Hex),
 			Version:          fmt.Sprintf("sha256:%s", info.Digest.DeepCopy().Hex),
-			Supplier:         "Organization: " + opts.OS.Name,
+			Supplier:         supplier(opts),
 			FilesAnalyzed:    false,
 			DownloadLocation: NOASSERTION,
 			PrimaryPurpose:   "CONTAINER",
@@ -651,7 +658,7 @@ func addSourcePackage(vcsURL string, doc *Document, parent *Package, opts *optio
 		ID:               fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(vcsURL)),
 		Name:             packageName,
 		Version:          version,
-		Supplier:         "Organization: " + opts.OS.Name,
+		Supplier:         supplier(opts),
 		FilesAnalyzed:    false,
 		PrimaryPurpose:   "SOURCE",
 		Description:      "Image configuration source",

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -32,12 +32,7 @@ var (
 )
 
 var DefaultOptions = options.Options{
-	// TODO(jason): Remove this default.
-	OS: options.OSInfo{
-		ID:      "unknown",
-		Name:    "Alpine Linux",
-		Version: "Unknown",
-	},
+	OS: options.OSInfo{},
 	ImageInfo: options.ImageInfo{
 		Images: []options.ArchImageInfo{},
 	},

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -32,7 +32,9 @@ var (
 )
 
 var DefaultOptions = options.Options{
-	OS: options.OSInfo{},
+	OS: options.OSInfo{
+		Name: "Chainguard, Inc.", // This populates the supplier for index SBOMs.
+	},
 	ImageInfo: options.ImageInfo{
 		Images: []options.ArchImageInfo{},
 	},


### PR DESCRIPTION
Index SBOMs had been defaulting to reporting as supplied by `Alpine Linux` due to a long-standing bad default.

This removes the default, and index SBOMs now report `supplier: NOASSERTION` instead of erroneously stating Alpine.