### PR TITLE
Simplify the resolution logic to use `expandapk.Split`

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -174,11 +174,11 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 				Architecture: rpkg.Package.Arch,
 				Version:      rpkg.Package.Version,
 				Control: pkglock.LockPkgRangeAndChecksum{
-					Range:    fmt.Sprintf("bytes=%d-%d", rpkg.SignatureSize, rpkg.ControlSize-1),
+					Range:    fmt.Sprintf("bytes=%d-%d", rpkg.SignatureSize, rpkg.SignatureSize+rpkg.ControlSize-1),
 					Checksum: "sha1-" + base64.StdEncoding.EncodeToString(rpkg.ControlHash),
 				},
 				Data: pkglock.LockPkgRangeAndChecksum{
-					Range:    fmt.Sprintf("bytes=%d-%d", rpkg.ControlSize, rpkg.DataSize),
+					Range:    fmt.Sprintf("bytes=%d-%d", rpkg.SignatureSize+rpkg.ControlSize, rpkg.SignatureSize+rpkg.ControlSize+rpkg.DataSize-1),
 					Checksum: "sha256-" + base64.StdEncoding.EncodeToString(rpkg.DataHash),
 				},
 				Checksum: rpkg.Package.ChecksumString(),

--- a/internal/cli/testdata/apko.lock.json
+++ b/internal/cli/testdata/apko.lock.json
@@ -39,7 +39,7 @@
           "checksum": "sha1-cs+Hlyu5sY+1mmwKPedcRWj8E24="
         },
         "data": {
-          "range": "bytes=965-2899",
+          "range": "bytes=965-2329",
           "checksum": "sha256-6Gbikm5tHIqetbTVz/wPcmtCcrO17ed1vPM6xuR0IrU="
         },
         "checksum": "Q1cs+Hlyu5sY+1mmwKPedcRWj8E24="
@@ -58,7 +58,7 @@
           "checksum": "sha1-ADqt8AXOdbDPVa9UeGNJngcURrk="
         },
         "data": {
-          "range": "bytes=975-2848",
+          "range": "bytes=975-2335",
           "checksum": "sha256-irIVeq+6d/ZEIg59H1sjgVycwhfmwYwD79+Gv5DJXb0="
         },
         "checksum": "Q1ADqt8AXOdbDPVa9UeGNJngcURrk="
@@ -77,7 +77,7 @@
           "checksum": "sha1-IhHX8PA1MiPcnOa5ig/Wjr/qhbU="
         },
         "data": {
-          "range": "bytes=962-2900",
+          "range": "bytes=962-2327",
           "checksum": "sha256-HxWjXtCvMsSYOmhE5OUPz9KQ4kpm0Ywg17OzSf3Ikl4="
         },
         "checksum": "Q1IhHX8PA1MiPcnOa5ig/Wjr/qhbU="
@@ -96,7 +96,7 @@
           "checksum": "sha1-twZgE0XMokZ89rlCxtGjp+XgtIc="
         },
         "data": {
-          "range": "bytes=978-2849",
+          "range": "bytes=978-2338",
           "checksum": "sha256-Mkciu4YKl5ibdvTTg7BQOBSN2xVT1GC5VBZ3/D4qz24="
         },
         "checksum": "Q1twZgE0XMokZ89rlCxtGjp+XgtIc="

--- a/internal/cli/testdata/image_on_top.apko.lock.json
+++ b/internal/cli/testdata/image_on_top.apko.lock.json
@@ -39,7 +39,7 @@
           "checksum": "sha1-ADqt8AXOdbDPVa9UeGNJngcURrk="
         },
         "data": {
-          "range": "bytes=975-2848",
+          "range": "bytes=975-2335",
           "checksum": "sha256-irIVeq+6d/ZEIg59H1sjgVycwhfmwYwD79+Gv5DJXb0="
         },
         "checksum": "Q1ADqt8AXOdbDPVa9UeGNJngcURrk="
@@ -58,7 +58,7 @@
           "checksum": "sha1-twZgE0XMokZ89rlCxtGjp+XgtIc="
         },
         "data": {
-          "range": "bytes=978-2849",
+          "range": "bytes=978-2338",
           "checksum": "sha256-Mkciu4YKl5ibdvTTg7BQOBSN2xVT1GC5VBZ3/D4qz24="
         },
         "checksum": "Q1twZgE0XMokZ89rlCxtGjp+XgtIc="

--- a/pkg/apk/apk/resolveapk.go
+++ b/pkg/apk/apk/resolveapk.go
@@ -2,46 +2,18 @@
 package apk
 
 import (
-	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/sha1"
-	"encoding/hex"
+	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
-	"strconv"
-	"strings"
 
-	"github.com/klauspost/compress/gzip"
+	"chainguard.dev/apko/pkg/apk/expandapk"
 
 	"go.opentelemetry.io/otel"
 )
-
-// An implementation of io.Reader designed specifically for use in the resolveApk() method.
-// When used in combination with the expandApkWrier (based on os.File) in a io.TeeReader,
-// the Go stdlib optimizes the write, causing readahead, even if the actual stream size
-// is less than the size of the incoming buffer. To fix this, the Read() method on this
-// Reader has been modified to read only a single byte at a time to workaround the issue.
-type noReadAheadApkReader struct {
-	io.Reader
-}
-
-func newNoReadAheadApkReader(r io.Reader) *noReadAheadApkReader {
-	return &noReadAheadApkReader{
-		Reader: r,
-	}
-}
-
-func (r *noReadAheadApkReader) Read(b []byte) (int, error) {
-	buf := make([]byte, 1)
-	n, err := r.Reader.Read(buf)
-	if err != nil && err != io.EOF {
-		err = fmt.Errorf("expandApkReader.Read: %w", err)
-	} else {
-		b[0] = buf[0]
-	}
-	return n, err
-}
 
 type APKResolved struct {
 	Package *RepositoryPackage
@@ -56,116 +28,49 @@ type APKResolved struct {
 	DataHash []byte
 }
 
-type countingWriter struct {
-	bytesWritten int
-}
-
-func (r *countingWriter) Write(p []byte) (n int, err error) {
-	r.bytesWritten += len(p)
-	return n, nil
-}
-
 func ResolveApk(ctx context.Context, source io.Reader) (*APKResolved, error) {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "ResolveApk")
 	defer span.End()
 
-	gzipStreamSizes := make([]int, 3)
-	hashes := make([][]byte, 3)
-	maxStreams := 2
-	streamId := 0
-	controlIdx := 0
-	signed := false
+	resolved := &APKResolved{}
 
-	var gzi *gzip.Reader
-	cr := &countingWriter{}
-	tr := io.TeeReader(source, cr)
-	norar := newNoReadAheadApkReader(tr)
+	split, err := expandapk.Split(source)
+	if err != nil {
+		return nil, fmt.Errorf("splitting apk: %w", err)
+	}
+	if len(split) < 2 {
+		return nil, fmt.Errorf("splitting apk: expected at least 2 streams, got %d", len(split))
+	}
 
-	for {
+	control, data := split[0], split[1]
+	if len(split) == 3 {
+		// When it's signed the control section is the second stream
+		control, data = split[1], split[2]
+
 		var h hash.Hash = sha1.New() //nolint:gosec
-
-		hr := io.TeeReader(norar, h)
-
-		var err error
-
-		if gzi == nil {
-			gzi, err = gzip.NewReader(hr)
-		} else {
-			err = gzi.Reset(hr)
+		size, err := io.Copy(h, split[0])
+		if err != nil {
+			return nil, fmt.Errorf("hashing signature: %w", err)
 		}
-
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return nil, fmt.Errorf("creating gzip reader: %w", err)
-		}
-		gzi.Multistream(false)
-
-		if streamId == 0 {
-			tr := tar.NewReader(gzi)
-			hdr, err := tr.Next()
-			if err != nil {
-				return nil, fmt.Errorf("ResolveApk error 1: %v", err)
-			}
-			if strings.HasPrefix(hdr.Name, ".SIGN.") {
-				maxStreams = 3
-				controlIdx = 1
-				signed = true
-			}
-		} else if controlIdx == streamId {
-			mapping, err := controlValue(gzi, "datahash", "size")
-			if err != nil {
-				return nil, fmt.Errorf("reading datahash and size from control: %w", err)
-			}
-
-			if sizes, ok := mapping["size"]; !ok {
-				return nil, fmt.Errorf("reading size from control: %w", err)
-			} else if len(sizes) != 1 {
-				return nil, fmt.Errorf("saw %d size values", len(sizes))
-			} else if size, err := strconv.Atoi(sizes[0]); err != nil {
-				return nil, fmt.Errorf("parsing size from  control: %w", err)
-			} else {
-				gzipStreamSizes[maxStreams-1] = size
-			}
-
-			if datahashes, ok := mapping["datahash"]; !ok {
-				return nil, fmt.Errorf("reading datahash from control: %w", err)
-			} else if len(datahashes) != 1 {
-				return nil, fmt.Errorf("saw %d datahash values", len(datahashes))
-			} else if hash, err := hex.DecodeString(datahashes[0]); err != nil {
-				return nil, fmt.Errorf("reading datahash from control: %w", err)
-			} else {
-				hashes[maxStreams-1] = hash
-			}
-		}
-
-		if streamId <= controlIdx {
-			if _, err := io.Copy(io.Discard, gzi); err != nil {
-				return nil, fmt.Errorf("ResolveApk error 2: %v", err)
-			}
-
-			hashes[streamId] = h.Sum(nil)
-			gzipStreamSizes[streamId] = cr.bytesWritten
-		} else {
-			gzi.Close()
-			break
-		}
-
-		streamId++
+		resolved.SignatureSize = int(size)
+		resolved.SignatureHash = h.Sum(nil)
 	}
 
-	resolved := &APKResolved{
-		SignatureSize: 0,
-		ControlSize:   gzipStreamSizes[controlIdx],
-		ControlHash:   hashes[controlIdx],
-		DataSize:      gzipStreamSizes[controlIdx+1],
-		DataHash:      hashes[controlIdx+1],
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, control); err != nil {
+		return nil, fmt.Errorf("hashing control: %w", err)
 	}
+	resolved.ControlSize = buf.Len()
+	ctrlHash := sha1.Sum(buf.Bytes())
+	resolved.ControlHash = ctrlHash[:]
 
-	if signed {
-		resolved.SignatureSize = gzipStreamSizes[0]
-		resolved.SignatureHash = hashes[0]
+	dataHash := sha256.New()
+	size, err := io.Copy(dataHash, data)
+	if err != nil {
+		return nil, fmt.Errorf("hashing data: %w", err)
 	}
+	resolved.DataSize = int(size)
+	resolved.DataHash = dataHash.Sum(nil)
 
 	return resolved, nil
 }

--- a/pkg/apk/apk/util.go
+++ b/pkg/apk/apk/util.go
@@ -41,11 +41,10 @@ func uniqify[T comparable](s []T) []T {
 
 func controlValue(controlTar io.Reader, want ...string) (map[string][]string, error) {
 	tr := tar.NewReader(controlTar)
-	mapping := map[string][]string{}
 	for {
 		header, err := tr.Next()
 		if errors.Is(err, io.EOF) {
-			break
+			return nil, fmt.Errorf("control file not found")
 		}
 		if err != nil {
 			return nil, err
@@ -60,6 +59,7 @@ func controlValue(controlTar io.Reader, want ...string) (map[string][]string, er
 		if err != nil {
 			return nil, fmt.Errorf("unable to read .PKGINFO from control tar.gz file: %w", err)
 		}
+		mapping := map[string][]string{}
 		lines := strings.Split(string(b), "\n")
 		for _, line := range lines {
 			parts := strings.Split(line, "=")
@@ -81,8 +81,6 @@ func controlValue(controlTar io.Reader, want ...string) (map[string][]string, er
 
 			mapping[key] = values
 		}
-
-		break
+		return mapping, nil
 	}
-	return mapping, nil
 }


### PR DESCRIPTION
The previous logic didn't properly handle unsigned APKs.