### PR TITLE
add test that images with old packages can build

### DIFF
--- a/examples/old-glibc.yaml
+++ b/examples/old-glibc.yaml
@@ -1,0 +1,17 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Testing that old packages with potentially invalid SBOMs can produce a valid image SBOM.
+    - glibc=2.36-r3
+    - binutils=2.39-r4
+    - git=2.39.0-r0
+    - openssl=3.0.7-r0
+    - sysstat=12.6.2-r0
+    - libcrypto3=3.0.8-r0
+
+archs:
+  - x86_64
+  - aarch64

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -277,7 +277,7 @@ func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}) 
 	// Loop until we don't find any new todos.
 	for prev, next := 0, len(todo); next != prev; prev, next = next, len(todo) {
 		for _, r := range sourceDoc.Relationships {
-			if strings.HasPrefix(r.Related, "SPDXRef-File--") {
+			if strings.HasPrefix(r.Related, "SPDXRef-File-") {
 				continue
 			}
 			if _, ok := todo[r.Element]; ok {
@@ -298,7 +298,7 @@ func copySBOMElements(sourceDoc, targetDoc *Document, todo map[string]struct{}) 
 
 	for _, r := range sourceDoc.Relationships {
 		if _, ok := todo[r.Element]; ok {
-			if strings.HasPrefix(r.Related, "SPDXRef-File--") {
+			if strings.HasPrefix(r.Related, "SPDXRef-File-") {
 				continue
 			}
 			targetDoc.Relationships = append(targetDoc.Relationships, r)


### PR DESCRIPTION
We've had some issues where apko can't build images from old packages that contain files data in the package SBOMs, resulting in errors like:

```
│ generating sbom for amd64: generating spdx sbom: parsing internal apk SBOM: copying element: unable to find 137 elements in source document: [SPDXRef-File-/usr/bin/objdump
│ SPDXRef-File-/usr/bin/size SPDXRef-File-/usr/lib/libctf.la SPDXRef-File-/usr/x86_64-pc-linux-gnu/bin/readelf SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf_iamcu.xce
│ SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf_x86_64.xswe SPDXRef-File-/usr/bin/gprof SPDXRef-File-/usr/lib/bfd-plugins/libdep.so SPDXRef-File-/usr/share/man/man1/addr2line.1
│ SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf_iamcu.xsw SPDXRef-File-/usr/share/man/man1/strip.1 SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf32_x86_64.xdw
│ SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf_i386.xbn SPDXRef-File-/usr/x86_64-pc-linux-gnu/lib/ldscripts/elf_iamcu.xdce
```

Melange has since stopped emitting files data in its SBOMs, but this doesn't help with old packages.

This PR fixes that issue, and adds a test that images from some old packages can still produce valid image SBOMs.