### PR TITLE
fix(ci): mark GitHub releases as latest from prerelease

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,5 +58,5 @@ changelog:
 
 release:
   draft: false
-  prerelease: true
+  prerelease: false
   name_template: "Release {{ .Tag }}"


### PR DESCRIPTION
Closes #1276 
Closes #639 

By using pre-releases, new updates are not discoverable by users and tooling.  GitHub does not promote these as much, and tools like Renovate and Dependabot will exclude all pre-release packages by default.

This PR changes the Goreleaser configuration to no longer create pre-release packages, and instead create proper releases which will be available at the https://github.com/chainguard-dev/apko/releases/latest URL.

While I do not know anything about goreleaser, there is a `prerelease: true` line which does look to be the cause for this.

This appears to have been set when GoReleaser was [first introduced to this repository over two years ago](https://github.com/chainguard-dev/apko/commit/50a81ccf1e901ea54eb5326aa63a0f1a90aa0405), and I assume may have been something that has been overlooked.
