### PR TITLE
Fail if APKINDEX has single-character lines

### DIFF
--- a/pkg/apk/apk/apkindex.go
+++ b/pkg/apk/apk/apkindex.go
@@ -119,8 +119,12 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 			continue
 		}
 
-		if len(line) > 1 && line[1:2] != ":" {
-			return nil, fmt.Errorf("cannot parse line %d: expected \":\" in not found", linenr)
+		if len(line) < 2 {
+			return nil, fmt.Errorf("cannot parse line %d: expected len >= 2, saw %q", linenr, line)
+		}
+
+		if line[1:2] != ":" {
+			return nil, fmt.Errorf("cannot parse line %d: expected \":\" not found", linenr)
 		}
 
 		token := line[:1]


### PR DESCRIPTION
We expect some blank lines, which delimit each entry. We expect every other line to have at least e.g. "C:", i.e. a single character followed by a colon.

I looked at our current APKINDEX to make sure I'm not missing anything:

```
$ awk '{print length}' APKINDEX | sort -n | uniq -c | head
83376 0
11137 2
7807 3
1214 4
18924 5
23738 6
49958 7
126520 8
62586 9
86165 10
```

We don't have any single-character lines, so this change should be fine.