### PR TITLE
Fix duplicates when overlaying the config with config with no contents

### DIFF
--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -65,6 +65,16 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, conf
 
 		mergedIc := ImageConfiguration{}
 
+		// Merge packages, repositories and keyrings from base and overlay configurations
+		keyring := append([]string{}, baseIc.Contents.Keyring...)
+		keyring = append(keyring, ic.Contents.Keyring...)
+
+		repos := append([]string{}, baseIc.Contents.Repositories...)
+		repos = append(repos, ic.Contents.Repositories...)
+
+		pkgs := append([]string{}, baseIc.Contents.Packages...)
+		pkgs = append(pkgs, ic.Contents.Packages...)
+
 		// Copy the base configuration...
 		if err := copier.Copy(&mergedIc, &baseIc); err != nil {
 			return fmt.Errorf("failed to copy base configuration: %w", err)
@@ -80,17 +90,9 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, conf
 			return fmt.Errorf("failed to copy merged configuration: %w", err)
 		}
 
-		// Merge packages, repositories and keyrings.
-		keyring := append([]string{}, baseIc.Contents.Keyring...)
-		keyring = append(keyring, mergedIc.Contents.Keyring...)
+		// Finally, update the repeated fields to the merged ones.
 		ic.Contents.Keyring = keyring
-
-		repos := append([]string{}, baseIc.Contents.Repositories...)
-		repos = append(repos, mergedIc.Contents.Repositories...)
 		ic.Contents.Repositories = repos
-
-		pkgs := append([]string{}, baseIc.Contents.Packages...)
-		pkgs = append(pkgs, mergedIc.Contents.Packages...)
 		ic.Contents.Packages = pkgs
 	}
 

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"path/filepath"
+	"testing"
+
+	"chainguard.dev/apko/pkg/build/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlayWithEmptyContents(t *testing.T) {
+	ctx := context.Background()
+
+	config_path := filepath.Join("testdata", "overlay", "overlay.apko.yaml")
+	hasher := sha256.New()
+	ic := types.ImageConfiguration{}
+
+	require.NoError(t, ic.Load(ctx, config_path, hasher))
+	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
+	require.ElementsMatch(t, ic.Contents.Packages, []string{"package"})
+}
+
+func TestOverlayWithAdditionalPackages(t *testing.T) {
+	ctx := context.Background()
+
+	config_path := filepath.Join("testdata", "overlay", "overlay_with_package.apko.yaml")
+	hasher := sha256.New()
+	ic := types.ImageConfiguration{}
+
+	require.NoError(t, ic.Load(ctx, config_path, hasher))
+	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
+	require.ElementsMatch(t, ic.Contents.Packages, []string{"package", "other_package"})
+}

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"chainguard.dev/apko/pkg/build/types"
 	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/build/types"
 )
 
 func TestOverlayWithEmptyContents(t *testing.T) {

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -13,11 +13,11 @@ import (
 func TestOverlayWithEmptyContents(t *testing.T) {
 	ctx := context.Background()
 
-	config_path := filepath.Join("testdata", "overlay", "overlay.apko.yaml")
+	configPath := filepath.Join("testdata", "overlay", "overlay.apko.yaml")
 	hasher := sha256.New()
 	ic := types.ImageConfiguration{}
 
-	require.NoError(t, ic.Load(ctx, config_path, hasher))
+	require.NoError(t, ic.Load(ctx, configPath, hasher))
 	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package"})
@@ -26,11 +26,11 @@ func TestOverlayWithEmptyContents(t *testing.T) {
 func TestOverlayWithAdditionalPackages(t *testing.T) {
 	ctx := context.Background()
 
-	config_path := filepath.Join("testdata", "overlay", "overlay_with_package.apko.yaml")
+	configPath := filepath.Join("testdata", "overlay", "overlay_with_package.apko.yaml")
 	hasher := sha256.New()
 	ic := types.ImageConfiguration{}
 
-	require.NoError(t, ic.Load(ctx, config_path, hasher))
+	require.NoError(t, ic.Load(ctx, configPath, hasher))
 	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package", "other_package"})

--- a/pkg/build/types/testdata/overlay/base.apko.yaml
+++ b/pkg/build/types/testdata/overlay/base.apko.yaml
@@ -1,0 +1,7 @@
+contents:
+  repositories:
+    - "repository"
+  keyring:
+    - "key"
+  packages:
+    - "package"

--- a/pkg/build/types/testdata/overlay/overlay.apko.yaml
+++ b/pkg/build/types/testdata/overlay/overlay.apko.yaml
@@ -1,0 +1,1 @@
+include: testdata/overlay/base.apko.yaml

--- a/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
+++ b/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
@@ -1,0 +1,5 @@
+include: testdata/overlay/overlay.apko.yaml
+
+contents:
+  packages:
+    - "other_package"


### PR DESCRIPTION
The problem was with

```
copier.CopyWithOption(&mergedIc, ic, copier.Option{IgnoreEmpty: true})
```

If `Contents` object of overlay config was empty, then the merged config kept the repeated fields of contents from base config. Then the merging of repeated fields was done as concatenating base arrays with merged arrays, effectively doubling each array from base. 