### PR TITLE
Preserve APK timestamps when using dirfs

### DIFF
--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -242,6 +242,10 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 
 			if installed {
 				a.installedFiles[header.Name] = pkg
+
+				if err := a.fs.Chtimes(header.Name, header.AccessTime, header.ModTime); err != nil {
+					return nil, fmt.Errorf("chtimes for %s: %w", header.Name, err)
+				}
 			}
 
 		case tar.TypeSymlink:

--- a/pkg/apk/fs/fs.go
+++ b/pkg/apk/fs/fs.go
@@ -16,6 +16,7 @@ package fs
 import (
 	"io"
 	"io/fs"
+	"time"
 )
 
 // FullFS is a filesystem that supports all filesystem operations.
@@ -39,6 +40,7 @@ type FullFS interface {
 	Remove(name string) error
 	Chmod(path string, perm fs.FileMode) error
 	Chown(path string, uid int, gid int) error
+	Chtimes(path string, atime time.Time, mtime time.Time) error
 	SetXattr(path string, attr string, data []byte) error
 	GetXattr(path string, attr string) ([]byte, error)
 	RemoveXattr(path string, attr string) error

--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -364,6 +364,7 @@ func (m *memFS) Chmod(path string, perm fs.FileMode) error {
 	anode.mode = perm | (anode.mode & os.ModeType)
 	return nil
 }
+
 func (m *memFS) Chown(path string, uid, gid int) error {
 	anode, err := m.getNode(path)
 	if err != nil {
@@ -371,6 +372,15 @@ func (m *memFS) Chown(path string, uid, gid int) error {
 	}
 	anode.uid = uid
 	anode.gid = gid
+	return nil
+}
+
+func (m *memFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
+	anode, err := m.getNode(path)
+	if err != nil {
+		return err
+	}
+	anode.modTime = mtime
 	return nil
 }
 

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -504,12 +504,20 @@ func (f *dirFS) Chmod(path string, perm fs.FileMode) error {
 	}
 	return f.overrides.Chmod(path, perm)
 }
+
 func (f *dirFS) Chown(path string, uid, gid int) error {
 	if f.caseSensitiveOnDisk(path) {
 		// ignore error, as we track it in memory anyways, and disk filesystem might not support it
 		_ = os.Chown(filepath.Join(f.base, path), uid, gid)
 	}
 	return f.overrides.Chown(path, uid, gid)
+}
+
+func (f *dirFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
+	if err := os.Chtimes(filepath.Join(f.base, path), atime, mtime); err != nil {
+		return fmt.Errorf("unable to change times: %w", err)
+	}
+	return f.overrides.Chtimes(path, atime, mtime)
 }
 
 func (f *dirFS) Mknod(name string, mode uint32, dev int) error {

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -77,10 +77,7 @@ func (bc *Context) BuildTarball(ctx context.Context) (string, hash.Hash, hash.Ha
 	bc.o.TarballPath = outfile.Name()
 	defer outfile.Close()
 
-	// we use a general override of 0,0 for all files, but the specific overrides, that come from the installed package DB, come later
-	tw, err := tarball.NewContext(
-		tarball.WithSourceDateEpoch(bc.o.SourceDateEpoch),
-	)
+	tw, err := tarball.NewContext()
 	if err != nil {
 		return "", nil, nil, 0, fmt.Errorf("failed to construct tarball build context: %w", err)
 	}

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -631,6 +631,7 @@ func (m *memFS) Chmod(path string, perm fs.FileMode) error {
 	anode.mode = perm | (anode.mode & os.ModeType)
 	return nil
 }
+
 func (m *memFS) Chown(path string, uid, gid int) error {
 	anode, err := m.getNode(path)
 	if err != nil {
@@ -638,6 +639,15 @@ func (m *memFS) Chown(path string, uid, gid int) error {
 	}
 	anode.uid = uid
 	anode.gid = gid
+	return nil
+}
+
+func (m *memFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
+	anode, err := m.getNode(path)
+	if err != nil {
+		return err
+	}
+	anode.modTime = mtime
 	return nil
 }
 


### PR DESCRIPTION
This worked in our happy tarfs path but not in the dirfs path that melange uses because some runners mount directories rather than actually packaging the layer up into an image. This made it impossible to test the timestamps properly in package tests because the APK files had modtimes set to SOURCE_DATE_EPOCH.