### PR TITLE
enable per-host auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module chainguard.dev/apko
 
 go 1.22.3
 
-replace github.com/chainguard-dev/go-apk => ../go-apk
-
 require (
 	github.com/chainguard-dev/clog v1.3.1
-	github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a
+	github.com/chainguard-dev/go-apk v0.0.0-20240602190255-5edcf7f32041
 	github.com/charmbracelet/log v0.4.0
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module chainguard.dev/apko
 
 go 1.22.3
 
+replace github.com/chainguard-dev/go-apk => ../go-apk
+
 require (
 	github.com/chainguard-dev/clog v1.3.1
 	github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.3.1 h1:CDNCty5WKQhJzoOPubk0GdXt+bPQyargmfClqebrpaQ=
 github.com/chainguard-dev/clog v1.3.1/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
+github.com/chainguard-dev/go-apk v0.0.0-20240602190255-5edcf7f32041 h1:b2qD/YE1WZ9IufD0CJSR1nWGQi2jDi0dZxbuTVBUF/8=
+github.com/chainguard-dev/go-apk v0.0.0-20240602190255-5edcf7f32041/go.mod h1:4UVB5GXk5yVOVwe3QPdmMLMVTpYbvzygjXlRrJxJPMc=
 github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=
 github.com/charmbracelet/lipgloss v0.10.0/go.mod h1:Wig9DSfvANsxqkRsqj6x87irdy123SR4dOXlKa91ciE=
 github.com/charmbracelet/log v0.4.0 h1:G9bQAcx8rWA2T3pWvx7YtPTPwgqpk7D68BX21IRW8ZM=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainguard-dev/clog v1.3.1 h1:CDNCty5WKQhJzoOPubk0GdXt+bPQyargmfClqebrpaQ=
 github.com/chainguard-dev/clog v1.3.1/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
-github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a h1:E8EgiRgZsmq1Twz6H2gyyzDB0OxHfZ+h3g8R9BimdAU=
-github.com/chainguard-dev/go-apk v0.0.0-20240530214935-2ff9aee8385a/go.mod h1:4UVB5GXk5yVOVwe3QPdmMLMVTpYbvzygjXlRrJxJPMc=
 github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=
 github.com/charmbracelet/lipgloss v0.10.0/go.mod h1:Wig9DSfvANsxqkRsqj6x87irdy123SR4dOXlKa91ciE=
 github.com/charmbracelet/log v0.4.0 h1:G9bQAcx8rWA2T3pWvx7YtPTPwgqpk7D68BX21IRW8ZM=

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -92,7 +92,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 			}
 			defer os.RemoveAll(tmp)
 
-			var user, pass string
+			var domain, user, pass string
 			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
 				// Fine, no auth.
 			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
@@ -100,8 +100,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 			} else if parts[0] != "basic" {
 				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
 			} else {
-				// NB: parts[1] is the realm, which we ignore.
-				user, pass = parts[2], parts[3]
+				domain, user, pass = parts[1], parts[2], parts[3]
 			}
 
 			return BuildCmd(cmd.Context(), args[1], args[2], archs,
@@ -122,7 +121,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithCacheDir(cacheDir, offline),
 				build.WithLockFile(lockfile),
 				build.WithTempDir(tmp),
-				build.WithAuth(user, pass),
+				build.WithAuth(domain, user, pass),
 			)
 		},
 	}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -99,7 +99,7 @@ in a keychain.`,
 			}
 			defer os.RemoveAll(tmp)
 
-			var user, pass string
+			var domain, user, pass string
 			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
 				// Fine, no auth.
 			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
@@ -107,8 +107,7 @@ in a keychain.`,
 			} else if parts[0] != "basic" {
 				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
 			} else {
-				// NB: parts[1] is the realm, which we ignore.
-				user, pass = parts[2], parts[3]
+				domain, user, pass = parts[1], parts[2], parts[3]
 			}
 
 			if err := PublishCmd(cmd.Context(), imageRefs, archs, remoteOpts,
@@ -127,7 +126,7 @@ in a keychain.`,
 					build.WithAnnotations(annotations),
 					build.WithCacheDir(cacheDir, offline),
 					build.WithTempDir(tmp),
-					build.WithAuth(user, pass),
+					build.WithAuth(domain, user, pass),
 				},
 				[]PublishOption{
 					// these are extra here just for publish; everything before is the same for BuildCmd as PublishCmd

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -267,8 +267,8 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		log.Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
 	}
 
-	if bc.o.User != "" || bc.o.Pass != "" {
-		apkOpts = append(apkOpts, apk.WithAuth(bc.o.User, bc.o.Pass))
+	for domain, auth := range bc.o.Auth {
+		apkOpts = append(apkOpts, apk.WithAuth(domain, auth.User, auth.Pass))
 	}
 
 	if bc.ic.Contents.BaseImage != nil {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chainguard-dev/go-apk/pkg/fs"
@@ -124,10 +125,11 @@ func TestAuth_good(t *testing.T) {
 		http.FileServer(http.Dir("testdata/packages")).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	ctx := context.Background()
 	bc, err := build.New(ctx, fs.NewMemFS(),
-		build.WithAuth(testUser, testPass),
+		build.WithAuth(host, testUser, testPass),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
 				Repositories: []string{s.URL},
@@ -162,10 +164,11 @@ func TestAuth_bad(t *testing.T) {
 		http.FileServer(http.Dir("testdata/packages")).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	ctx := context.Background()
 	_, err := build.New(ctx, fs.NewMemFS(),
-		build.WithAuth("baduser", "badpass"),
+		build.WithAuth(host, "baduser", "badpass"),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
 				Keyring: []string{s.URL + "/melange.rsa.pub"},

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -209,14 +209,12 @@ func WithTempDir(tmp string) Option {
 	}
 }
 
-type auth struct{ user, pass string }
-
 func WithAuth(domain, user, pass string) Option {
 	return func(bc *Context) error {
 		if bc.o.Auth == nil {
 			bc.o.Auth = make(map[string]options.Auth)
 		}
-		bc.o.Auth[domain] = options.Auth{user, pass}
+		bc.o.Auth[domain] = options.Auth{User: user, Pass: pass}
 		return nil
 	}
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
 
 	"github.com/chainguard-dev/clog"
 )
@@ -208,10 +209,14 @@ func WithTempDir(tmp string) Option {
 	}
 }
 
-func WithAuth(user, pass string) Option {
+type auth struct{ user, pass string }
+
+func WithAuth(domain, user, pass string) Option {
 	return func(bc *Context) error {
-		bc.o.User = user
-		bc.o.Pass = pass
+		if bc.o.Auth == nil {
+			bc.o.Auth = make(map[string]options.Auth)
+		}
+		bc.o.Auth[domain] = options.Auth{user, pass}
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -48,9 +48,10 @@ type Options struct {
 	CacheDir                string             `json:"cacheDir,omitempty"`
 	Offline                 bool               `json:"offline,omitempty"`
 	Lockfile                string             `json:"lockfile,omitempty"`
-	User                    string             `json:"user"`
-	Pass                    string             `json:"-"`
+	Auth                    map[string]Auth    `json:"-"`
 }
+
+type Auth struct{ User, Pass string }
 
 var Default = Options{
 	Arch:            types.ParseArchitecture(runtime.GOARCH),


### PR DESCRIPTION
Builds on https://github.com/chainguard-dev/go-apk/pull/281

This augments `HTTP_AUTH` handling to (ab)use the `realm` component to specify the domain that the auth should be used for. Domains that don't have auth specified don't pass a user+pass; those that do, do.