### PR TITLE
Make etag checks optional

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/chainguard-dev/clog"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/oci"
 	"chainguard.dev/apko/pkg/build/types"
@@ -108,7 +109,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithTags(args[1]),
 				build.WithVCS(withVCS),
 				build.WithAnnotations(annotations),
-				build.WithCacheDir(cacheDir, offline),
+				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 				build.WithLockFile(lockfile),
 				build.WithTempDir(tmp),
 				build.WithIncludePaths(includePaths),

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -72,7 +72,7 @@ apko dot --web -S example.yaml
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
 				build.WithExtraRuntimeRepos(extraRuntimeRepos),
-				build.WithCacheDir(cacheDir, offline),
+				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
 	}

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/chainguard-dev/clog"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/oci"
 	"chainguard.dev/apko/pkg/build/types"
@@ -116,7 +117,7 @@ in a keychain.`,
 					build.WithTags(args[1:]...),
 					build.WithVCS(withVCS),
 					build.WithAnnotations(annotations),
-					build.WithCacheDir(cacheDir, offline),
+					build.WithCache(cacheDir, offline, apk.NewCache(true)),
 					build.WithLockFile(lockfile),
 					build.WithTempDir(tmp),
 					build.WithIgnoreSignatures(ignoreSignatures),

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build"
 )
@@ -49,7 +50,7 @@ The derived configuration is rendered in YAML.
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
 				build.WithExtraRuntimeRepos(extraRuntimeRepos),
-				build.WithCacheDir(cacheDir, offline),
+				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
 	}

--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/chainguard-dev/clog"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
 )
@@ -108,7 +109,7 @@ packagelock and packagelock-source are particularly useful for inserting back in
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
 				build.WithExtraRuntimeRepos(extraRuntimeRepos),
-				build.WithCacheDir(cacheDir, offline),
+				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
 	}

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -26,133 +26,74 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/singleflight"
 )
 
-// This is terrible but simpler than plumbing around a cache for now.
-// We will assume that for a given process, we want to reuse etag values.
-// Doing this cuts down on the number of requests we send for index and keys.
-var globalEtagCache = &etagCache{}
-
-type etagResp struct {
-	resp      *http.Response
-	err       error
-	cacheFile string
+type Cache struct {
+	etagCache  *sync.Map
+	headFlight *singleflight.Group
+	getFlight  *singleflight.Group
 }
 
-type etagCache struct {
-	// url -> *sync.Once
-	etags sync.Map
+// NewCache returns a new Cache, which allows us to persist the results of HEAD requests
+// for a given URL across multiple builds. This is generally desirable when building many images
+// all at once, since we can eliminate round trips to HEAD the same e.g. APKINDEX repeatedly.
+// However, this is not desirable for long-lived processes where we expected the APKINDEX to change
+// over time and want to observe those changes and re-fetch the new APKINDEX. Since apko is used
+// in both contexts, this knob is exposed, but very few people actually should be using apko as a library,
+// so I'm mostly just talking to myself here. This used to be a process-wide global cache, which was
+// great for the short-lived terraform module, but a terrible default behavior for a library.
+//
+// Even if you don't want to cache HEAD requests, this is still useful for coalescing concurrent
+// requests for the same resource when passing etag=false.
+func NewCache(etag bool) *Cache {
+	c := &Cache{
+		headFlight: &singleflight.Group{},
+		getFlight:  &singleflight.Group{},
+	}
 
-	// url -> etagResp
-	resps sync.Map
+	if etag {
+		c.etagCache = &sync.Map{}
+	}
+
+	return c
 }
 
-// get dedupes incoming etag-based requests by url (using a sync.Map[string]sync.Once) and stores the results
-// in a sync.Map[string]etagResp. If we request the same URL multiple times, we will only ever reach out to
-// the internet for the first once and reuse the results for all subsequent calls (unless the response does
-// not have an etag).
-func (e *etagCache) get(ctx context.Context, t *cacheTransport, request *http.Request, cacheFile string) (*http.Response, error) {
-	ctx, span := otel.Tracer("go-apk").Start(ctx, fmt.Sprintf("etagCache.get(%q)", request.URL.String()))
-	defer span.End()
+func (c *Cache) load(cacheFile string) (*http.Response, bool) {
+	if c == nil || c.etagCache == nil {
+		return nil, false
+	}
 
-	url := request.URL.String()
-
-	// Do all the expensive things inside the once.
-	once, _ := e.etags.LoadOrStore(url, &sync.Once{})
-	once.(*sync.Once).Do(func() {
-		ctx, span := otel.Tracer("go-apk").Start(ctx, "once.Do")
-		defer span.End()
-
-		req := request.Clone(request.Context())
-		req.Method = http.MethodHead
-		resp, rerr := t.wrapped.Do(req)
-		if resp != nil {
-			// We don't expect any body from a HEAD so just always close it to appease the linter.
-			resp.Body.Close()
-		}
-		if rerr != nil || resp.StatusCode != 200 {
-			e.resps.Store(url, etagResp{
-				resp: resp,
-				err:  rerr,
-			})
-			return
-		}
-
-		initialEtag, ok := etagFromResponse(resp)
-		if !ok {
-			return
-		}
-
-		// We simulate content-based addressing with the etag values using an .etag
-		// file extension.
-		etagFile := cacheFileFromEtag(cacheFile, initialEtag)
-		if _, err := os.Stat(etagFile); err == nil {
-			e.resps.Store(url, etagResp{
-				cacheFile: etagFile,
-			})
-			return
-		}
-
-		// Only download the index once.
-		etagFile, err := t.retrieveAndSaveFile(ctx, request, func(r *http.Response) (string, error) {
-			_, span := otel.Tracer("go-apk").Start(ctx, "callback")
-			defer span.End()
-			// On the etag path, use the etag from the actual response to
-			// compute the final file name.
-			finalEtag, ok := etagFromResponse(r)
-			if !ok {
-				return "", fmt.Errorf("GET response did not contain an etag, but HEAD returned %q", initialEtag)
-			}
-
-			return cacheFileFromEtag(cacheFile, finalEtag), nil
-		})
-		e.resps.Store(url, etagResp{
-			err:       err,
-			cacheFile: etagFile,
-		})
-	})
-
-	v, ok := e.resps.Load(url)
+	v, ok := c.etagCache.Load(cacheFile)
 	if !ok {
-		// If the server doesn't return etags, and we require them,
-		// then do not cache.
-		return t.wrapped.Do(request)
-	}
-	resp := v.(etagResp)
-
-	// If we didn't manage to cache it, return the response and/or error.
-	if resp.cacheFile == "" {
-		return resp.resp, resp.err
+		return nil, false
 	}
 
-	f, err := os.Open(resp.cacheFile)
-	if err != nil {
-		return nil, fmt.Errorf("open(%q): %w", resp.cacheFile, err)
+	return v.(*http.Response), true
+}
+
+func (c *Cache) store(cacheFile string, resp *http.Response) {
+	if c == nil || c.etagCache == nil {
+		return
 	}
 
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat(%q): %w", resp.cacheFile, err)
-	}
-
-	return &http.Response{
-		StatusCode:    http.StatusOK,
-		Body:          f,
-		ContentLength: fi.Size(),
-	}, nil
+	c.etagCache.Store(cacheFile, resp)
 }
 
 // cache
 type cache struct {
 	dir     string
 	offline bool
+
+	shared *Cache
 }
 
 // client return an http.Client that knows how to read from and write to the cache
 // key is in the implementation of https://pkg.go.dev/net/http#RoundTripper
-func (c cache) client(wrapped *http.Client, etagRequired bool) *http.Client {
+func (c *cache) client(wrapped *http.Client, etagRequired bool) *http.Client {
 	return &http.Client{
 		Transport: &cacheTransport{
+			cache:        c.shared,
 			wrapped:      wrapped,
 			root:         c.dir,
 			offline:      c.offline,
@@ -162,6 +103,7 @@ func (c cache) client(wrapped *http.Client, etagRequired bool) *http.Client {
 }
 
 type cacheTransport struct {
+	cache        *Cache
 	wrapped      *http.Client
 	root         string
 	offline      bool
@@ -172,20 +114,12 @@ func (t *cacheTransport) RoundTrip(request *http.Request) (*http.Response, error
 	ctx, span := otel.Tracer("go-apk").Start(request.Context(), "cacheTransport.RoundTrip")
 	defer span.End()
 
-	// do we have the file in the cache?
-	if request.URL == nil {
-		return nil, fmt.Errorf("no URL in request")
-	}
 	cacheFile, err := cachePathFromURL(t.root, *request.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cache path based on URL: %w", err)
 	}
 
 	if !t.etagRequired {
-		// We don't cache the response for these because they get cached later in cachePackage.
-
-		ctx, span := otel.Tracer("go-apk").Start(ctx, fmt.Sprintf("Open(%q)", cacheFile))
-		defer span.End()
 		// Try to open the file in the cache.
 		// If we hit an error, just send the request.
 		f, err := os.Open(cacheFile)
@@ -193,9 +127,11 @@ func (t *cacheTransport) RoundTrip(request *http.Request) (*http.Response, error
 			if t.offline {
 				return nil, fmt.Errorf("failed to read %q in offline cache: %w", cacheFile, err)
 			}
+
 			_, span := otel.Tracer("go-apk").Start(ctx, fmt.Sprintf("Request(%q)", request.URL.String()))
 			defer span.End()
 
+			// We don't cache the response for these because they get cached later in cachePackage.
 			return t.wrapped.Do(request)
 		}
 
@@ -206,45 +142,157 @@ func (t *cacheTransport) RoundTrip(request *http.Request) (*http.Response, error
 	}
 
 	if t.offline {
-		cacheDir := cacheDirFromFile(cacheFile)
-		des, err := os.ReadDir(cacheDir)
-		if err != nil {
-			return nil, fmt.Errorf("listing %q for offline cache: %w", cacheDir, err)
-		}
-
-		if len(des) == 0 {
-			return nil, fmt.Errorf("no offline cached entries for %s", cacheDir)
-		}
-
-		newest, err := des[0].Info()
-		if err != nil {
-			return nil, err
-		}
-
-		for _, de := range des[1:] {
-			fi, err := de.Info()
-			if err != nil {
-				return nil, err
-			}
-
-			if fi.ModTime().After(newest.ModTime()) {
-				newest = fi
-			}
-		}
-
-		f, err := os.Open(filepath.Join(cacheDir, newest.Name()))
-		if err != nil {
-			return nil, err
-		}
-
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          f,
-			ContentLength: newest.Size(),
-		}, nil
+		return t.fetchOffline(cacheFile)
 	}
 
-	return globalEtagCache.get(ctx, t, request, cacheFile)
+	return t.fetchAndCache(ctx, request, cacheFile)
+}
+
+func (t *cacheTransport) head(request *http.Request, cacheFile string) (*http.Response, error) {
+	resp, ok := t.cache.load(cacheFile)
+	if ok {
+		return resp, nil
+	}
+
+	v, err, _ := t.cache.headFlight.Do(cacheFile, func() (interface{}, error) {
+		req := request.Clone(request.Context())
+		req.Method = http.MethodHead
+		resp, err := t.wrapped.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		// HEAD shouldn't have a body. Make sure we close it so we can reuse the connection.
+		defer resp.Body.Close()
+
+		t.cache.store(cacheFile, resp)
+
+		return resp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return v.(*http.Response), nil
+}
+
+func (t *cacheTransport) get(ctx context.Context, request *http.Request, cacheFile, initialEtag string) (string, error) {
+	v, err, _ := t.cache.getFlight.Do(cacheFile, func() (interface{}, error) {
+		// We simulate content-based addressing with the etag values using an .etag file extension.
+		etagFile, err := cacheFileFromEtag(cacheFile, initialEtag)
+		if err != nil {
+			return "", err
+		}
+		if _, err := os.Stat(etagFile); err == nil {
+			return etagFile, nil
+		}
+
+		// Only download the index once.
+		return t.retrieveAndSaveFile(ctx, request, func(r *http.Response) (string, error) {
+			_, span := otel.Tracer("go-apk").Start(ctx, "callback")
+			defer span.End()
+
+			// On the etag path, use the etag from the actual response to compute the final file name.
+			finalEtag, ok := etagFromResponse(r)
+			if !ok {
+				return "", fmt.Errorf("GET response did not contain an etag, but HEAD returned %q", initialEtag)
+			}
+
+			return cacheFileFromEtag(cacheFile, finalEtag)
+		})
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return v.(string), nil
+}
+
+func (t *cacheTransport) fetchAndCache(ctx context.Context, request *http.Request, cacheFile string) (*http.Response, error) {
+	initialEtag := request.Header.Get("If-None-Match")
+	if initialEtag == "" {
+		resp, err := t.head(request, cacheFile)
+		if err != nil {
+			return nil, err
+		}
+
+		if request.Method == http.MethodHead {
+			return resp, err
+		}
+
+		etag, ok := etagFromResponse(resp)
+		if !ok {
+			return t.wrapped.Do(request)
+		}
+
+		initialEtag = etag
+	}
+
+	// This is a bit of a hack. We cache parsed APKINDEX files in globalIndexCache, which needs the etag as a cache key.
+	// Since we already send a HEAD request to get that etag, we want to avoid sending a redundant HEAD request above if we can.
+	// However, we don't actually want to pass along this header because it's using the "parsed" version of the Etag from
+	// etagFromResponse and doesn't actually attempt to follow HTTP semantics, so we remove it here to avoid any confusion.
+	request.Header.Del("If-None-Match")
+
+	etagFile, err := t.get(ctx, request, cacheFile, initialEtag)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(etagFile)
+	if err != nil {
+		return nil, fmt.Errorf("open(%q): %w", etagFile, err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat(%q): %w", etagFile, err)
+	}
+
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          f,
+		ContentLength: fi.Size(),
+	}, nil
+}
+
+func (t *cacheTransport) fetchOffline(cacheFile string) (*http.Response, error) {
+	cacheDir := cacheDirFromFile(cacheFile)
+	des, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing %q for offline cache: %w", cacheDir, err)
+	}
+
+	if len(des) == 0 {
+		return nil, fmt.Errorf("no offline cached entries for %s", cacheDir)
+	}
+
+	newest, err := des[0].Info()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, de := range des[1:] {
+		fi, err := de.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		if fi.ModTime().After(newest.ModTime()) {
+			newest = fi
+		}
+	}
+
+	f, err := os.Open(filepath.Join(cacheDir, newest.Name()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          f,
+		ContentLength: newest.Size(),
+	}, nil
 }
 
 func cacheDirFromFile(cacheFile string) string {
@@ -255,7 +303,7 @@ func cacheDirFromFile(cacheFile string) string {
 	return filepath.Dir(cacheFile)
 }
 
-func cacheFileFromEtag(cacheFile, etag string) string {
+func cacheFileFromEtag(cacheFile, etag string) (string, error) {
 	cacheDir := filepath.Dir(cacheFile)
 	ext := ".etag"
 
@@ -265,7 +313,15 @@ func cacheFileFromEtag(cacheFile, etag string) string {
 		ext = ".tar.gz"
 	}
 
-	return filepath.Join(cacheDir, etag+ext)
+	absPath, err := filepath.Abs(filepath.Join(cacheDir, etag+ext))
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(absPath, cacheDir) {
+		return "", fmt.Errorf("unsafe etag value: %q", etag)
+	}
+
+	return absPath, nil
 }
 
 func etagFromResponse(resp *http.Response) (string, bool) {

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -421,7 +421,7 @@ func TestFetchPackage(t *testing.T) {
 
 		opts := []Option{WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors)}
 		if cache != "" {
-			opts = append(opts, WithCache(cache, false))
+			opts = append(opts, WithCache(cache, false, NewCache(false)))
 		}
 		a, err := New(opts...)
 		require.NoError(t, err, "unable to create APK")

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -83,7 +83,7 @@ func WithFS(fs apkfs.FullFS) Option {
 //
 // If offline is true, only read from the cache and do not make any network requests to
 // populate it.
-func WithCache(cacheDir string, offline bool) Option {
+func WithCache(cacheDir string, offline bool, shared *Cache) Option {
 	return func(o *opts) error {
 		var err error
 		if cacheDir == "" {
@@ -96,6 +96,7 @@ func WithCache(cacheDir string, offline bool) Option {
 		o.cache = &cache{
 			dir:     cacheDir,
 			offline: offline,
+			shared:  shared,
 		}
 		return nil
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -257,9 +257,9 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 	// note that this is not easy to do in a switch statement, because of the second
 	// condition, if err := ...; err == nil {}
 	if bc.o.CacheDir != "" {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline))
+		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
 	} else if _, err := os.UserCacheDir(); err == nil {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline))
+		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
 	} else {
 		log.Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -112,7 +112,7 @@ func TestAuth_good(t *testing.T) {
 	called := false
 	testUser, testPass := "user", "pass"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("ETag", "123")
+		w.Header().Set("ETag", "234")
 		if r.Method == http.MethodHead {
 			return
 		}
@@ -151,7 +151,7 @@ func TestAuth_bad(t *testing.T) {
 	called := false
 	testUser, testPass := "user", "pass"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("ETag", "123")
+		w.Header().Set("ETag", "345")
 		if r.Method == http.MethodHead {
 			return
 		}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/build/types"
 
@@ -189,11 +190,12 @@ func WithAnnotations(annotations map[string]string) Option {
 	}
 }
 
-// WithCacheDir set the cache directory to use
-func WithCacheDir(cacheDir string, offline bool) Option {
+// WithCache set the cache directory to use
+func WithCache(cacheDir string, offline bool, shared *apk.Cache) Option {
 	return func(bc *Context) error {
 		bc.o.CacheDir = cacheDir
 		bc.o.Offline = offline
+		bc.o.SharedCache = shared
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"time"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/build/types"
 )
@@ -49,6 +50,7 @@ type Options struct {
 	Local                   bool               `json:"local,omitempty"`
 	CacheDir                string             `json:"cacheDir,omitempty"`
 	Offline                 bool               `json:"offline,omitempty"`
+	SharedCache             *apk.Cache         `json:"-"`
 	Lockfile                string             `json:"lockfile,omitempty"`
 	Auth                    auth.Authenticator `json:"-"`
 	IncludePaths            []string           `json:"includePaths,omitempty"`
@@ -61,6 +63,7 @@ var Default = Options{
 	Arch:            types.ParseArchitecture(runtime.GOARCH),
 	SourceDateEpoch: time.Unix(0, 0).UTC(),
 	Auth:            auth.DefaultAuthenticators,
+	SharedCache:     apk.NewCache(false),
 }
 
 // Tempdir returns the temporary directory where apko will create


### PR DESCRIPTION
This isn't perfect but I think it moves us closer in the right direction. Previously, we had a process-wide global etag cache that would prevent sending multiple HEAD requests to check the etag value of any URLs we fetched (keys and APKINDEX, mostly).

This is great for a local tool or even the terraform provider, but it's awful as a library used by a service because the lifetime of the process is liable to outlive the validity of the cach.

This hoists that global etag caching mechanism out into a little apk.Cache struct, which is where I'm hoping to put even more things that I'm ashamed of going forward.

Using the same apk.NewCache(true) instance across multiple builds will skip HEAD requests to the same URL and just assume that the tag hasn't changed. This was the previous default behavior.

Using the same apk.NewCache(false) instance across multiple builds (the default) will send a HEAD request prior to every key or index fetch in order to see if they've changed.

We still have some global caching going on for actually parsing the results, which keys off of etag values, so we shouldn't have any progressions re: the recent CPU savings changes I've made.

Another thing this introduces (because we dropped the more powerful etag-based caching) is a some singleflight instances for these outgoing requests. We don't want to cache the results indefinitely, but we do want to avoid sending redundant requests in every case, so apk.NewCache(false) will still coalesce multiple concurrent requests for the same URL, so there's still benefit to using this cache object even with the etag caching disabled.

One thing that's missing here is a distinction between ~request-scoped caching if e.g. I want to use an etag cache for any outgoing URLs for a single build, but I also want to use a global cache for coalescing requests. I'll probably split the singleflight stuff off from this struct at some point, but I want to measure first to see if that's really necessary.