### PR TITLE
spdx: allow specifying custom license

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -470,7 +470,7 @@ type ExternalDocumentRef struct {
 
 // Can also contain name, comment, seeAlso
 type LicensingInfo struct {
-	LicenseId          string    `json:"licenseId"`
+	LicenseID          string    `json:"licenseId"`
 	ExtractedText      string    `json:"extractedText"`
 }
 

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -470,8 +470,8 @@ type ExternalDocumentRef struct {
 
 // Can also contain name, comment, seeAlso
 type LicensingInfo struct {
-	LicenseID          string    `json:"licenseId"`
-	ExtractedText      string    `json:"extractedText"`
+	LicenseID     string `json:"licenseId"`
+	ExtractedText string `json:"extractedText"`
 }
 
 type CreationInfo struct {

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2023 Chainguard, Inc.
+// Copyright 2022-2024 Chainguard, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -459,12 +459,19 @@ type Document struct {
 	Packages             []Package             `json:"packages"`
 	Relationships        []Relationship        `json:"relationships"`
 	ExternalDocumentRefs []ExternalDocumentRef `json:"externalDocumentRefs,omitempty"`
+	LicensingInfos       []LicensingInfo       `json:"hasExtractedLicensingInfos,omitempty"`
 }
 
 type ExternalDocumentRef struct {
 	Checksum           Checksum `json:"checksum"`
 	ExternalDocumentID string   `json:"externalDocumentId"`
 	SPDXDocument       string   `json:"spdxDocument"`
+}
+
+// Can also contain name, comment, seeAlso
+type LicensingInfo struct {
+	LicenseId          string    `json:"licenseId"`
+	ExtractedText      string    `json:"extractedText"`
 }
 
 type CreationInfo struct {


### PR DESCRIPTION
If licenserefs are passed, include them in the SPDX document.

Related: https://github.com/chainguard-dev/melange/issues/1212

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
