### PR TITLE
Revert "drop dependency on go.lsp.dev/uri (#1259)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tmc/dot v0.0.0-20210901225022-f9bc17da75c0
 	github.com/u-root/u-root v0.14.0
+	go.lsp.dev/uri v0.3.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.lsp.dev/uri v0.3.0 h1:KcZJmh6nFIBeJzTugn5JTU6OOyG0lDOo3R9KwTxTYbo=
+go.lsp.dev/uri v0.3.0/go.mod h1:P5sbO1IQR+qySTWOCnhnK7phBx+W3zbLqSMDJNTw88I=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -329,7 +329,7 @@ func (t *cacheTransport) retrieveAndSaveFile(ctx context.Context, request *http.
 }
 
 func cacheDirForPackage(root string, pkg InstallablePackage) (string, error) {
-	u, err := packageAsURL(pkg.URL())
+	u, err := packageAsURL(pkg)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/hashicorp/go-retryablehttp"
+	"go.lsp.dev/uri"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -414,7 +415,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 			} else {
 				// Attempt to parse non-https elements into URI's so they are translated into
 				// file:// URLs allowing them to parse into a url.URL{}
-				asURL, err = packageAsURL(element)
+				asURL, err = url.Parse(string(uri.New(element)))
 			}
 			if err != nil {
 				return fmt.Errorf("failed to parse key as URI: %w", err)
@@ -1126,14 +1127,23 @@ func expandPackage(ctx context.Context, a *APK, pkg InstallablePackage) (*expand
 	return a.cachePackage(ctx, pkg, exp, cacheDir)
 }
 
-func packageAsURL(u string) (*url.URL, error) {
-	if strings.HasPrefix(u, "./") {
-		u = "file://" + u
+func packageAsURI(pkg InstallablePackage) (uri.URI, error) {
+	u := pkg.URL()
+
+	if strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "http://") {
+		return uri.Parse(u)
 	}
-	if filepath.IsAbs(u) {
-		u = "file://" + u
+
+	return uri.New(u), nil
+}
+
+func packageAsURL(pkg InstallablePackage) (*url.URL, error) {
+	asURI, err := packageAsURI(pkg)
+	if err != nil {
+		return nil, err
 	}
-	return url.Parse(u)
+
+	return url.Parse(string(asURI))
 }
 
 func (a *APK) FetchPackage(ctx context.Context, pkg InstallablePackage) (io.ReadCloser, error) {
@@ -1145,7 +1155,10 @@ func (a *APK) FetchPackage(ctx context.Context, pkg InstallablePackage) (io.Read
 
 	u := pkg.URL()
 
-	asURL, err := packageAsURL(pkg.URL())
+	// Normalize the repo as a URI, so that local paths
+	// are translated into file:// URLs, allowing them to be parsed
+	// into a url.URL{}.
+	asURL, err := packageAsURL(pkg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse package as URL: %w", err)
 	}


### PR DESCRIPTION
This seems to have broken handling of repos named like `packages/foo`