### PR TITLE
Keep apk modtime

### DIFF
--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -129,13 +129,11 @@ func (m *memFS) Mkdir(path string, perms fs.FileMode) error {
 	}
 	// now create the directory
 	anode.children[filepath.Base(path)] = &node{
-		name:       filepath.Base(path),
-		mode:       fs.ModeDir | perms,
-		dir:        true,
-		modTime:    time.Now(),
-		createTime: time.Now(),
-		children:   map[string]*node{},
-		xattrs:     map[string][]byte{},
+		name:     filepath.Base(path),
+		mode:     fs.ModeDir | perms,
+		dir:      true,
+		children: map[string]*node{},
+		xattrs:   map[string][]byte{},
 	}
 	return nil
 }
@@ -179,13 +177,11 @@ func (m *memFS) MkdirAll(path string, perm fs.FileMode) error {
 		newnode, ok := anode.children[part]
 		if !ok {
 			newnode = &node{
-				name:       part,
-				mode:       fs.ModeDir | perm,
-				dir:        true,
-				modTime:    time.Now(),
-				createTime: time.Now(),
-				children:   map[string]*node{},
-				xattrs:     map[string][]byte{},
+				name:     part,
+				mode:     fs.ModeDir | perm,
+				dir:      true,
+				children: map[string]*node{},
+				xattrs:   map[string][]byte{},
 			}
 			anode.children[part] = newnode
 		}
@@ -245,12 +241,10 @@ func (m *memFS) openFile(name string, flag int, perm fs.FileMode, linkCount int)
 	if flag&os.O_CREATE != 0 && !ok {
 		// create the file
 		anode = &node{
-			name:       base,
-			mode:       perm,
-			dir:        false,
-			modTime:    time.Now(),
-			createTime: time.Now(),
-			xattrs:     map[string][]byte{},
+			name:   base,
+			mode:   perm,
+			dir:    false,
+			xattrs: map[string][]byte{},
 		}
 		parentAnode.children[base] = anode
 	}
@@ -332,13 +326,11 @@ func (m *memFS) Mknod(path string, mode uint32, dev int) error {
 		return os.ErrExist
 	}
 	anode.children[base] = &node{
-		name:       base,
-		mode:       fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
-		modTime:    time.Now(),
-		createTime: time.Now(),
-		major:      unix.Major(uint64(dev)),
-		minor:      unix.Minor(uint64(dev)),
-		xattrs:     map[string][]byte{},
+		name:   base,
+		mode:   fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
+		major:  unix.Major(uint64(dev)),
+		minor:  unix.Minor(uint64(dev)),
+		xattrs: map[string][]byte{},
 	}
 
 	return nil
@@ -401,7 +393,6 @@ func (m *memFS) Symlink(oldname, newname string) error {
 	anode.children[base] = &node{
 		name:       base,
 		mode:       0o777 | os.ModeSymlink,
-		modTime:    time.Now(),
 		linkTarget: oldname,
 		xattrs:     map[string][]byte{},
 	}
@@ -625,7 +616,6 @@ type node struct {
 	name         string
 	data         []byte
 	modTime      time.Time
-	createTime   time.Time
 	linkTarget   string
 	linkCount    int // extra links, so 0 means a single pointer. O-based, like most compuuter counting systems.
 	major, minor uint32

--- a/pkg/apk/tarball/write.go
+++ b/pkg/apk/tarball/write.go
@@ -149,9 +149,7 @@ func (c *Context) writeTar(ctx context.Context, tw *tar.Writer, fsys fs.FS, user
 		header.Name = path
 
 		// zero out timestamps for reproducibility
-		header.AccessTime = c.SourceDateEpoch
-		header.ModTime = c.SourceDateEpoch
-		header.ChangeTime = c.SourceDateEpoch
+		header.ModTime = info.ModTime()
 
 		if uid, ok := c.remapUIDs[header.Uid]; ok {
 			header.Uid = uid

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -259,14 +259,12 @@ func (m *memFS) Mkdir(path string, perms fs.FileMode) error {
 	}
 	// now create the directory
 	anode.children[filepath.Base(path)] = &node{
-		name:       filepath.Base(path),
-		mode:       fs.ModeDir | perms,
-		dir:        true,
-		modTime:    time.Now(),
-		createTime: time.Now(),
-		children:   map[string]*node{},
-		xattrs:     map[string][]byte{},
-		hardlinks:  map[string]*tar.Header{},
+		name:      filepath.Base(path),
+		mode:      fs.ModeDir | perms,
+		dir:       true,
+		children:  map[string]*node{},
+		xattrs:    map[string][]byte{},
+		hardlinks: map[string]*tar.Header{},
 	}
 	return nil
 }
@@ -310,14 +308,12 @@ func (m *memFS) MkdirAll(path string, perm fs.FileMode) error {
 		newnode, ok := anode.children[part]
 		if !ok {
 			newnode = &node{
-				name:       part,
-				mode:       fs.ModeDir | perm,
-				dir:        true,
-				modTime:    time.Now(),
-				createTime: time.Now(),
-				children:   map[string]*node{},
-				xattrs:     map[string][]byte{},
-				hardlinks:  map[string]*tar.Header{},
+				name:      part,
+				mode:      fs.ModeDir | perm,
+				dir:       true,
+				children:  map[string]*node{},
+				xattrs:    map[string][]byte{},
+				hardlinks: map[string]*tar.Header{},
 			}
 			anode.children[part] = newnode
 		}
@@ -383,13 +379,11 @@ func (m *memFS) openFile(name string, flag int, perm fs.FileMode, linkCount int)
 		if !ok {
 			// create the file
 			anode = &node{
-				name:       base,
-				mode:       perm,
-				dir:        false,
-				modTime:    time.Now(),
-				createTime: time.Now(),
-				xattrs:     map[string][]byte{},
-				hardlinks:  map[string]*tar.Header{},
+				name:      base,
+				mode:      perm,
+				dir:       false,
+				xattrs:    map[string][]byte{},
+				hardlinks: map[string]*tar.Header{},
 			}
 			parentAnode.children[base] = anode
 		}
@@ -461,8 +455,7 @@ func (m *memFS) writeHeader(name string, te tarEntry) (bool, error) {
 			name:       base,
 			mode:       te.header.FileInfo().Mode(),
 			dir:        false,
-			modTime:    time.Now(),
-			createTime: time.Now(),
+			modTime:    te.header.ModTime,
 			linkTarget: te.header.Linkname,
 			xattrs:     map[string][]byte{},
 			hardlinks:  map[string]*tar.Header{},
@@ -526,8 +519,7 @@ func (m *memFS) writeHeader(name string, te tarEntry) (bool, error) {
 		name:       base,
 		mode:       te.header.FileInfo().Mode(),
 		dir:        false,
-		modTime:    time.Now(),
-		createTime: time.Now(),
+		modTime:    te.header.ModTime,
 		linkTarget: te.header.Linkname,
 		xattrs:     map[string][]byte{},
 		hardlinks:  map[string]*tar.Header{},
@@ -600,14 +592,12 @@ func (m *memFS) Mknod(path string, mode uint32, dev int) error {
 		return fs.ErrExist
 	}
 	anode.children[base] = &node{
-		name:       base,
-		mode:       fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
-		modTime:    time.Now(),
-		createTime: time.Now(),
-		major:      unix.Major(uint64(dev)),
-		minor:      unix.Minor(uint64(dev)),
-		xattrs:     map[string][]byte{},
-		hardlinks:  map[string]*tar.Header{},
+		name:      base,
+		mode:      fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
+		major:     unix.Major(uint64(dev)),
+		minor:     unix.Minor(uint64(dev)),
+		xattrs:    map[string][]byte{},
+		hardlinks: map[string]*tar.Header{},
 	}
 
 	return nil
@@ -670,7 +660,6 @@ func (m *memFS) Symlink(oldname, newname string) error {
 	anode.children[base] = &node{
 		name:       base,
 		mode:       0o777 | os.ModeSymlink,
-		modTime:    time.Now(),
 		linkTarget: oldname,
 		xattrs:     map[string][]byte{},
 		hardlinks:  map[string]*tar.Header{},
@@ -932,7 +921,6 @@ type node struct {
 	name         string
 	data         []byte
 	modTime      time.Time
-	createTime   time.Time
 	linkTarget   string
 	linkCount    int // extra links, so 0 means a single pointer. O-based, like most compuuter counting systems.
 	major, minor uint32


### PR DESCRIPTION
We were overwriting all the file timestamps with a configurable SOURCE_DATE_EPOCH, which was always the unix epoch. The only reason we were doing this is that we were also setting the modtime of everything to time.Now() elsewhere.

That's silly.

Instead, don't set anything to time.Now() and keep file modtimes when we add them to the filesystem. If the APKs change, nothing will be reproducible anyway, so keeping the data from the APK seems way better.