### PR TITLE
auth: refactor into Authenticator interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.21.0
+	golang.org/x/time v0.5.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.30.2

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -22,7 +22,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -94,17 +93,6 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 			}
 			defer os.RemoveAll(tmp)
 
-			var domain, user, pass string
-			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
-				// Fine, no auth.
-			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
-			} else if parts[0] != "basic" {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
-			} else {
-				domain, user, pass = parts[1], parts[2], parts[3]
-			}
-
 			return BuildCmd(cmd.Context(), args[1], args[2], archs,
 				[]string{args[1]},
 				writeSBOM,
@@ -124,7 +112,6 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithCacheDir(cacheDir, offline),
 				build.WithLockFile(lockfile),
 				build.WithTempDir(tmp),
-				build.WithAuth(domain, user, pass),
 				build.WithIncludePaths(includePaths),
 				build.WithIgnoreSignatures(ignoreSignatures),
 			)

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -103,17 +103,6 @@ in a keychain.`,
 			}
 			defer os.RemoveAll(tmp)
 
-			var domain, user, pass string
-			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
-				// Fine, no auth.
-			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
-			} else if parts[0] != "basic" {
-				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
-			} else {
-				domain, user, pass = parts[1], parts[2], parts[3]
-			}
-
 			if err := PublishCmd(cmd.Context(), imageRefs, archs, remoteOpts,
 				sbomPath,
 				[]build.Option{
@@ -132,7 +121,6 @@ in a keychain.`,
 					build.WithCacheDir(cacheDir, offline),
 					build.WithLockFile(lockfile),
 					build.WithTempDir(tmp),
-					build.WithAuth(domain, user, pass),
 					build.WithIgnoreSignatures(ignoreSignatures),
 				},
 				[]PublishOption{

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -43,6 +43,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/ini.v1"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/apk/expandapk"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/apk/internal/tarfs"
@@ -65,7 +66,7 @@ type APK struct {
 	cache              *cache
 	ignoreSignatures   bool
 	noSignatureIndexes []string
-	auth               map[string]auth
+	auth               auth.Authenticator
 
 	// filename to owning package, last write wins
 	installedFiles map[string]*Package
@@ -412,15 +413,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 					return err
 				}
 
-				// if the URL contains HTTP Basic Auth credentials, add them to the request
-				if asURL.User != nil {
-					user := asURL.User.Username()
-					pass, _ := asURL.User.Password()
-					req.SetBasicAuth(user, pass)
-					req.URL.User = nil
-				} else if a, ok := a.auth[asURL.Host]; ok && a.user != "" && a.pass != "" {
-					req.SetBasicAuth(a.user, a.pass)
-				}
+				a.auth.AddAuth(ctx, req)
 
 				resp, err := client.Do(req)
 				if err != nil {
@@ -1073,9 +1066,7 @@ func (a *APK) FetchPackage(ctx context.Context, pkg InstallablePackage) (io.Read
 		if err != nil {
 			return nil, err
 		}
-		if a, ok := a.auth[asURL.Host]; ok && a.user != "" && a.pass != "" {
-			req.SetBasicAuth(a.user, a.pass)
-		}
+		a.auth.AddAuth(ctx, req)
 
 		// This will return a body that retries requests using Range requests if Read() hits an error.
 		rrt := newRangeRetryTransport(ctx, client)

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -412,7 +412,6 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				if err != nil {
 					return err
 				}
-
 				a.auth.AddAuth(ctx, req)
 
 				resp, err := client.Do(req)
@@ -422,7 +421,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				defer resp.Body.Close()
 
 				if resp.StatusCode < 200 || resp.StatusCode > 299 {
-					return fmt.Errorf("failed to fetch apk key: http response indicated error code: %d", resp.StatusCode)
+					return fmt.Errorf("failed to fetch apk key from %s: http response indicated error code: %d", req.Host, resp.StatusCode)
 				}
 
 				data, err = io.ReadAll(resp.Body)

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 )
 
@@ -247,7 +248,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuth(host, testUser, testPass))
+			a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -262,7 +263,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuth(host, "baduser", "badpass"))
+			a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -556,7 +557,7 @@ func TestAuth_good(t *testing.T) {
 	err := src.MkdirAll("lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuth(host, testUser, testPass))
+	a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)
@@ -588,7 +589,7 @@ func TestAuth_bad(t *testing.T) {
 	err := src.MkdirAll("lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuth(host, "baduser", "badpass"))
+	a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -209,7 +209,6 @@ func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, a
 		if err != nil {
 			return nil, err
 		}
-
 		opts.auth.AddAuth(ctx, req)
 
 		// This will return a body that retries requests using Range requests if Read() hits an error.

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 )
 
@@ -30,7 +31,7 @@ type opts struct {
 	version            string
 	cache              *cache
 	noSignatureIndexes []string
-	auth               map[string]auth
+	auth               auth.Authenticator
 	ignoreSignatures   bool
 }
 
@@ -116,14 +117,9 @@ func WithNoSignatureIndexes(noSignatureIndex ...string) Option {
 	}
 }
 
-type auth struct{ user, pass string }
-
-func WithAuth(domain, user, pass string) Option {
+func WithAuthenticator(a auth.Authenticator) Option {
 	return func(o *opts) error {
-		if o.auth == nil {
-			o.auth = make(map[string]auth)
-		}
-		o.auth[domain] = auth{user, pass}
+		o.auth = a
 		return nil
 	}
 }
@@ -132,5 +128,6 @@ func defaultOpts() *opts {
 	return &opts{
 		arch:              ArchToAPK(runtime.GOARCH),
 		ignoreMknodErrors: false,
+		auth:              auth.DefaultAuthenciators,
 	}
 }

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -178,9 +178,8 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	}
 	opts := []IndexOption{WithIgnoreSignatures(ignoreSignatures),
 		WithIgnoreSignatureForIndexes(a.noSignatureIndexes...),
-		WithHTTPClient(httpClient)}
-	for domain, auth := range a.auth {
-		opts = append(opts, WithIndexAuth(domain, auth.user, auth.pass))
+		WithHTTPClient(httpClient),
+		WithIndexAuthenticator(a.auth),
 	}
 	return GetRepositoryIndexes(ctx, repos, keys, arch, opts...)
 }

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 )
 
@@ -321,8 +322,8 @@ func TestIndexAuth_good(t *testing.T) {
 	ctx := context.Background()
 
 	a, err := New(WithFS(apkfs.NewMemFS()),
-		WithAuth(host, testUser, testPass),
-		WithArch("x86_64"))
+		WithArch("x86_64"),
+		WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 	require.NoErrorf(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err, "unable to init db")
@@ -350,8 +351,8 @@ func TestIndexAuth_bad(t *testing.T) {
 	ctx := context.Background()
 
 	a, err := New(WithFS(apkfs.NewMemFS()),
-		WithAuth(host, "baduser", "badpass"),
-		WithArch("x86_64"))
+		WithArch("x86_64"),
+		WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 	require.NoErrorf(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err, "unable to init db")

--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+)
+
+// DefaultAuthenciators is a list of authenticators that are used by default.
+var DefaultAuthenciators = multiAuthenticator{EnvAuth{}, CGRAuth{}}
+
+// Authenticator is an interface for types that can add HTTP basic auth to a
+// request.
+type Authenticator interface {
+	AddAuth(ctx context.Context, req *http.Request)
+}
+
+// MultiAuthenticator returns an Authenticator that tries each of the given
+// authenticators in order until one of them adds auth to the request.
+func MultiAuthenticator(auths ...Authenticator) Authenticator { return multiAuthenticator(auths) }
+
+type multiAuthenticator []Authenticator
+
+func (m multiAuthenticator) AddAuth(ctx context.Context, req *http.Request) {
+	for _, a := range m {
+		if _, _, ok := req.BasicAuth(); ok {
+			// The request has auth, so we can stop here.
+			return
+		}
+		a.AddAuth(ctx, req)
+	}
+}
+
+// EnvAuth adds HTTP basic auth to the request if the request URL matches the
+// HTTP_AUTH environment variable.
+type EnvAuth struct{}
+
+func (e EnvAuth) AddAuth(_ context.Context, req *http.Request) {
+	env := os.Getenv("HTTP_AUTH")
+	parts := strings.Split(env, ":")
+	if len(parts) != 4 || parts[0] != "basic" {
+		return
+	}
+	if req.URL.Host == parts[1] {
+		req.SetBasicAuth(parts[2], parts[3])
+	}
+}
+
+// CGRAuth adds HTTP basic auth to the request if the request URL matches
+// apk.cgr.dev and the chainctl command is available.
+type CGRAuth struct{}
+
+func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) {
+	log := clog.FromContext(ctx)
+
+	host := req.Host
+	if host != "apk.cgr.dev" {
+		return
+	}
+
+	if _, err := exec.LookPath("chainctl"); err != nil {
+		log.Warnf("chainctl not found, skipping CGR auth")
+		return
+	}
+
+	cmd := exec.CommandContext(ctx, "chainctl", "auth", "token", "--audience", host)
+	out, err := cmd.Output()
+	if err != nil {
+		log.Warnf("Error running `chainctl auth token`: %v", err)
+		return
+	}
+	req.SetBasicAuth("user", string(out))
+}

--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -76,3 +76,17 @@ func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) {
 	}
 	req.SetBasicAuth("user", string(out))
 }
+
+// StaticAuth is an Authenticator that adds HTTP basic auth to the request if
+// the request URL matches the given domain.
+func StaticAuth(domain, user, pass string) Authenticator {
+	return staticAuth{domain, user, pass}
+}
+
+type staticAuth struct{ domain, user, pass string }
+
+func (s staticAuth) AddAuth(_ context.Context, req *http.Request) {
+	if req.Host == s.domain {
+		req.SetBasicAuth(s.user, s.pass)
+	}
+}

--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -67,6 +67,7 @@ func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) {
 		return
 	}
 
+	// TODO(jason): Don't call this more than once per minute.
 	cmd := exec.CommandContext(ctx, "chainctl", "auth", "token", "--audience", host)
 	out, err := cmd.Output()
 	if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -252,6 +252,7 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		apk.WithArch(bc.o.Arch.ToAPK()),
 		apk.WithIgnoreMknodErrors(true),
 		apk.WithIgnoreIndexSignatures(bc.o.IgnoreSignatures),
+		apk.WithAuthenticator(bc.o.Auth),
 	}
 	// only try to pass the cache dir if one of the following is true:
 	// - the user has explicitly set a cache dir
@@ -268,10 +269,6 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline))
 	} else {
 		log.Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
-	}
-
-	for domain, auth := range bc.o.Auth {
-		apkOpts = append(apkOpts, apk.WithAuth(domain, auth.User, auth.Pass))
 	}
 
 	if bc.ic.Contents.BaseImage != nil {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
@@ -129,7 +130,6 @@ func TestAuth_good(t *testing.T) {
 
 	ctx := context.Background()
 	bc, err := build.New(ctx, fs.NewMemFS(),
-		build.WithAuth(host, testUser, testPass),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
 				RuntimeRepositories: []string{s.URL},
@@ -138,7 +138,7 @@ func TestAuth_good(t *testing.T) {
 			},
 			Archs: types.ParseArchitectures([]string{"amd64", "arm64"}),
 		}),
-	)
+		build.WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,6 @@ func TestAuth_bad(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := build.New(ctx, fs.NewMemFS(),
-		build.WithAuth(host, "baduser", "badpass"),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
 				Keyring: []string{s.URL + "/melange.rsa.pub"},
@@ -176,6 +175,7 @@ func TestAuth_bad(t *testing.T) {
 			},
 			Archs: types.ParseArchitectures([]string{"amd64", "arm64"}),
 		}),
+		build.WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")),
 	)
 	require.Error(t, err, "build should have failed to init keyring")
 	require.True(t, called)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/apko/pkg/options"
 
 	"github.com/chainguard-dev/clog"
 )
@@ -223,12 +223,9 @@ func WithTempDir(tmp string) Option {
 	}
 }
 
-func WithAuth(domain, user, pass string) Option {
+func WithAuthenticator(a auth.Authenticator) Option {
 	return func(bc *Context) error {
-		if bc.o.Auth == nil {
-			bc.o.Auth = make(map[string]options.Auth)
-		}
-		bc.o.Auth[domain] = options.Auth{User: user, Pass: pass}
+		bc.o.Auth = a
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -60,6 +60,7 @@ type Auth struct{ User, Pass string }
 var Default = Options{
 	Arch:            types.ParseArchitecture(runtime.GOARCH),
 	SourceDateEpoch: time.Unix(0, 0).UTC(),
+	Auth:            auth.DefaultAuthenciators,
 }
 
 // Tempdir returns the temporary directory where apko will create

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"time"
 
+	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/build/types"
 )
 
@@ -49,7 +50,7 @@ type Options struct {
 	CacheDir                string             `json:"cacheDir,omitempty"`
 	Offline                 bool               `json:"offline,omitempty"`
 	Lockfile                string             `json:"lockfile,omitempty"`
-	Auth                    map[string]Auth    `json:"-"`
+	Auth                    auth.Authenticator `json:"-"`
 	IncludePaths            []string           `json:"includePaths,omitempty"`
 	IgnoreSignatures        bool               `json:"ignoreSignatures,omitempty"`
 }


### PR DESCRIPTION
Opening as draft to discuss.

This refactors our current auth handling -- reading `HTTP_AUTH` env var once at CLI startup, and passing through build options -- with a more cred-helper-centric form, with `EnvAuth` mimicking the current behavior, and `CGRAuth` providing an implementation that relies on `chainctl auth token`.

Go API consumers can choose to implement other auth helpers if they want, or change the behavior of the default if they want.

This should be backward-compatible with apko CLI, but breaks the Go API in ways that Melange and TF-Apko will have to adapt to.