### PR TITLE
 Make solving multi-architecture aware

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -246,7 +246,7 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 	// computation.
 	multiArchBDE := o.SourceDateEpoch
 
-	mc, err := build.NewMulti(ctx, archs, opts...)
+	mc, err := build.NewMultiArch(ctx, archs, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -257,6 +257,12 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 		}
 	}
 
+	// This is a little different, but we use a multiarch builder to call BuildLayers because we want
+	// each architecture to be aware of the other architectures during the solve stage. We don't want
+	// to select any packages unless they are available on every architecture because we want solutions
+	// to match across architectures.
+	//
+	// Eventually, we probably want to do something similar for all this logic around stitching images together.
 	layers, err := mc.BuildLayers(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("building layers: %w", err)

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -29,7 +29,6 @@ import (
 	coci "github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 
@@ -39,7 +38,6 @@ import (
 	"chainguard.dev/apko/pkg/build/oci"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/sbom"
-	"chainguard.dev/apko/pkg/tarfs"
 )
 
 func buildCmd() *cobra.Command {
@@ -236,10 +234,9 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 	if err := os.MkdirAll(imageDir, 0755); err != nil {
 		return nil, nil, fmt.Errorf("unable to create working image directory %s: %w", imageDir, err)
 	}
+	opts = append(opts, build.WithSBOM(imageDir))
 
 	imgs := map[types.Architecture]coci.SignedImage{}
-	contexts := map[types.Architecture]*build.Context{}
-	imageTars := map[types.Architecture]string{}
 
 	mtx := sync.Mutex{}
 
@@ -249,34 +246,31 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 	// computation.
 	multiArchBDE := o.SourceDateEpoch
 
-	for _, arch := range archs {
-		arch := arch
-		bopts := slices.Clone(opts)
-		bopts = append(bopts,
-			build.WithArch(arch),
-			build.WithSBOM(imageDir),
-		)
+	mc, err := build.NewMulti(ctx, archs, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
 
-		bc, err := build.New(ctx, tarfs.New(), bopts...)
-		if err != nil {
-			return nil, nil, err
-		}
-
+	for _, bc := range mc.Contexts {
 		if bc.ImageConfiguration().Contents.BaseImage != nil && o.Lockfile == "" {
 			return nil, nil, fmt.Errorf("building with base image is supported only with a lockfile")
 		}
+	}
 
-		// save the build context for later
-		contexts[arch] = bc
+	layers, err := mc.BuildLayers(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building layers: %w", err)
+	}
+
+	for _, arch := range archs {
+		arch := arch
 
 		errg.Go(func() error {
 			log := clog.New(slog.Default().Handler()).With("arch", arch.ToAPK())
 			ctx := clog.WithLogger(ctx, log)
 
-			layerTarGZ, layer, err := bc.BuildLayer(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to build layer image for %q: %w", arch, err)
-			}
+			bc := mc.Contexts[arch]
+			layer := layers[arch]
 
 			// Compute the "build date epoch" from the packages that were
 			// installed.  The "build date epoch" is the MAX of the builddate
@@ -299,7 +293,6 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 			defer mtx.Unlock()
 
 			imgs[arch] = img
-			imageTars[arch] = layerTarGZ
 
 			if bde.After(multiArchBDE) {
 				multiArchBDE = bde
@@ -321,7 +314,6 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 	opts = append(opts,
 		build.WithImageConfiguration(*ic),       // We mutate Archs above.
 		build.WithSourceDateEpoch(multiArchBDE), // Maximum child's time.
-		build.WithSBOM(imageDir),
 	)
 
 	o, ic, err = build.NewOptions(opts...)
@@ -341,7 +333,7 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 		)
 		for arch, img := range imgs {
 			arch, img := arch, img
-			bc := contexts[arch]
+			bc := mc.Contexts[arch]
 
 			g.Go(func() error {
 				log := clog.New(slog.Default().Handler()).With("arch", arch.ToAPK())

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
@@ -458,7 +459,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		// - eliminate duplicates
 		// - reverse the order, so that it is in order of installation
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
-		pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.NoErrorf(t, err, "unable to get packages")
 		actual := make([]string, 0, len(pkgs))
 		for _, pkg := range pkgs {
@@ -479,7 +480,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 			name, version := "package5", "2.0.0" //nolint:goconst // no, we do not want to make it a constant
 			names := []string{name, "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -493,7 +494,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 			name, version := "package5", "1.5.1"
 			names := []string{fmt.Sprintf("%s=%s", name, version), "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -507,7 +508,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 			providesName, version := "package5-special", "1.2.0"
 			names := []string{providesName, "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -525,7 +526,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		names := []string{"package5-special", "package5-noconflict", "abc9"}
 		sort.Strings(names)
-		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.NoError(t, err, "provided package should not conflict")
 	})
 	t.Run("conflicting provides", func(t *testing.T) {
@@ -535,7 +536,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		names := []string{"package5-special", "package5-conflict", "abc9"}
 		sort.Strings(names)
-		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.Error(t, err, "provided package should conflict")
 	})
 	t.Run("locked versions", func(t *testing.T) {
@@ -545,7 +546,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		names := []string{"package5", "locked-dep"}
 		sort.Strings(names)
-		install, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		install, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.NoError(t, err)
 		want := []string{
 			"package5-1.5.1",
@@ -562,7 +563,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		names := []string{"package5>1.0.0", "package5=1.5.1"}
 		sort.Strings(names)
-		install, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		install, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.NoError(t, err)
 		want := []string{
 			"package5-1.5.1",
@@ -578,7 +579,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		names := []string{"package5=1.0.0", "package5=1.5.1"}
 		sort.Strings(names)
-		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
+		_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, nil)
 		require.Error(t, err, "Packages should conflict")
 	})
 }
@@ -852,7 +853,7 @@ func TestExcludedDeps(t *testing.T) {
 	}
 
 	resolver := makeResolver(providers, dependers)
-	pkgs, conflicts, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"})
+	pkgs, conflicts, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"}, nil)
 	require.NoError(t, err)
 
 	wantPkgs := []string{
@@ -879,7 +880,7 @@ func TestSameProvidedVersion(t *testing.T) {
 	}
 
 	resolver := makeResolver(providers, dependers)
-	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"})
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"}, nil)
 	require.NoError(t, err)
 
 	// When two options provide the same version of a virtual, we expect to take the higher version package.
@@ -904,7 +905,7 @@ func TestHigherProvidedVersion(t *testing.T) {
 	}
 
 	resolver := makeResolver(providers, dependers)
-	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"})
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc"}, nil)
 	require.NoError(t, err)
 
 	// When two options provide the different versions of a virtual, we expect to take the higher virtual version.
@@ -931,7 +932,7 @@ func TestConstrains(t *testing.T) {
 	}
 
 	resolver := makeResolver(providers, dependers)
-	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc~2.38", "foo"})
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"glibc~2.38", "foo"}, nil)
 	require.NoError(t, err)
 
 	// We expect to get the r10 of ld-linux because glibc~2.38 should constraint the solution to that, even though "foo" doesn't care.
@@ -998,4 +999,24 @@ func makeResolver(provs, deps map[string][]string) *PkgResolver {
 		Packages: maps.Values(packages),
 	})
 	return NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{repoWithIndex}))
+}
+
+func TestDisqualifyingOtherArchitectures(t *testing.T) {
+	names := []string{"package1", "package2", "onlyinarm64"}
+	_, index := testGetPackagesAndIndex()
+
+	others := map[string][]NamedIndex{
+		"x86_64": testNamedRepositoryFromIndexes(index),
+	}
+
+	arm64 := slices.Clone(index)
+	repo := Repository{}
+	repoWithIndex := repo.WithIndex(&APKIndex{
+		Packages: []*Package{{Name: "onlyinarm64", Version: "1.0.0"}},
+	})
+	arm64 = append(arm64, repoWithIndex)
+
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(arm64))
+	_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, others)
+	require.ErrorContains(t, err, "package \"onlyinarm64-1.0.0.apk\" not available for arch \"x86_64\"")
 }

--- a/pkg/build/multi.go
+++ b/pkg/build/multi.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/tarfs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+// Multi is a build context that can be used to build a multi-architecture image.
+// It is used to coordinate the solvers across architectures to ensure they have a consistent solution.
+// It does this by disqualifying any packages that are not present in other architectures.
+type Multi struct {
+	Contexts map[types.Architecture]*Context
+}
+
+func NewMulti(ctx context.Context, archs []types.Architecture, opts ...Option) (*Multi, error) {
+	m := &Multi{
+		Contexts: make(map[types.Architecture]*Context),
+	}
+
+	for _, arch := range archs {
+		fs := tarfs.New()
+		bopts := slices.Clone(opts)
+		bopts = append(bopts, WithArch(arch))
+		c, err := New(ctx, fs, bopts...)
+		if err != nil {
+			return nil, err
+		}
+		m.Contexts[arch] = c
+	}
+
+	return m, nil
+}
+
+func (m *Multi) BuildLayers(ctx context.Context) (map[types.Architecture]v1.Layer, error) {
+	var (
+		g  errgroup.Group
+		mu sync.Mutex
+	)
+	layers := map[types.Architecture]v1.Layer{}
+	for arch, bc := range m.Contexts {
+		arch, bc := arch, bc
+
+		g.Go(func() error {
+			_, layer, err := bc.BuildLayer(ctx)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			layers[arch] = layer
+
+			return nil
+		})
+	}
+
+	return layers, g.Wait()
+}

--- a/pkg/tarfs/fs_test.go
+++ b/pkg/tarfs/fs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tarfs
+package tarfs_test
 
 import (
 	"archive/tar"
@@ -23,10 +23,11 @@ import (
 	"chainguard.dev/apko/pkg/apk/apk"
 
 	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/tarfs"
 )
 
 func TestTarFS(t *testing.T) {
-	tfs := New()
+	tfs := tarfs.New()
 	ctx := context.Background()
 
 	opts := []build.Option{


### PR DESCRIPTION
When building an image with multiple architectures, we now disqualify any packages that aren't available on every architecture.

An example given wolfi trying to solve for `trivy=0.36.1-r2`, which was only built for arm64, probably because there was a bug in the build that was fixed in a subsequent epoch:

>   for arch "arm64": installing apk packages: error getting package dependencies: solving "trivy=0.36.1-r2" constraint:
>   ...
>   trivy-0.36.1-r2.apk disqualified because package "trivy-0.36.1-r2.apk" not available for arch "amd64"