### PR TITLE
Canonicalize the architecture.

### DIFF
--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -233,7 +233,7 @@ var AllArchs = []Architecture{
 
 // ToAPK returns the apk-style equivalent string for the Architecture.
 func (a Architecture) ToAPK() string {
-	switch a {
+	switch a := ParseArchitecture(a.String()); a {
 	case _386:
 		return "x86"
 	case amd64:
@@ -251,7 +251,7 @@ func (a Architecture) ToAPK() string {
 
 func (a Architecture) ToOCIPlatform() *v1.Platform {
 	plat := v1.Platform{OS: "linux"}
-	switch a {
+	switch a := ParseArchitecture(a.String()); a {
 	case armv6:
 		plat.Architecture = "arm"
 		plat.Variant = "v6"
@@ -265,7 +265,7 @@ func (a Architecture) ToOCIPlatform() *v1.Platform {
 }
 
 func (a Architecture) ToQEmu() string {
-	switch a {
+	switch a := ParseArchitecture(a.String()); a {
 	case _386:
 		return "i386"
 	case amd64:
@@ -282,7 +282,7 @@ func (a Architecture) ToQEmu() string {
 }
 
 func (a Architecture) ToTriplet(suffix string) string {
-	switch a {
+	switch a := ParseArchitecture(a.String()); a {
 	case _386:
 		return fmt.Sprintf("i486-pc-linux-%s", suffix)
 	case amd64:
@@ -303,7 +303,7 @@ func (a Architecture) ToTriplet(suffix string) string {
 }
 
 func (a Architecture) ToRustTriplet(suffix string) string {
-	switch a {
+	switch a := ParseArchitecture(a.String()); a {
 	case _386:
 		return fmt.Sprintf("i686-unknown-linux-%s", suffix)
 	case amd64:
@@ -324,7 +324,7 @@ func (a Architecture) ToRustTriplet(suffix string) string {
 }
 
 func (a Architecture) Compatible(b Architecture) bool {
-	switch b {
+	switch ParseArchitecture(b.String()) {
 	case _386:
 		return a == b
 	case amd64:

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -62,3 +62,32 @@ func TestParseArchitectures(t *testing.T) {
 		})
 	}
 }
+
+func TestOCIPlatform(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+		in   string
+		want string
+	}{{
+		desc: "x86_64",
+		in:   "x86_64",
+		want: "amd64",
+	}, {
+		desc: "amd64",
+		in:   "amd64",
+		want: "amd64",
+	}, {
+		desc: "arm64",
+		in:   "arm64",
+		want: "arm64",
+	}, {
+		desc: "aarch64",
+		in:   "aarch64",
+		want: "arm64",
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := Architecture(c.in)
+			require.Equal(t, c.want, got.ToOCIPlatform().Architecture)
+		})
+	}
+}


### PR DESCRIPTION
I noticed downstream that if I used `x86_64` in an apko yaml that the resulting OCI platform would be `x86_64` instead of `amd64`.

With this change, we always canonicalize the architecture before each switch statement to ensure that we are dealing with a canonical form of the architecture.

This adds a regression test for the OCI cases specifically.