### PR TITLE
fix: ensure cacheTransport returns an error for non-200 responses

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -344,8 +344,10 @@ func (t *cacheTransport) retrieveAndSaveFile(ctx context.Context, request *http.
 		return "", fmt.Errorf("wrapped client is nil")
 	}
 	resp, err := t.wrapped.Do(request)
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil {
 		return "", err
+	} else if resp.StatusCode != 200 {
+		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 
 	// Determine the file we will caching stuff in based on the URL/response


### PR DESCRIPTION
Currently there is a bug in `cacheTransport` I found when working on #1378 where non-success status codes do not result in a returned `error` (despite exiting early) resulting in other confusing/hard to debug problems later on.