### PR TITLE
index throws nil pointer when no auth set

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -209,6 +209,10 @@ func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, a
 		if err != nil {
 			return nil, err
 		}
+
+		if opts.auth == nil {
+			opts.auth = auth.DefaultAuthenticators
+		}
 		opts.auth.AddAuth(ctx, req)
 
 		// This will return a body that retries requests using Range requests if Read() hits an error.


### PR DESCRIPTION
wolfing text was failing because of nil pointer 
```
2024/07/04 23:19:55 INFO   adding package "scanelf" for pipeline "Strip binaries"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x102841114]

goroutine 1 [running]:
chainguard.dev/apko/pkg/apk/apk.getRepositoryIndex({0x105a6d938, 0x1400a061230}, {0x1400af57300, 0x34}, 0x1400345b848, {0x1046100b3, 0x6}, 0x1400937e4c0)
	chainguard.dev/apko@v0.16.0/pkg/apk/apk/index.go:212 +0x2f4
chainguard.dev/apko/pkg/apk/apk.(*indexCache).get.func1()
	chainguard.dev/apko@v0.16.0/pkg/apk/apk/index.go:72 +0x50
sync.(*Once).doSlow(0x1074fc560?, 0x1054607e0?)
	sync/once.go:74 +0x100
sync.(*Once).Do(...)
```

After fix
```
2024/07/04 23:24:02 INFO   adding package "git" for pipeline "Check out sources from git"
2024/07/04 23:24:02 INFO   adding package "patch" for pipeline "Apply patches"
2024/07/04 23:24:02 INFO   adding package "binutils" for pipeline "Strip binaries"
2024/07/04 23:24:02 INFO   adding package "scanelf" for pipeline "Strip binaries"
2024/07/04 23:24:02 INFO   adding package "autoconf" for pipeline "Run autoconf configure script"
2024/07/04 23:24:02 INFO   adding package "automake" for pipeline "Run autoconf configure script"
2024/07/04 23:24:02 INFO   adding package "make" for pipeline "Run autoconf make"
2024/07/04 23:24:02 INFO   adding package "make" for pipeline "Run autoconf make install"
2024/07/04 23:24:02 INFO   adding package "binutils" for pipeline "Strip binaries"
2024/07/04 23:24:02 INFO   adding package "scanelf" for pipeline "Strip binaries"
make packages/x86_64/openssl-3.3.1-r3.apk
make packages/x86_64/ca-certificates-20240315-r4.apk
make packages/x86_64/wolfi-baselayout-20230201-r12.apk
make packages/x86_64/sqlite-3.45.1-r1.apk
make packages/x86_64/xz-5.6.2-r0.apk


```