### PR TITLE
openssl on alpine(Riscv64) returns a different version causing ci failures 

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -67,7 +67,7 @@ jobs:
           go-version-file: 'go.mod'
       - run: |
           make apko
-          ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx.tar
+          ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx.tar --arch x86_64,386,armv7,aarch64,s390x,ppc64le
 
       - name: Check SBOM Conformance
         run: |
@@ -136,11 +136,11 @@ jobs:
           SOURCE_DATE_EPOCH: "0"
         run: |
           make apko
-          FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+          FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine --arch x86_64,386,armv7,aarch64,s390x,ppc64le 2> /dev/null)
 
           for idx in {2..10}
           do
-            NEXT=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+            NEXT=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine --arch x86_64,386,armv7,aarch64,s390x,ppc64le 2> /dev/null)
 
             if [ "${FIRST}" = "${NEXT}" ]; then
               echo "Build ${idx} matches."
@@ -174,11 +174,11 @@ jobs:
           make apko
           # Without SOURCE_DATE_EPOCH set, the timestamp of the image will be computed to be
           # the maximum build date of the resolved APKs.
-          FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+          FIRST=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine --arch x86_64,386,armv7,aarch64,s390x,ppc64le 2> /dev/null)
 
           for idx in {2..10}
           do
-            NEXT=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine 2> /dev/null)
+            NEXT=$(./apko publish ./examples/alpine-base.yaml localhost:5000/alpine --arch x86_64,386,armv7,aarch64,s390x,ppc64le 2> /dev/null)
 
             if [ "${FIRST}" = "${NEXT}" ]; then
               echo "Build ${idx} matches."
@@ -212,7 +212,7 @@ jobs:
           make apko
 
           # Build image with annotations.
-          ref=$(./apko publish ./examples/nginx.yaml localhost:5000/nginx)
+          ref=$(./apko publish ./examples/nginx.yaml localhost:5000/nginx --arch x86_64,386,armv7,aarch64,s390x,ppc64le)
 
           # Check index annotations.
           crane manifest $ref | jq -r '.annotations.foo' | grep bar

--- a/hack/ci/00-build.sh
+++ b/hack/ci/00-build.sh
@@ -14,7 +14,7 @@ for f in examples/alpine-base-rootless.yaml examples/wolfi-base.yaml; do
   echo "=== building $f"
 
   REF="apko.local/ci-testing:$(basename ${f})"
-  "${APKO}" build "${f}" "${REF}" "${OUTPUT_TAR}"
+  "${APKO}" build "${f}" "${REF}" "${OUTPUT_TAR}"  --arch amd64,arm64
 
   # Subtest #1: Does it load?
   ARCH_REF="$(docker load < output.tar | grep "Loaded image" | sed 's/^Loaded image: //' | head -1)"

--- a/hack/ci/01-publish.sh
+++ b/hack/ci/01-publish.sh
@@ -20,7 +20,7 @@ for f in examples/alpine-base-rootless.yaml examples/wolfi-base.yaml; do
   echo "=== building $f"
 
   REF="localhost:${PORT}/ci-testing:$(basename ${f})"
-  img=$("${APKO}" publish "${f}" "${REF}")
+  img=$("${APKO}" publish "${f}" "${REF}"  --arch amd64,arm64)
 
   # Run the image.
   docker run --rm ${img} echo hello | grep hello


### PR DESCRIPTION
Openssl on [riscv64]( https://apk.dag.dev/https/dl-cdn.alpinelinux.org/alpine/edge/main/riscv64/APKINDEX.tar.gz@etag:36363835623333652d3731343934/APKINDEX?full=false&search=openssl-3&depend=&provide=) returns [openssl-3.3.1-r1.apk](https://apk.dag.dev/https/dl-cdn.alpinelinux.org/alpine/edge/main/riscv64/openssl-3.3.1-r1.apk@sha1:723b9ab5dca1151f3d9dffa2e143c2482eef2e7c)

where are on [aarch64](https://apk.dag.dev/https/dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/APKINDEX.tar.gz@etag:36363837373638322d3733373166/APKINDEX?full=false&search=openssl-3&depend=&provide=) returns [openssl-3.3.1-r2.apk](https://apk.dag.dev/https/dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/openssl-3.3.1-r2.apk@sha1:5ce776fb7e56089507d7c30b654ed332341204d5)


Causing CI tests and other tests to fail on the main from the commit https://github.com/chainguard-dev/apko/commit/b1262eb1fbb110bd3e9d0432cfc5ed4fe405ca9e