### PR TITLE
This fixes the boolean logic to pass auth.

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -98,7 +98,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
 				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
 			} else if parts[0] != "basic" {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first parth)", parts[0])
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
 			} else {
 				// NB: parts[1] is the realm, which we ignore.
 				user, pass = parts[2], parts[3]

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -93,7 +93,13 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 			defer os.RemoveAll(tmp)
 
 			var user, pass string
-			if parts := strings.Split(os.Getenv("HTTP_AUTH"), ":"); len(parts) != 4 && parts[0] == "basic" {
+			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
+				// Fine, no auth.
+			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
+			} else if parts[0] != "basic" {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first parth)", parts[0])
+			} else {
 				// NB: parts[1] is the realm, which we ignore.
 				user, pass = parts[2], parts[3]
 			}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -100,7 +100,13 @@ in a keychain.`,
 			defer os.RemoveAll(tmp)
 
 			var user, pass string
-			if parts := strings.Split(os.Getenv("HTTP_AUTH"), ":"); len(parts) != 4 && parts[0] == "basic" {
+			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
+				// Fine, no auth.
+			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
+			} else if parts[0] != "basic" {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first parth)", parts[0])
+			} else {
 				// NB: parts[1] is the realm, which we ignore.
 				user, pass = parts[2], parts[3]
 			}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -105,7 +105,7 @@ in a keychain.`,
 			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
 				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
 			} else if parts[0] != "basic" {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first parth)", parts[0])
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
 			} else {
 				// NB: parts[1] is the realm, which we ignore.
 				user, pass = parts[2], parts[3]

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -268,7 +268,6 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 	}
 
 	if bc.o.User != "" || bc.o.Pass != "" {
-		log.Infof("using auth for apk") // TODO: remove
 		apkOpts = append(apkOpts, apk.WithAuth(bc.o.User, bc.o.Pass))
 	}
 


### PR DESCRIPTION
As written we refuse to pass auth unless the `HTTP_AUTH` variable DOES NOT have 4 parts, but we really want the opposite.

This change makes things more strict and we will actually error out if `HTTP_AUTH` is specified but malformed.