### PR TITLE
Plumb through the notion of build-time repositories.

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -50,7 +50,8 @@ func buildCmd() *cobra.Command {
 	var sbomPath string
 	var sbomFormats []string
 	var extraKeys []string
-	var extraRepos []string
+	var extraBuildRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 	var rawAnnotations []string
 	var cacheDir string
@@ -115,7 +116,8 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithSBOM(sbomPath),
 				build.WithSBOMFormats(sbomFormats),
 				build.WithExtraKeys(extraKeys),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraBuildRepos(extraBuildRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithExtraPackages(extraPackages),
 				build.WithTags(args[1]),
 				build.WithVCS(withVCS),
@@ -136,7 +138,8 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -42,7 +42,8 @@ import (
 
 func dotcmd() *cobra.Command {
 	var extraKeys []string
-	var extraRepos []string
+	var extraBuildRepos []string
+	var extraRuntimeRepos []string
 	var archstrs []string
 	var web, span bool
 	var cacheDir string
@@ -69,14 +70,16 @@ apko dot --web -S example.yaml
 			return DotCmd(cmd.Context(), args[0], archs, web, span,
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraBuildRepos(extraBuildRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCacheDir(cacheDir, offline),
 			)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().BoolVarP(&span, "spanning-tree", "S", false, "does something like a spanning tree to avoid a huge number of edges")
 	cmd.Flags().BoolVar(&web, "web", false, "launch a browser")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -45,7 +45,8 @@ func publish() *cobra.Command {
 	var sbomFormats []string
 	var archstrs []string
 	var extraKeys []string
-	var extraRepos []string
+	var extraBuildRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 	var rawAnnotations []string
 	var withVCS bool
@@ -121,7 +122,8 @@ in a keychain.`,
 					build.WithSBOM(sbomPath),
 					build.WithSBOMFormats(sbomFormats),
 					build.WithExtraKeys(extraKeys),
-					build.WithExtraRepos(extraRepos),
+					build.WithExtraBuildRepos(extraBuildRepos),
+					build.WithExtraRuntimeRepos(extraRuntimeRepos),
 					build.WithExtraPackages(extraPackages),
 					build.WithTags(args[1:]...),
 					build.WithVCS(withVCS),
@@ -150,7 +152,8 @@ in a keychain.`,
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -29,7 +29,8 @@ import (
 
 func showConfig() *cobra.Command {
 	var extraKeys []string
-	var extraRepos []string
+	var extraBuildRepos []string
+	var extraRuntimeRepos []string
 	var cacheDir string
 	var offline bool
 
@@ -47,14 +48,16 @@ The derived configuration is rendered in YAML.
 				build.WithConfig(args[0], []string{}),
 				build.WithAssertions(build.RequireGroupFile(true), build.RequirePasswdFile(true)),
 				build.WithExtraKeys(extraKeys),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraBuildRepos(extraBuildRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCacheDir(cacheDir, offline),
 			)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
 	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 

--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -65,7 +65,8 @@ type pkgInfo struct {
 
 func showPackages() *cobra.Command {
 	var extraKeys []string
-	var extraRepos []string
+	var extraBuildRepos []string
+	var extraRuntimeRepos []string
 	var archstrs []string
 	var format string
 	var tmpl string
@@ -109,14 +110,16 @@ packagelock and packagelock-source are particularly useful for inserting back in
 			return ShowPackagesCmd(cmd.Context(), tmpl, archs,
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraBuildRepos(extraBuildRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCacheDir(cacheDir, offline),
 			)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringVar(&format, "format", showPkgsFormatDefault, "format for showing packages; if pre-defined from list, will use that, else go template. See https://pkg.go.dev/text/template for more information. Available vars are `.Name`, `.Version`, `.Source`")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/testdata/apko.lock.json
+++ b/internal/cli/testdata/apko.lock.json
@@ -11,6 +11,7 @@
         "url": "./testdata/melange.rsa.pub"
       }
     ],
+    "build_repositories": [],
     "repositories": [
       {
         "name": "./testdata/packages/x86_64",

--- a/internal/cli/testdata/image_on_top.apko.lock.json
+++ b/internal/cli/testdata/image_on_top.apko.lock.json
@@ -11,6 +11,7 @@
         "url": "./testdata/melange.rsa.pub"
       }
     ],
+    "build_repositories": [],
     "repositories": [
       {
         "name": "./testdata/packages/x86_64",

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -99,8 +99,7 @@ func (a *APK) SetRepositories(ctx context.Context, repos []string) error {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "SetRepositories")
 	defer span.End()
 
-	log := clog.FromContext(ctx)
-	log.Debug("setting apk repositories")
+	clog.InfoContextf(ctx, "setting apk repositories: %v", repos)
 
 	if len(repos) == 0 {
 		return fmt.Errorf("must provide at least one repository")

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -132,9 +132,9 @@ func TestAuth_good(t *testing.T) {
 		build.WithAuth(host, testUser, testPass),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Repositories: []string{s.URL},
-				Keyring:      []string{s.URL + "/melange.rsa.pub"},
-				Packages:     []string{"pretend-baselayout"},
+				RuntimeRepositories: []string{s.URL},
+				Keyring:             []string{s.URL + "/melange.rsa.pub"},
+				Packages:            []string{"pretend-baselayout"},
 			},
 			Archs: types.ParseArchitectures([]string{"amd64", "arm64"}),
 		}),

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -133,9 +133,16 @@ func WithExtraKeys(keys []string) Option {
 	}
 }
 
-func WithExtraRepos(repos []string) Option {
+func WithExtraBuildRepos(repos []string) Option {
 	return func(bc *Context) error {
-		bc.o.ExtraRepos = repos
+		bc.o.ExtraBuildRepos = repos
+		return nil
+	}
+}
+
+func WithExtraRuntimeRepos(repos []string) Option {
+	return func(bc *Context) error {
+		bc.o.ExtraRuntimeRepos = repos
 		return nil
 	}
 }

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -71,8 +71,11 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, incl
 		keyring := append([]string{}, baseIc.Contents.Keyring...)
 		keyring = append(keyring, ic.Contents.Keyring...)
 
-		repos := append([]string{}, baseIc.Contents.Repositories...)
-		repos = append(repos, ic.Contents.Repositories...)
+		buildRepos := append([]string{}, baseIc.Contents.BuildRepositories...)
+		buildRepos = append(buildRepos, ic.Contents.BuildRepositories...)
+
+		runtimeRepos := append([]string{}, baseIc.Contents.RuntimeRepositories...)
+		runtimeRepos = append(runtimeRepos, ic.Contents.RuntimeRepositories...)
 
 		pkgs := append([]string{}, baseIc.Contents.Packages...)
 		pkgs = append(pkgs, ic.Contents.Packages...)
@@ -94,16 +97,24 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, incl
 
 		// Finally, update the repeated fields to the merged ones.
 		ic.Contents.Keyring = keyring
-		ic.Contents.Repositories = repos
+		ic.Contents.BuildRepositories = buildRepos
+		ic.Contents.RuntimeRepositories = runtimeRepos
 		ic.Contents.Packages = pkgs
 	}
 
-	repos := make([]string, 0, len(ic.Contents.Repositories))
-	for _, repo := range ic.Contents.Repositories {
+	runtimeRepos := make([]string, 0, len(ic.Contents.RuntimeRepositories))
+	for _, repo := range ic.Contents.RuntimeRepositories {
 		repo = strings.TrimRight(repo, "/")
-		repos = append(repos, repo)
+		runtimeRepos = append(runtimeRepos, repo)
 	}
-	ic.Contents.Repositories = repos
+	ic.Contents.RuntimeRepositories = runtimeRepos
+
+	buildRepos := make([]string, 0, len(ic.Contents.BuildRepositories))
+	for _, repo := range ic.Contents.BuildRepositories {
+		repo = strings.TrimRight(repo, "/")
+		buildRepos = append(buildRepos, repo)
+	}
+	ic.Contents.BuildRepositories = buildRepos
 
 	// The top level components restriction is on the conservative side. Some of them would probably work out of the box.
 	// If someone needs any of them, it should be a matter of testing and hopefully doing minor changes.
@@ -235,7 +246,8 @@ func (ic *ImageConfiguration) Summarize(ctx context.Context) {
 
 	log.Infof("image configuration:")
 	log.Infof("  contents:")
-	log.Infof("    repositories: %v", ic.Contents.Repositories)
+	log.Infof("    build repositories: %v", ic.Contents.BuildRepositories)
+	log.Infof("    runtime repositories: %v", ic.Contents.RuntimeRepositories)
 	log.Infof("    keyring:      %v", ic.Contents.Keyring)
 	log.Infof("    packages:     %v", ic.Contents.Packages)
 	if ic.Entrypoint.Type != "" || ic.Entrypoint.Command != "" || len(ic.Entrypoint.Services) != 0 {

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -19,7 +19,8 @@ func TestOverlayWithEmptyContents(t *testing.T) {
 	ic := types.ImageConfiguration{}
 
 	require.NoError(t, ic.Load(ctx, configPath, []string{"testdata"}, hasher))
-	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.BuildRepositories, []string{"secret repository"})
+	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package"})
 }
@@ -32,7 +33,8 @@ func TestOverlayWithAdditionalPackages(t *testing.T) {
 	ic := types.ImageConfiguration{}
 
 	require.NoError(t, ic.Load(ctx, configPath, []string{}, hasher))
-	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.BuildRepositories, []string{"secret repository", "other_secret repository"})
+	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package", "other_package"})
 }

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -141,12 +141,19 @@
     },
     "ImageContents": {
       "properties": {
+        "build_repositories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "A list of apk repositories to use for pulling packages at build time,\nwhich are not installed into /etc/apk/repositories in the image (to\ninstall packages at runtime)"
+        },
         "repositories": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "A list of apk repositories to use for pulling packages"
+          "description": "A list of apk repositories to use for pulling packages during both the\ninitial construction of the image, and also at runtime by seeding them\ninto /etc/apk/repositories in the resulting image."
         },
         "keyring": {
           "items": {

--- a/pkg/build/types/testdata/overlay/base.apko.yaml
+++ b/pkg/build/types/testdata/overlay/base.apko.yaml
@@ -1,4 +1,6 @@
 contents:
+  build_repositories:
+    - "secret repository"
   repositories:
     - "repository"
   keyring:

--- a/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
+++ b/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
@@ -1,5 +1,7 @@
 include: testdata/overlay/overlay.apko.yaml
 
 contents:
+  build_repositories:
+    - "other_secret repository"
   packages:
     - "other_package"

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -21,8 +21,9 @@ type Config struct {
 }
 
 type LockContents struct {
-	Keyrings     []LockKeyring `json:"keyring"`
-	Repositories []LockRepo    `json:"repositories"`
+	Keyrings            []LockKeyring `json:"keyring"`
+	BuildRepositories   []LockRepo    `json:"build_repositories"`
+	RuntimeRepositories []LockRepo    `json:"repositories"`
 	// Packages in order of installation -> for a single architecture.
 	Packages []LockPkg `json:"packages"`
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -36,7 +36,8 @@ type Options struct {
 	SBOMPath                string             `json:"sbomPath,omitempty"`
 	SBOMFormats             []string           `json:"sbomFormats,omitempty"`
 	ExtraKeyFiles           []string           `json:"extraKeyFiles,omitempty"`
-	ExtraRepos              []string           `json:"extraRepos,omitempty"`
+	ExtraBuildRepos         []string           `json:"extraBuildRepos,omitempty"`
+	ExtraRuntimeRepos       []string           `json:"extraRepos,omitempty"`
 	ExtraPackages           []string           `json:"extraPackages,omitempty"`
 	Arch                    types.Architecture `json:"arch,omitempty"`
 	TempDirPath             string             `json:"tempDirPath,omitempty"`


### PR DESCRIPTION
There are three interesting use cases enabled by this change:

1. Silence `./packages` warnings with our private images.

Currently for our private images, we pull private packages via GCS fuse mounted to `./packages/`.  This results in warnings from `apk` when the indices are updated today because this path does not exist.

By making `./packages` a build-time only thing, this goes away.

2. Stop leaking auth in build repository URLs into the final image

Currently it is impossible to use `https://user:pass@repo` style repositories without the credential leaking into the image's `/etc/apk/repositories`.

With this change, credentialed URLs may be passed to `--build-repository-append` and the credentials will only be used for the initial image construction and not be present in the final image.

3. Enable using private APK registries with `HTTP_AUTH` without breaking `apk update`

We uncovered an unfortunate side-effect of switching from `./packages` to `apk.cgr.dev/chainguard-private` for our packages: `apk update` breaks.

With the former, we get a `WARNING` that `./packages` is not found (see `1.` above).

With the latter, we get a `WARNING` that the caller isn't authorized, but unlike `./packages` it returns a non-zero exit code breaking `Dockerfile` builds.

Armed with this change, we can move `apk.cgr.dev/chainguard-private` into our `build_repositories`, specify auth at build-time via `HTTP_AUTH` and avoid the private repository URL leaking into the final image causing `apk update` to break.