### PR TITLE
Add expandapk.Split and use it

### DIFF
--- a/pkg/apk/apk/package_test.go
+++ b/pkg/apk/apk/package_test.go
@@ -72,8 +72,13 @@ func TestParsePackage(t *testing.T) {
 				t.Fatalf("opening apk: %v", err)
 			}
 			defer f.Close()
+
+			stat, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
 			ctx := context.Background()
-			got, err := ParsePackage(ctx, f)
+			got, err := ParsePackage(ctx, f, uint64(stat.Size()))
 			if err != nil {
 				t.Fatalf("ParsePackage(): %v", err)
 			}

--- a/pkg/apk/expandapk/split.go
+++ b/pkg/apk/expandapk/split.go
@@ -1,0 +1,113 @@
+package expandapk
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/klauspost/compress/gzip"
+)
+
+// Split takes an APK reader and splits it into its constituent parts.
+//
+// If the length of the returned slice is 3, the first part is the signature section.
+// If the length of the returned slice is 2, the first part is the control section.
+// The last part is the data section.
+//
+// These values are the compressed gzip streams, and should be decompressed before use.
+//
+// The signature and control sections are buffered in memory, while the data section is streamed
+// from the input reader.
+func Split(source io.Reader) ([]io.Reader, error) {
+	parts := []io.Reader{}
+
+	br := bufio.NewReader(source)
+
+	buf := bytes.Buffer{}
+	tee := &teeByteReader{r: br, w: &buf}
+
+	gzi, err := gzip.NewReader(tee)
+	if err != nil {
+		return nil, fmt.Errorf("creating gzip reader: %w", err)
+	}
+	gzi.Multistream(false)
+
+	tr := tar.NewReader(gzi)
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("reading first tar header: %w", err)
+	}
+
+	// Handle optional signature section.
+	if strings.HasPrefix(hdr.Name, ".SIGN.") {
+		if _, err := io.Copy(io.Discard, gzi); err != nil {
+			return nil, fmt.Errorf("copying signature stream: %w", err)
+		}
+
+		parts = append(parts, bytes.NewReader(buf.Bytes()))
+
+		// Use a new buffer for the control section.
+		buf = bytes.Buffer{}
+		tee.w = &buf
+
+		if err := gzi.Reset(tee); err != nil {
+			return nil, fmt.Errorf("resetting gzip reader after signature: %w", err)
+		}
+		gzi.Multistream(false)
+	}
+
+	// There should always be a control section.
+	if _, err := io.Copy(io.Discard, gzi); err != nil {
+		return nil, fmt.Errorf("copying signature stream: %w", err)
+	}
+
+	parts = append(parts, bytes.NewReader(buf.Bytes()))
+
+	if err := gzi.Close(); err != nil {
+		return nil, fmt.Errorf("closing gzip reader: %w", err)
+	}
+
+	// And the rest is the data section.
+	parts = append(parts, br)
+
+	return parts, nil
+}
+
+// like io.TeeReader but also implements io.ByteReader for gzip.
+//
+// From gzip.Reader.Multistream:
+//
+// > If the underlying reader implements io.ByteReader,
+// > it will be left positioned just after the gzip stream.
+type teeByteReader struct {
+	r interface {
+		io.Reader
+		io.ByteReader
+	}
+
+	w interface {
+		io.Writer
+		io.ByteWriter
+	}
+}
+
+func (t *teeByteReader) ReadByte() (byte, error) {
+	c, err := t.r.ReadByte()
+	if err := t.w.WriteByte(c); err != nil {
+		return c, err
+	}
+	return c, err
+}
+
+func (t *teeByteReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 {
+		if n, err := t.w.Write(p[:n]); err != nil {
+			return n, err
+		}
+	}
+	return n, err
+}

--- a/pkg/apk/expandapk/split_test.go
+++ b/pkg/apk/expandapk/split_test.go
@@ -1,0 +1,63 @@
+package expandapk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	file := "testdata/hello-wolfi-2.12.1-r0.apk"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	parts, err := Split(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(parts), 3; got != want {
+		t.Fatalf("len(Split()): %d != %d", got, want)
+	}
+
+	f2, err := os.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f2.Close()
+
+	exp, err := ExpandApk(context.Background(), f2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer exp.Close()
+
+	checks := []string{exp.SignatureFile, exp.ControlFile, exp.PackageFile}
+
+	for i, part := range parts {
+		check, err := os.Open(checks[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer check.Close()
+
+		want, err := io.ReadAll(check)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Errorf("Split() != ExpandAPK() for part %d (%d, %d)", i, len(got), len(want))
+		}
+	}
+}

--- a/pkg/apk/expandapk/testdata
+++ b/pkg/apk/expandapk/testdata
@@ -1,0 +1,1 @@
+../apk/testdata/


### PR DESCRIPTION
We have a lot of code that calls ExpandAPK. It's a convenient function, but it's incredibly expensive because it does everything all at once. This wasn't supposed to be exposed, but it escaped the lab.

What's worse is that we have things like ParsePackage being used all over the place that also call ExpandAPK. Most things calling ParsePackage only care about the .PKGINFO file, but we end up caching tons of stuff to disk and hashing every file in the APK. This is very wasteful.

Instead, this adds a new expandapk.Split function that just returns a slice of readers in the order they're encountered. The first 1 (or 2 if signed) readers are just buffered bytes. The last reader is whatever remains from the input, which will be the data section.

This allows us to rewrite ParsePackage to be much faster by just requiring the caller to supply a size. The caller is usually in a much better position to know the size via Stat() or headers, so we don't have to consume the entire reader in order to compute it.

This also adds ParsePackageInfo, which includes only the information present in .PKGINFO. The existing struct returned by ParsePackage also includes the APK size and the control section hash, which makes it really confusing to interpret.