### PR TITLE
Faster NewPkgResolver and GetRepositoryIndexes

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -23,12 +23,18 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/chainguard-dev/clog"
+)
+
+var (
+	parsedVersions    sync.Map // map[string]Version
+	parsedConstraints sync.Map // map[string]parsedConstraint
 )
 
 // NamedIndex an index that contains all of its packages,
@@ -197,14 +203,14 @@ type PkgResolver struct {
 	indexes      []NamedIndex
 	nameMap      map[string][]*repositoryPackage
 	installIfMap map[string][]*repositoryPackage // contains any package that should be installed if the named package is installed
-
-	parsedVersions map[string]Version
-	depForVersion  map[string]parsedConstraint
 }
 
 // NewPkgResolver creates a new pkgResolver from a list of indexes.
 // The indexes are anything that implements NamedIndex.
-func NewPkgResolver(_ context.Context, indexes []NamedIndex) *PkgResolver {
+func NewPkgResolver(ctx context.Context, indexes []NamedIndex) *PkgResolver {
+	_, span := otel.Tracer("go-apk").Start(ctx, "NewPkgResolver")
+	defer span.End()
+
 	numPackages := 0
 	for _, index := range indexes {
 		numPackages += index.Count()
@@ -215,9 +221,7 @@ func NewPkgResolver(_ context.Context, indexes []NamedIndex) *PkgResolver {
 		installIfMap = map[string][]*repositoryPackage{}
 	)
 	p := &PkgResolver{
-		indexes:        indexes,
-		parsedVersions: map[string]Version{},
-		depForVersion:  map[string]parsedConstraint{},
+		indexes: indexes,
 	}
 
 	// create a map of every package by name and version to its RepositoryPackage
@@ -246,7 +250,7 @@ func NewPkgResolver(_ context.Context, indexes []NamedIndex) *PkgResolver {
 	for _, pkgVersions := range allPkgs {
 		for _, pkg := range pkgVersions {
 			for _, provide := range pkg.Provides {
-				name := p.resolvePackageNameVersionPin(provide).name
+				name := cachedResolvePackageNameVersionPin(provide).name
 				pkgNameMap[name] = append(pkgNameMap[name], pkg)
 			}
 		}
@@ -288,13 +292,13 @@ func (p *PkgResolver) nextPackage(packages []string, dq map[*RepositoryPackage]s
 
 // Disqualify anything that provides "constraint". This is used for !foo style constraints.
 func (p *PkgResolver) disqualifyProviders(constraint string, dq map[*RepositoryPackage]string) {
-	parsed := p.resolvePackageNameVersionPin(constraint)
+	parsed := cachedResolvePackageNameVersionPin(constraint)
 	providers, ok := p.nameMap[parsed.name]
 	if !ok {
 		return
 	}
 
-	conflicting := p.filterPackages(providers, dq, withVersion(parsed.version, parsed.dep), withPreferPin(parsed.pin))
+	conflicting := filterPackages(providers, dq, withVersion(parsed.version, parsed.dep), withPreferPin(parsed.pin))
 
 	for _, conflict := range conflicting {
 		if _, dqed := dq[conflict.RepositoryPackage]; dqed {
@@ -320,7 +324,7 @@ func (p *PkgResolver) conflictingVersion(constraint parsedConstraint, conflict *
 	}
 
 	for _, confProv := range conflict.Provides {
-		confConstraint := p.resolvePackageNameVersionPin(confProv)
+		confConstraint := cachedResolvePackageNameVersionPin(confProv)
 		if confConstraint.name != constraint.name {
 			// Not the constraint we're looking for.
 			continue
@@ -340,7 +344,7 @@ func (p *PkgResolver) conflictingVersion(constraint parsedConstraint, conflict *
 // Disqualify anything that conflicts with the given pkg.
 func (p *PkgResolver) disqualifyConflicts(pkg *RepositoryPackage, dq map[*RepositoryPackage]string) {
 	for _, prov := range pkg.Provides {
-		constraint := p.resolvePackageNameVersionPin(prov)
+		constraint := cachedResolvePackageNameVersionPin(prov)
 		providers, ok := p.nameMap[constraint.name]
 		if !ok {
 			continue
@@ -381,7 +385,7 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 			continue
 		}
 
-		parsed := p.resolvePackageNameVersionPin(constraint)
+		parsed := cachedResolvePackageNameVersionPin(constraint)
 		if parsed.dep == versionAny {
 			continue
 		}
@@ -391,7 +395,7 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 			continue
 		}
 
-		requiredVersion, err := p.parseVersion(parsed.version)
+		requiredVersion, err := cachedParseVersion(parsed.version)
 		if err != nil {
 			// This shouldn't happen but return an error to be safe.
 			return fmt.Errorf("parsing constraint %q: %w", constraint, err)
@@ -399,7 +403,7 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 
 		for _, provider := range providers {
 			if provider.Name == parsed.name {
-				actualVersion, err := p.parseVersion(provider.Version)
+				actualVersion, err := cachedParseVersion(provider.Version)
 				// skip invalid ones
 				if err != nil {
 					p.disqualify(dq, provider.RepositoryPackage, fmt.Sprintf("parsing version %q failed: %v", provider.Version, err))
@@ -411,11 +415,11 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 				}
 			} else {
 				for _, provides := range provider.Provides {
-					pp := p.resolvePackageNameVersionPin(provides)
+					pp := cachedResolvePackageNameVersionPin(provides)
 					if pp.name != parsed.name {
 						continue
 					}
-					actualVersion, err := p.parseVersion(pp.version)
+					actualVersion, err := cachedParseVersion(pp.version)
 					// skip invalid ones
 					if err != nil {
 						dq[provider.RepositoryPackage] = fmt.Sprintf("parsing %q: %v", pp.version, err)
@@ -567,7 +571,7 @@ func (p *PkgResolver) GetPackageWithDependencies(pkgName string, existing map[st
 		return nil, nil, nil, err
 	}
 
-	pin := p.resolvePackageNameVersionPin(pkgName).pin
+	pin := cachedResolvePackageNameVersionPin(pkgName).pin
 	deps, conflicts, err := p.getPackageDependencies(pkg, pin, true, parents, localExisting, existingOrigins, dq)
 	if err != nil {
 		return nil, nil, nil, err
@@ -595,7 +599,7 @@ func (p *PkgResolver) GetPackageWithDependencies(pkgName string, existing map[st
 			var matchCount int
 			for _, subDep := range installIfPkg.InstallIf {
 				// two possibilities: package name, or name=version
-				constraint := p.resolvePackageNameVersionPin(subDep)
+				constraint := cachedResolvePackageNameVersionPin(subDep)
 				name, version := constraint.name, constraint.version
 				// precise match of whatever it is, take it and continue
 				if _, ok := added[subDep]; ok {
@@ -625,7 +629,7 @@ func (p *PkgResolver) GetPackageWithDependencies(pkgName string, existing map[st
 // and decreasing from there. In general, the first one in the list is the best match. This function
 // returns multiple in case you need to see all potential matches.
 func (p *PkgResolver) ResolvePackage(pkgName string, dq map[*RepositoryPackage]string) ([]*RepositoryPackage, error) {
-	constraint := p.resolvePackageNameVersionPin(pkgName)
+	constraint := cachedResolvePackageNameVersionPin(pkgName)
 	name, version, compare, pin := constraint.name, constraint.version, constraint.dep, constraint.pin
 	pkgsWithVersions, ok := p.nameMap[name]
 	if !ok {
@@ -634,7 +638,7 @@ func (p *PkgResolver) ResolvePackage(pkgName string, dq map[*RepositoryPackage]s
 
 	// pkgsWithVersions contains a map of all versions of the package
 	// get the one that most matches what was requested
-	packages := p.filterPackages(pkgsWithVersions, dq, withVersion(version, compare), withPreferPin(pin))
+	packages := filterPackages(pkgsWithVersions, dq, withVersion(version, compare), withPreferPin(pin))
 	if len(packages) == 0 {
 		return nil, maybedqerror(pkgName, pkgsWithVersions, dq)
 	}
@@ -651,7 +655,7 @@ func (p *PkgResolver) ResolvePackage(pkgName string, dq map[*RepositoryPackage]s
 
 // This is like ResolvePackage but we only care about the best match and not all matches.
 func (p *PkgResolver) resolvePackage(pkgName string, dq map[*RepositoryPackage]string) (*RepositoryPackage, error) {
-	constraint := p.resolvePackageNameVersionPin(pkgName)
+	constraint := cachedResolvePackageNameVersionPin(pkgName)
 	name, version, compare, pin := constraint.name, constraint.version, constraint.dep, constraint.pin
 
 	pkgsWithVersions, ok := p.nameMap[name]
@@ -661,7 +665,7 @@ func (p *PkgResolver) resolvePackage(pkgName string, dq map[*RepositoryPackage]s
 
 	// pkgsWithVersions contains a map of all versions of the package
 	// get the one that most matches what was requested
-	packages := p.filterPackages(pkgsWithVersions, dq, withVersion(version, compare), withPreferPin(pin))
+	packages := filterPackages(pkgsWithVersions, dq, withVersion(version, compare), withPreferPin(pin))
 	if len(packages) == 0 {
 		return nil, maybedqerror(pkgName, pkgsWithVersions, dq)
 	}
@@ -704,7 +708,7 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 	myProvides := make(map[string]bool, 2*len(pkg.Provides))
 	// see if we provide this
 	for _, provide := range pkg.Provides {
-		name := p.resolvePackageNameVersionPin(provide).name
+		name := cachedResolvePackageNameVersionPin(provide).name
 		myProvides[provide] = true
 		myProvides[name] = true
 	}
@@ -731,7 +735,7 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 			}
 
 			// this package might be pinned to a version
-			constraint := p.resolvePackageNameVersionPin(dep)
+			constraint := cachedResolvePackageNameVersionPin(dep)
 			name, version, compare := constraint.name, constraint.version, constraint.dep
 			// see if we provide this
 			if myProvides[name] || myProvides[dep] {
@@ -744,9 +748,9 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 					actualVersion, requiredVersion Version
 					err1, err2                     error
 				)
-				actualVersion, err1 = p.parseVersion(pkg.Version)
+				actualVersion, err1 = cachedParseVersion(pkg.Version)
 				if compare != versionAny {
-					requiredVersion, err2 = p.parseVersion(version)
+					requiredVersion, err2 = cachedParseVersion(version)
 				}
 				// we accept invalid versions for ourself, but do not try to use it to fulfill
 				if err1 == nil && err2 == nil {
@@ -764,7 +768,7 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 			}
 			// pkgsWithVersions contains a map of all versions of the package
 			// get the one that most matches what was requested
-			pkgs := p.filterPackages(depPkgWithVersions,
+			pkgs := filterPackages(depPkgWithVersions,
 				dq,
 				withVersion(version, compare),
 				withAllowPin(allowPin),
@@ -794,7 +798,7 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 		}
 
 		pkgs := options[lowest]
-		name := p.resolvePackageNameVersionPin(lowest).name
+		name := cachedResolvePackageNameVersionPin(lowest).name
 
 		// Remove this from our constraints.
 		constraints = slices.DeleteFunc(constraints, func(s string) bool {
@@ -833,10 +837,10 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 	return dependencies, conflicts, nil
 }
 
-func (p *PkgResolver) parseVersion(version string) (Version, error) {
-	pkg, ok := p.parsedVersions[version]
+func cachedParseVersion(version string) (Version, error) {
+	pkg, ok := parsedVersions.Load(version)
 	if ok {
-		return pkg, nil
+		return pkg.(Version), nil
 	}
 
 	parsed, err := ParseVersion(version)
@@ -844,19 +848,19 @@ func (p *PkgResolver) parseVersion(version string) (Version, error) {
 		return parsed, err
 	}
 
-	p.parsedVersions[version] = parsed
+	parsedVersions.Store(version, parsed)
 	return parsed, nil
 }
 
-func (p *PkgResolver) resolvePackageNameVersionPin(pkgName string) parsedConstraint {
-	cached, ok := p.depForVersion[pkgName]
+func cachedResolvePackageNameVersionPin(pkgName string) parsedConstraint {
+	cached, ok := parsedConstraints.Load(pkgName)
 	if ok {
-		return cached
+		return cached.(parsedConstraint)
 	}
 
 	pin := resolvePackageNameVersionPin(pkgName)
 
-	p.depForVersion[pkgName] = pin
+	parsedConstraints.Store(pkgName, pin)
 	return pin
 }
 
@@ -943,11 +947,11 @@ func (p *PkgResolver) comparePackages(compare *RepositoryPackage, name string, e
 		}
 		// both matched or both did not, so just compare versions
 		// version priority
-		iVersion, err := p.parseVersion(iVersionStr)
+		iVersion, err := cachedParseVersion(iVersionStr)
 		if err != nil {
 			return 1
 		}
-		jVersion, err := p.parseVersion(jVersionStr)
+		jVersion, err := cachedParseVersion(jVersionStr)
 		if err != nil {
 			// If j fails to parse, prefer i.
 			return -1
@@ -958,11 +962,11 @@ func (p *PkgResolver) comparePackages(compare *RepositoryPackage, name string, e
 		}
 		// if versions are equal, they might not be the same as the package versions
 		if iVersionStr != a.Version || jVersionStr != b.Version {
-			iVersion, err := p.parseVersion(a.Version)
+			iVersion, err := cachedParseVersion(a.Version)
 			if err != nil {
 				return 1
 			}
-			jVersion, err := p.parseVersion(b.Version)
+			jVersion, err := cachedParseVersion(b.Version)
 			if err != nil {
 				// If j fails to parse, prefer i.
 				return -1
@@ -998,7 +1002,7 @@ func (p *PkgResolver) getDepVersionForName(pkg *repositoryPackage, name string) 
 		return pkg.Version
 	}
 	for _, prov := range pkg.Provides {
-		constraint := p.resolvePackageNameVersionPin(prov)
+		constraint := cachedResolvePackageNameVersionPin(prov)
 		pName, pVersion := constraint.name, constraint.version
 		if pVersion == "" {
 			pVersion = pkg.Version

--- a/pkg/apk/apk/version.go
+++ b/pkg/apk/apk/version.go
@@ -427,7 +427,7 @@ func withInstalledPackage(pkg *RepositoryPackage) filterOption {
 	}
 }
 
-func (p *PkgResolver) filterPackages(pkgs []*repositoryPackage, dq map[*RepositoryPackage]string, opts ...filterOption) []*repositoryPackage {
+func filterPackages(pkgs []*repositoryPackage, dq map[*RepositoryPackage]string, opts ...filterOption) []*repositoryPackage {
 	o := &filterOptions{
 		compare: versionAny,
 	}
@@ -461,13 +461,13 @@ func (p *PkgResolver) filterPackages(pkgs []*repositoryPackage, dq map[*Reposito
 		}
 
 		// We check this error later in the loop.
-		requiredVersion, reqErr := p.parseVersion(o.version)
+		requiredVersion, reqErr := cachedParseVersion(o.version)
 		// if the required version is invalid, we can't compare, so we return no matches
 		if reqErr != nil {
 			return nil
 		}
 
-		actualVersion, err := p.parseVersion(pkg.Version)
+		actualVersion, err := cachedParseVersion(pkg.Version)
 		// skip invalid ones
 		if err != nil {
 			continue
@@ -479,12 +479,12 @@ func (p *PkgResolver) filterPackages(pkgs []*repositoryPackage, dq map[*Reposito
 		}
 
 		for _, prov := range pkg.Provides {
-			version := p.resolvePackageNameVersionPin(prov).version
+			version := cachedResolvePackageNameVersionPin(prov).version
 			if version == "" {
 				continue
 			}
 
-			actualVersion, err = p.parseVersion(version)
+			actualVersion, err = cachedParseVersion(version)
 			// again, we skip invalid ones
 			if err != nil {
 				continue

--- a/pkg/apk/apk/version_test.go
+++ b/pkg/apk/apk/version_test.go
@@ -898,7 +898,7 @@ func TestResolveVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			pr := NewPkgResolver(context.Background(), []NamedIndex{})
-			found := pr.filterPackages(pkgs, map[*RepositoryPackage]string{}, withVersion(tt.version, tt.compare), withPreferPin(tt.pin), withInstalledPackage(tt.installed))
+			found := filterPackages(pkgs, map[*RepositoryPackage]string{}, withVersion(tt.version, tt.compare), withPreferPin(tt.pin), withInstalledPackage(tt.installed))
 			// add the existing in, if any
 			existing := make(map[string]*RepositoryPackage)
 			existingOrigins := make(map[string]bool)

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -40,7 +40,7 @@ func (bc *Context) postBuildSetApk(ctx context.Context) error {
 }
 
 func (bc *Context) initializeApk(ctx context.Context) error {
-	ctx, span := otel.Tracer("apko").Start(ctx, "iniializeApk")
+	ctx, span := otel.Tracer("apko").Start(ctx, "initializeApk")
 	defer span.End()
 
 	alpineVersions := parseOptionsFromRepositories(bc.ic.Contents.RuntimeRepositories)


### PR DESCRIPTION
I've been taking a look at where we're spending time on some mega-builds and on my machine it takes ~250ms to call NewPkgResolver for each image.

This is fast in the grand scheme of things but not if we need to do it thousands of times. The main culprit here is a regex, which sucks, but we hacked around that by caching the results in a map. This takes that one step further and introduces yet another (I know, sorry) global cache of the things that need a regex. This is less terrible than the other instances, IMO, because the cached functions are pure and take only version strings as inputs.

Using a sync.Map over a map doesn't seem to be measureably slower on my machine in the worst case (the first time we call NewPkgResolver), and subsequent calls drop from ~250ms to ~90ms.

We can still do much better here by implement a real parser and maybe even taking advantage of the interning stuff in go 1.23, but this is an easy win without having to thing about it too hard.

The other change I'm sneaking in is to parallelize GetRepositoryIndexes so we fetch every index in parallel. This saves us quite a bit of time the first time we fetch these (we cache them for subsequent fetches).

With both of these changes, I dropped a large `terraform plan`'s time spent in tf-apko from 3m38s to 2m36s.