### PR TITLE
Drop a period from a command's help

### DIFF
--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -51,8 +51,8 @@ func dotcmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "dot",
-		Short: "Output a digraph showing the resolved dependencies of an apko config.",
-		Long: `Output a digraph showing the resolved dependencies of an apko config.
+		Short: "Output a digraph showing the resolved dependencies of an apko config",
+		Long: `Output a digraph showing the resolved dependencies of an apko config
 
 # Render an svg of example.yaml
 apko dot example.yaml | dot -Tvsg > graph.svg


### PR DESCRIPTION
The help for every other command does not end with a period so let's make them consistent.