### PR TITLE
Avoid race when mutating annotations

### DIFF
--- a/pkg/build/oci/image.go
+++ b/pkg/build/oci/image.go
@@ -39,8 +39,14 @@ import (
 	"chainguard.dev/apko/pkg/options"
 )
 
-func BuildImageFromLayer(ctx context.Context, baseImage v1.Image, layer v1.Layer, ic types.ImageConfiguration, created time.Time, arch types.Architecture) (oci.SignedImage, error) {
+func BuildImageFromLayer(ctx context.Context, baseImage v1.Image, layer v1.Layer, oic types.ImageConfiguration, created time.Time, arch types.Architecture) (oci.SignedImage, error) {
 	log := clog.FromContext(ctx)
+
+	// Create a copy to avoid modifying the original ImageConfiguration.
+	ic := &types.ImageConfiguration{}
+	if err := oic.MergeInto(ic); err != nil {
+		return nil, err
+	}
 
 	mediaType, err := layer.MediaType()
 	if err != nil {


### PR DESCRIPTION
This is a quick fix to a race condition we're hitting when building multi-arch images. The ImageConfiguration struct gets passed around by value, but the collections (e.g. annotations) don't get copied, so if multiple architectures attempt to set an annotation at the same time, we'll hit a race. This creates a defensive copy to avoid that.