### PR TITLE
drop dependency on go.lsp.dev/uri

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0
 	github.com/u-root/u-root v0.14.0
-	go.lsp.dev/uri v0.3.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,6 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.lsp.dev/uri v0.3.0 h1:KcZJmh6nFIBeJzTugn5JTU6OOyG0lDOo3R9KwTxTYbo=
-go.lsp.dev/uri v0.3.0/go.mod h1:P5sbO1IQR+qySTWOCnhnK7phBx+W3zbLqSMDJNTw88I=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -329,7 +329,7 @@ func (t *cacheTransport) retrieveAndSaveFile(ctx context.Context, request *http.
 }
 
 func cacheDirForPackage(root string, pkg InstallablePackage) (string, error) {
-	u, err := packageAsURL(pkg)
+	u, err := packageAsURL(pkg.URL())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/gzip"
-	"go.lsp.dev/uri"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
@@ -201,21 +200,8 @@ func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, a
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "getRepositoryIndex")
 	defer span.End()
 
-	// Normalize the repo as a URI, so that local paths
-	// are translated into file:// URLs, allowing them to be parsed
-	// into a url.URL{}.
-	var (
-		b     []byte
-		asURL *url.URL
-		err   error
-	)
-	if strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "http://") {
-		asURL, err = url.Parse(u)
-	} else {
-		// Attempt to parse non-https elements into URI's so they are translated into
-		// file:// URLs allowing them to parse into a url.URL{}
-		asURL, err = url.Parse(string(uri.New(u)))
-	}
+	var b []byte
+	asURL, err := packageAsURL(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
 	}


### PR DESCRIPTION
This was only imported to enable handling file paths as URLs, which we can do by just adding `file://`.