### PR TITLE
fix: --cache-dir broken after in 0.19.3+

### DIFF
--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -92,6 +92,11 @@ func WithCache(cacheDir string, offline bool, shared *Cache) Option {
 				return err
 			}
 			cacheDir = filepath.Join(cacheDir, "dev.chainguard.go-apk")
+		} else {
+			cacheDir, err = filepath.Abs(cacheDir)
+			if err != nil {
+				return err
+			}
 		}
 		o.cache = &cache{
 			dir:     cacheDir,


### PR DESCRIPTION
Resolves #1378 where `--cache-dir` was broken after in 0.19.3+ due to a regression in #1327. This error happened because `cacheDir` is not an absolute path when provided via the CLI option. This PR fixes the bug by resolving `cacheDir` to an absolute path when initializing the `cache` instance.