### PR TITLE
Add include-paths flag to build and lock.

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -42,7 +42,7 @@ func buildMinirootFS() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return BuildMinirootFSCmd(cmd.Context(),
-				build.WithConfig(args[0]),
+				build.WithConfig(args[0], []string{}),
 				build.WithTarball(args[1]),
 				build.WithBuildDate(buildDate),
 				build.WithSBOM(sbomPath),

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -56,6 +56,7 @@ func buildCmd() *cobra.Command {
 	var cacheDir string
 	var offline bool
 	var lockfile string
+	var includePaths []string
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -108,7 +109,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				[]string{args[1]},
 				writeSBOM,
 				sbomPath,
-				build.WithConfig(args[0]),
+				build.WithConfig(args[0], includePaths),
 				build.WithBuildDate(buildDate),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithSBOM(sbomPath),
@@ -123,6 +124,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithLockFile(lockfile),
 				build.WithTempDir(tmp),
 				build.WithAuth(domain, user, pass),
+				build.WithIncludePaths(includePaths),
 			)
 		},
 	}
@@ -140,7 +142,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
 	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 	cmd.Flags().StringVar(&lockfile, "lockfile", "", "a path to .lock.json file (e.g. produced by apko lock) that constraints versions of packages to the listed ones (default '' means no additional constraints)")
-
+	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir")
 	return cmd
 }
 

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -142,7 +142,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
 	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 	cmd.Flags().StringVar(&lockfile, "lockfile", "", "a path to .lock.json file (e.g. produced by apko lock) that constraints versions of packages to the listed ones (default '' means no additional constraints)")
-	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir")
+	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append.")
 	return cmd
 }
 

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -41,7 +41,7 @@ func TestBuild(t *testing.T) {
 	config := filepath.Join("testdata", "apko.yaml")
 
 	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
-	opts := []build.Option{build.WithConfig(config), build.WithSBOMFormats([]string{"spdx"}), build.WithTags("golden:latest")}
+	opts := []build.Option{build.WithConfig(config, []string{}), build.WithSBOMFormats([]string{"spdx"}), build.WithTags("golden:latest")}
 
 	sbomPath := filepath.Join(tmp, "sboms")
 	err := os.MkdirAll(sbomPath, 0o750)
@@ -116,7 +116,7 @@ func TestBuildWithBase(t *testing.T) {
 	lockfile := filepath.Join("testdata", "image_on_top.apko.lock.json")
 
 	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
-	opts := []build.Option{build.WithConfig(config), build.WithSBOMFormats([]string{"spdx"}), build.WithTags("golden_top:latest"), build.WithLockFile(lockfile), build.WithTempDir(apkoTempDir)}
+	opts := []build.Option{build.WithConfig(config, []string{}), build.WithSBOMFormats([]string{"spdx"}), build.WithTags("golden_top:latest"), build.WithLockFile(lockfile), build.WithTempDir(apkoTempDir)}
 
 	sbomPath := filepath.Join(tmp, "sboms")
 	err := os.MkdirAll(sbomPath, 0o750)

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -67,7 +67,7 @@ apko dot --web -S example.yaml
 		RunE: func(cmd *cobra.Command, args []string) error {
 			archs := types.ParseArchitectures(archstrs)
 			return DotCmd(cmd.Context(), args[0], archs, web, span,
-				build.WithConfig(args[0]),
+				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
 				build.WithCacheDir(cacheDir, offline),

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -51,6 +51,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	var extraRepos []string
 	var archstrs []string
 	var output string
+	var includePaths []string
 
 	cmd := &cobra.Command{
 		Use: cmdName,
@@ -71,9 +72,10 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 				output,
 				archs,
 				[]build.Option{
-					build.WithConfig(args[0]),
+					build.WithConfig(args[0], includePaths),
 					build.WithExtraKeys(extraKeys),
 					build.WithExtraRepos(extraRepos),
+					build.WithIncludePaths(includePaths),
 				},
 			)
 		},
@@ -83,6 +85,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringVar(&output, "output", "", "path to file where lock file will be written")
+	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir")
 
 	return cmd
 }

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -85,7 +85,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringVar(&output, "output", "", "path to file where lock file will be written")
-	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir")
+	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append")
 
 	return cmd
 }

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -35,9 +35,9 @@ func TestLock(t *testing.T) {
 
 	golden := filepath.Join("testdata", "apko.lock.json")
 
-	config := filepath.Join("testdata", "apko.yaml")
+	config := "apko.yaml"
 	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
-	opts := []build.Option{build.WithConfig(config)}
+	opts := []build.Option{build.WithConfig(config, []string{"testdata"})}
 	outputPath := filepath.Join(tmp, "apko.lock.json")
 
 	err := cli.LockCmd(ctx, outputPath, archs, opts)
@@ -63,7 +63,7 @@ func TestLockWithBaseImage(t *testing.T) {
 
 	config := filepath.Join("testdata", "image_on_top.apko.yaml")
 	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
-	opts := []build.Option{build.WithConfig(config)}
+	opts := []build.Option{build.WithConfig(config, []string{})}
 	outputPath := filepath.Join(tmp, "apko.lock.json")
 
 	err := cli.LockCmd(ctx, outputPath, archs, opts)

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -115,7 +115,7 @@ in a keychain.`,
 			if err := PublishCmd(cmd.Context(), imageRefs, archs, remoteOpts,
 				sbomPath,
 				[]build.Option{
-					build.WithConfig(args[0]),
+					build.WithConfig(args[0], []string{}),
 					build.WithBuildDate(buildDate),
 					build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 					build.WithSBOM(sbomPath),

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -62,7 +62,7 @@ func TestPublish(t *testing.T) {
 	outputRefs := ""
 	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
 	ropt := []remote.Option{remote.WithTransport(st)}
-	opts := []build.Option{build.WithConfig(config), build.WithTags(dst), build.WithSBOMFormats(sbom.DefaultOptions.Formats)}
+	opts := []build.Option{build.WithConfig(config, []string{}), build.WithTags(dst), build.WithSBOMFormats(sbom.DefaultOptions.Formats)}
 	publishOpts := []cli.PublishOption{cli.WithTags(dst)}
 
 	sbomPath := filepath.Join(tmp, "sboms")

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -44,7 +44,7 @@ The derived configuration is rendered in YAML.
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ShowConfigCmd(cmd.Context(),
-				build.WithConfig(args[0]),
+				build.WithConfig(args[0], []string{}),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),

--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -107,7 +107,7 @@ packagelock and packagelock-source are particularly useful for inserting back in
 				tmpl = format
 			}
 			return ShowPackagesCmd(cmd.Context(), tmpl, archs,
-				build.WithConfig(args[0]),
+				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
 				build.WithCacheDir(cacheDir, offline),

--- a/internal/cli/testdata/apko.lock.json
+++ b/internal/cli/testdata/apko.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "v1",
   "config": {
-    "name": "testdata/apko.yaml",
+    "name": "apko.yaml",
     "checksum": "sha256-eal7+HCFuOLz/8m3vNO5cYyNK0Zw7AphCcsc76TbTXg="
   },
   "contents": {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -41,6 +41,7 @@ import (
 	"chainguard.dev/apko/pkg/baseimg"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
+	"chainguard.dev/apko/pkg/paths"
 	"chainguard.dev/apko/pkg/s6"
 )
 
@@ -273,7 +274,15 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 	}
 
 	if bc.ic.Contents.BaseImage != nil {
-		baseImg, err := baseimg.New(bc.ic.Contents.BaseImage.Image, bc.ic.Contents.BaseImage.APKIndex, bc.Arch(), bc.o.TempDir())
+		imgPath, err := paths.ResolvePath(bc.ic.Contents.BaseImage.Image, bc.o.IncludePaths)
+		if err != nil {
+			return nil, err
+		}
+		apkindexPath, err := paths.ResolvePath(bc.ic.Contents.BaseImage.APKIndex, bc.o.IncludePaths)
+		if err != nil {
+			return nil, err
+		}
+		baseImg, err := baseimg.New(imgPath, apkindexPath, bc.Arch(), bc.o.TempDir())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -36,7 +36,7 @@ func TestBuildImage(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []build.Option{
-		build.WithConfig(filepath.Join("testdata", "apko.yaml")),
+		build.WithConfig("apko.yaml", []string{"testdata"}),
 	}
 
 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
@@ -64,7 +64,7 @@ func TestBuildImageFromLockFile(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []build.Option{
-		build.WithConfig(filepath.Join("testdata", "apko.yaml")),
+		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
 		build.WithLockFile(filepath.Join("testdata", "apko.lock.json")),
 	}
 
@@ -93,7 +93,7 @@ func TestBuildImageFromTooOldResolvedFile(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []build.Option{
-		build.WithConfig(filepath.Join("testdata", "apko.yaml")),
+		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
 		build.WithLockFile(filepath.Join("testdata", "apko.pre-0.13.lock.json")),
 	}
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -34,7 +34,7 @@ type Option func(*Context) error
 // The image configuration is parsed from given config file.
 // TODO(jason): Remove this.
 // Deprecated: Use WithImageConfiguration instead.
-func WithConfig(configFile string) Option {
+func WithConfig(configFile string, includePaths []string) Option {
 	return func(bc *Context) error {
 		ctx := context.Background()
 		log := clog.FromContext(ctx)
@@ -42,7 +42,7 @@ func WithConfig(configFile string) Option {
 
 		var ic types.ImageConfiguration
 		hasher := sha2562.New()
-		if err := ic.Load(ctx, configFile, hasher); err != nil {
+		if err := ic.Load(ctx, configFile, includePaths, hasher); err != nil {
 			return fmt.Errorf("failed to load image configuration: %w", err)
 		}
 
@@ -143,6 +143,13 @@ func WithExtraRepos(repos []string) Option {
 func WithExtraPackages(packages []string) Option {
 	return func(bc *Context) error {
 		bc.o.ExtraPackages = packages
+		return nil
+	}
+}
+
+func WithIncludePaths(includePaths []string) Option {
+	return func(bc *Context) error {
+		bc.o.IncludePaths = includePaths
 		return nil
 	}
 }

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -14,11 +14,11 @@ import (
 func TestOverlayWithEmptyContents(t *testing.T) {
 	ctx := context.Background()
 
-	configPath := filepath.Join("testdata", "overlay", "overlay.apko.yaml")
+	configPath := filepath.Join("overlay", "overlay.apko.yaml")
 	hasher := sha256.New()
 	ic := types.ImageConfiguration{}
 
-	require.NoError(t, ic.Load(ctx, configPath, hasher))
+	require.NoError(t, ic.Load(ctx, configPath, []string{"testdata"}, hasher))
 	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package"})
@@ -31,7 +31,7 @@ func TestOverlayWithAdditionalPackages(t *testing.T) {
 	hasher := sha256.New()
 	ic := types.ImageConfiguration{}
 
-	require.NoError(t, ic.Load(ctx, configPath, hasher))
+	require.NoError(t, ic.Load(ctx, configPath, []string{}, hasher))
 	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package", "other_package"})
@@ -44,7 +44,7 @@ func TestUserContents(t *testing.T) {
 	hasher := sha256.New()
 	ic := types.ImageConfiguration{}
 
-	require.NoError(t, ic.Load(ctx, configPath, hasher))
+	require.NoError(t, ic.Load(ctx, configPath, []string{}, hasher))
 	if err := ic.Validate(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	Offline                 bool               `json:"offline,omitempty"`
 	Lockfile                string             `json:"lockfile,omitempty"`
 	Auth                    map[string]Auth    `json:"-"`
+	IncludePaths            []string           `json:"includePaths,omitempty"`
 }
 
 type Auth struct{ User, Pass string }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -1,0 +1,21 @@
+package paths
+
+import (
+	"os"
+	"path"
+)
+
+func ResolvePath(p string, includePaths []string) (string, error) {
+	_, err := os.Stat(p)
+	if err == nil {
+		return p, nil
+	}
+	for _, pathPrefix := range includePaths {
+		resolvedPath := path.Join(pathPrefix, p)
+		_, err := os.Stat(resolvedPath)
+		if err == nil {
+			return resolvedPath, nil
+		}
+	}
+	return "", os.ErrNotExist
+}

--- a/pkg/tarfs/fs_test.go
+++ b/pkg/tarfs/fs_test.go
@@ -30,7 +30,7 @@ func TestTarFS(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []build.Option{
-		build.WithConfig(filepath.Join("testdata", "apko.yaml")),
+		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
 	}
 
 	bc, err := build.New(ctx, tfs, opts...)


### PR DESCRIPTION
This works in similar fashion as PATH variable. All config files are searched for in provided include-paths.

By config files I mean:
1. The config file itself
2. Included configs
3. Base image and it's metadata
