### PR TITLE
auth: attempt CG auth if envs are configured

### DIFF
--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -13,7 +13,12 @@ import (
 )
 
 // DefaultAuthenticators is a list of authenticators that are used by default.
-var DefaultAuthenticators Authenticator = multiAuthenticator{EnvAuth{}, CGRAuth{}}
+var DefaultAuthenticators Authenticator = multiAuthenticator{
+	EnvAuth{},
+	NewChainguardIdentityAuth(os.Getenv("CHAINGUARD_IDENTITY"), "https://issuer.enforce.dev", "https://apk.cgr.dev"),
+	NewK8sAuth(os.Getenv("K8S_TOKEN_PATH"), os.Getenv("CHAINGUARD_IDENTITY"), "https://issuer.enforce.dev", "https://apk.cgr.dev"),
+	CGRAuth{},
+}
 
 // Authenticator is an interface for types that can add HTTP basic auth to a
 // request.
@@ -88,7 +93,9 @@ func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) error {
 		}
 		tok = string(out)
 	})
-	req.SetBasicAuth("user", tok)
+	if tok != "" {
+		req.SetBasicAuth("user", tok)
+	}
 	return nil
 }
 

--- a/pkg/apk/auth/chainguard.go
+++ b/pkg/apk/auth/chainguard.go
@@ -3,11 +3,15 @@ package auth
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"chainguard.dev/sdk/sts"
+	"github.com/charmbracelet/log"
 	"golang.org/x/time/rate"
 	"google.golang.org/api/idtoken"
 )
@@ -19,46 +23,105 @@ import (
 // Issuer is usually https://issuer.enforce.dev.
 // Audience is usually https://apk.cgr.dev.
 func NewChainguardIdentityAuth(identity, issuer, audience string) Authenticator {
-	return authenticator{
+	return &cgAuth{
 		id:  identity,
 		iss: issuer,
 		aud: audience,
 	}
 }
 
-type authenticator struct {
+type cgAuth struct {
 	id, iss, aud string
+
+	sometimes rate.Sometimes
+	cgtok     string
+	cgerr     error
 }
 
-var cgSometimes = rate.Sometimes{Interval: 10 * time.Minute}
-var cgtok string
-var cerr error
-
-func (a authenticator) AddAuth(ctx context.Context, req *http.Request) error {
+func (a *cgAuth) AddAuth(ctx context.Context, req *http.Request) error {
+	if a.id == "" {
+		return nil
+	}
 	if req.Host != strings.TrimPrefix(a.aud, "https://") {
 		return nil
 	}
 
-	cgSometimes.Do(func() {
+	a.sometimes.Do(func() {
+		a.cgerr = nil
 		ts, err := idtoken.NewTokenSource(ctx, a.iss)
 		if err != nil {
-			cerr = fmt.Errorf("creating token source: %w", err)
+			a.cgerr = fmt.Errorf("creating token source: %w", err)
 			return
 		}
+		log.Infof("Exchanging GCP token for Chainguard identity %s", a.id)
 		tok, err := ts.Token()
 		if err != nil {
-			cerr = fmt.Errorf("getting token: %w", err)
+			a.cgerr = fmt.Errorf("getting token: %w", err)
 			return
 		}
 		ctok, err := sts.Exchange(ctx, a.iss, a.aud, tok.AccessToken, sts.WithIdentity(a.id))
 		if err != nil {
-			cerr = fmt.Errorf("exchanging token: %w", err)
+			a.cgerr = fmt.Errorf("exchanging token: %w", err)
 		}
-		cgtok = ctok
+		a.cgtok = ctok
 	})
-	if cerr != nil {
-		return cerr
+	if a.cgerr != nil {
+		return a.cgerr
 	}
-	req.SetBasicAuth("user", cgtok)
+	req.SetBasicAuth("user", a.cgtok)
+	return nil
+}
+
+type k8sAuth struct {
+	path, id, iss, aud string
+
+	sometimes rate.Sometimes
+	cgtok     string
+	cgerr     error
+}
+
+// NewK8sAuth returns an Authenticator that authorizes
+// requests as the given assumeable identity, given a projected K8s SA token.
+//
+// The token path is the path to the projected K8s SA token.
+// The identity is a UIDP of a Chainguard Identity.
+// Issuer is usually https://issuer.enforce.dev.
+// Audience is usually https://apk.cgr.dev.
+func NewK8sAuth(tokenPath, identity, issuer, audience string) Authenticator {
+	return &k8sAuth{
+		path:      tokenPath,
+		id:        identity,
+		iss:       issuer,
+		aud:       audience,
+		sometimes: rate.Sometimes{Interval: 10 * time.Minute},
+	}
+}
+
+func (k *k8sAuth) AddAuth(ctx context.Context, req *http.Request) error {
+	if k.id == "" || k.path == "" {
+		return nil
+	}
+	if req.Host != strings.TrimPrefix(k.aud, "https://") {
+		return nil
+	}
+
+	k.sometimes.Do(func() {
+		k.cgerr = nil
+		b, err := fs.ReadFile(os.DirFS(filepath.Dir(k.path)), filepath.Base(k.path))
+		if err != nil {
+			k.cgerr = fmt.Errorf("reading token: %w", err)
+			return
+		}
+		log.Infof("Exchanging K8s token for Chainguard identity %s", k.id)
+		ctok, err := sts.Exchange(ctx, k.iss, k.aud, string(b), sts.WithIdentity(k.id))
+		if err != nil {
+			k.cgerr = fmt.Errorf("exchanging token: %w", err)
+		}
+		k.cgtok = ctok
+	})
+	if k.cgerr != nil {
+		return k.cgerr
+	}
+	req.SetBasicAuth("user", k.cgtok)
 	return nil
 }


### PR DESCRIPTION
With this change, by default:

1. if `HTTP_AUTH` is set and parseable, we'll try to use that token for apk auth.
1. if `CHAINGUARD_IDENTITY` and `K8S_TOKEN_PATH` are set, we'll try to use a K8s SA token and exchange it for the CG identity.
2. if `CHAINGUARD_IDENTITY` is set and (1) didn't set auth, we'll try to get a GCP token and exchange it for a CG identity token.
3. finally, if none of the above has worked, and `chainctl` is available, we'll try to get a token from that.

For K8s auth: in order for the exchange to work, the token must be projected into the path, with a matching configured audience, and the identity has to be assumable by the token (its issuer, subject and optionally its claims)