### PR TITLE
begin a new APK client

### DIFF
--- a/pkg/apk/apk/client.go
+++ b/pkg/apk/apk/client.go
@@ -1,0 +1,65 @@
+package apk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"chainguard.dev/apko/pkg/apk/auth"
+)
+
+const (
+	WolfiAPKRepo                = "https://packages.wolfi.dev/os"
+	ChainguardEnterpriseAPKRepo = "https://packages.cgr.dev/os"
+	ChainguardExtrasAPKRepo     = "https://packages.cgr.dev/extras"
+)
+
+const (
+	Aarch64Arch = "aarch64"
+	X86_64Arch  = "x86_64"
+)
+
+// Client is a client for interacting with an APK package repository.
+type Client struct {
+	httpClient *http.Client
+}
+
+// NewClient creates a new Client, suitable for accessing remote APK indexes and
+// packages.
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{httpClient: httpClient}
+}
+
+// GetRemoteIndex retrieves the index of APK packages from the specified remote
+// repository.
+func (c Client) GetRemoteIndex(ctx context.Context, apkRepo, arch string) (*APKIndex, error) {
+	indexURL := IndexURL(apkRepo, arch)
+
+	u, err := url.Parse(indexURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %w", indexURL, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("GET %q: %w", u.Redacted(), err)
+	}
+	if err := auth.DefaultAuthenticators.AddAuth(ctx, req); err != nil {
+		return nil, fmt.Errorf("error adding auth: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %q: %w", u.Redacted(), err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("GET %q: status %d: %s", u.Redacted(), resp.StatusCode, resp.Status)
+	}
+
+	return IndexFromArchive(resp.Body)
+}

--- a/pkg/apk/client/client.go
+++ b/pkg/apk/client/client.go
@@ -1,4 +1,4 @@
-package apk
+package client
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/auth"
 )
 
@@ -25,9 +26,9 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// NewClient creates a new Client, suitable for accessing remote APK indexes and
+// New creates a new Client, suitable for accessing remote APK indexes and
 // packages.
-func NewClient(httpClient *http.Client) *Client {
+func New(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
@@ -36,8 +37,8 @@ func NewClient(httpClient *http.Client) *Client {
 
 // GetRemoteIndex retrieves the index of APK packages from the specified remote
 // repository.
-func (c Client) GetRemoteIndex(ctx context.Context, apkRepo, arch string) (*APKIndex, error) {
-	indexURL := IndexURL(apkRepo, arch)
+func (c Client) GetRemoteIndex(ctx context.Context, apkRepo, arch string) (*apk.APKIndex, error) {
+	indexURL := apk.IndexURL(apkRepo, arch)
 
 	u, err := url.Parse(indexURL)
 	if err != nil {
@@ -61,5 +62,5 @@ func (c Client) GetRemoteIndex(ctx context.Context, apkRepo, arch string) (*APKI
 		return nil, fmt.Errorf("GET %q: status %d: %s", u.Redacted(), resp.StatusCode, resp.Status)
 	}
 
-	return IndexFromArchive(resp.Body)
+	return apk.IndexFromArchive(resp.Body)
 }


### PR DESCRIPTION
The idea here is to orient remote APK interactions around a **client**, in order to give consumers the ability to handle dependency injection properly (such as by injecting an HTTP client).

And the ultimate goal is to re-use this client whenever we need to access remote indexes and packages. It'd be great if we can refine this API enough where we can reuse this in all the places we need to interact with APK repositories, to replace the many disparate implementations of this logic we have in our tools today.

I haven't gone as far as to refactor other code in apko to use this client, but I think that's a reasonable next step. So far this implementation saves me from writing it again in an internal tool.

Feedback welcome. 😃 

cc: @imjasonh 