### PR TITLE
Implement client-side APK discovery in `apko`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e
 	github.com/sigstore/cosign/v2 v2.3.0
-	github.com/sigstore/sigstore v1.8.7
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
@@ -100,6 +99,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sigstore/rekor v1.3.6 // indirect
+	github.com/sigstore/sigstore v1.8.7 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/log v0.4.0
 	github.com/dominodatalab/os-release v0.0.0-20190522011736-bcdb4a3e3c2f
 	github.com/go-git/go-git/v5 v5.12.0
+	github.com/go-jose/go-jose/v4 v4.0.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -17,6 +18,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e
 	github.com/sigstore/cosign/v2 v2.3.0
+	github.com/sigstore/sigstore v1.8.7
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
@@ -59,7 +61,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -99,7 +100,6 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sigstore/rekor v1.3.6 // indirect
-	github.com/sigstore/sigstore v1.8.7 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -29,11 +30,14 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"go.lsp.dev/uri"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -231,7 +235,7 @@ func (a *APK) ListInitFiles() []tar.Header {
 // Returns the list of files and directories and files installed and permissions,
 // unless those files will be included in the installed database, in which case they can
 // be retrieved via GetInstalled().
-func (a *APK) InitDB(ctx context.Context, alpineVersions ...string) error {
+func (a *APK) InitDB(ctx context.Context, buildRepos ...string) error {
 	log := clog.FromContext(ctx)
 	/*
 		equivalent of: "apk add --initdb --arch arch --root root"
@@ -303,19 +307,35 @@ func (a *APK) InitDB(ctx context.Context, alpineVersions ...string) error {
 
 	// nothing to add to it; scripts.tar should be empty
 
-	// get the alpine-keys base keys for our usage
-	if len(alpineVersions) > 0 {
-		if err := a.fetchAlpineKeys(ctx, alpineVersions); err != nil {
-			var nokeysErr *NoKeysFoundError
-			if !errors.As(err, &nokeysErr) {
-				return fmt.Errorf("failed to fetch alpine-keys: %w", err)
+	// Perform key discovery for the various build-time repositories.
+	for _, repo := range buildRepos {
+		if ver, ok := parseAlpineVersion(repo); ok {
+			if err := a.fetchAlpineKeys(ctx, ver); err != nil {
+				var nokeysErr *NoKeysFoundError
+				if !errors.As(err, &nokeysErr) {
+					return fmt.Errorf("failed to fetch alpine-keys: %w", err)
+				}
+				log.Warnf("ignoring missing keys: %v", err)
 			}
+		}
+
+		if err := a.fetchChainguardKeys(ctx, repo); err != nil {
 			log.Warnf("ignoring missing keys: %v", err)
 		}
 	}
 
 	log.Debug("finished initializing apk database")
 	return nil
+}
+
+var repoRE = regexp.MustCompile(`^http[s]?://.+\/alpine\/([^\/]+)\/[^\/]+$`)
+
+func parseAlpineVersion(repo string) (version string, ok bool) {
+	parts := repoRE.FindStringSubmatch(repo)
+	if len(parts) < 2 {
+		return "", false
+	}
+	return parts[1], true
 }
 
 // loadSystemKeyring returns the keys found in the system keyring
@@ -725,7 +745,7 @@ func (e *NoKeysFoundError) Error() string {
 }
 
 // fetchAlpineKeys fetches the public keys for the repositories in the APK database.
-func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions []string) error {
+func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions ...string) error {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "fetchAlpineKeys")
 	defer span.End()
 
@@ -791,6 +811,85 @@ func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions []string) erro
 			return fmt.Errorf("failed to write key file %s: %w", filename, err)
 		}
 	}
+	return nil
+}
+
+// fetchChainguardKeys fetches the public keys for the repositories in the APK database.
+func (a *APK) fetchChainguardKeys(ctx context.Context, repository string) error {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "fetchChainguardKeys")
+	defer span.End()
+
+	client := a.client
+	discoveryRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/%s", strings.TrimSuffix(repository, "/"), "apk-configuration"), nil)
+	if err != nil {
+		return err
+	}
+	if err := a.auth.AddAuth(ctx, discoveryRequest); err != nil {
+		return err
+	}
+	discoveryResponse, err := client.Do(discoveryRequest)
+	if err != nil {
+		return fmt.Errorf("failed to perform key discovery: %w", err)
+	}
+	defer discoveryResponse.Body.Close()
+	switch discoveryResponse.StatusCode {
+	case http.StatusNotFound:
+		// This doesn't implement Chainguard-style key discovery.
+		return nil
+
+	case http.StatusOK:
+		// proceed!
+		break
+
+	default:
+		return fmt.Errorf("chainguard key discovery was unsuccessful for repo %s: %v", repository, discoveryResponse.Status)
+	}
+	// Parse our the JWKS URI
+	var discovery struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(discoveryResponse.Body).Decode(&discovery); err != nil {
+		return fmt.Errorf("failed to unmarshal discovery payload: %w", err)
+	}
+
+	jwksRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, discovery.JWKSURI, nil)
+	if err != nil {
+		return err
+	}
+	if err := a.auth.AddAuth(ctx, jwksRequest); err != nil {
+		return err
+	}
+	jwksResponse, err := client.Do(jwksRequest)
+	if err != nil {
+		return fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+	defer jwksResponse.Body.Close()
+	if jwksResponse.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch JWKS: %v", jwksResponse.Status)
+	}
+
+	jwks := jose.JSONWebKeySet{}
+	if err := json.NewDecoder(jwksResponse.Body).Decode(&jwks); err != nil {
+		return fmt.Errorf("failed to unmarshal JWKS: %w", err)
+	}
+
+	for _, key := range jwks.Keys {
+		filename := filepath.Join(keysDirPath, key.KeyID+".rsa.pub")
+		f, err := a.fs.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("failed to open key file %s: %w", filename, err)
+		}
+		defer f.Close()
+
+		pubBytes, err := cryptoutils.MarshalPublicKeyToPEM(key.Key.(*rsa.PublicKey))
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(pubBytes); err != nil {
+			return fmt.Errorf("failed to write key file %s: %w", filename, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The protocol follows a roughly similar handshake to OIDC discovery, hitting `{repository}/apk-configuration`, extracting the `jwks_uri` and then recording each pem-encoded key as `/etc/apk/keys/{kid}.rsa.pub`.

I have tested this locally with both public and private APK repositories against `apk.mattmoor.dev` with the changes in: https://github.com/chainguard-dev/mono/pull/18431

Once this lands, I can use this in e2e tests there, but those are somewhat 🐔  & 🥚 