### PR TITLE
Re-instantiate each APK's tarfs after caching

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -996,6 +996,26 @@ func (a *APK) cachePackage(ctx context.Context, pkg InstallablePackage, exp *exp
 	}
 	exp.TarFile = tarDst
 
+	if err := exp.TarFS.Close(); err != nil {
+		return nil, fmt.Errorf("closing tarfs: %w", err)
+	}
+
+	// Re-initialize the tarfs with the renamed file.
+	// TODO: Split out the tarfs Index creation from the FS.
+	// TODO: Consolidate ExpandAPK(), cachedPackage(), and cachePackage().
+	data, err := exp.PackageData()
+	if err != nil {
+		return nil, err
+	}
+	info, err := data.Stat()
+	if err != nil {
+		return nil, err
+	}
+	exp.TarFS, err = tarfs.New(data, info.Size())
+	if err != nil {
+		return nil, err
+	}
+
 	return exp, nil
 }
 


### PR DESCRIPTION
On cache miss, we'll expand and APK into a tempdir, then move all the files into the final place in our cache dir. On ExpandedAPK.Close(), we'll remove that tempdir.

If we have concurrent images installing the same package, one might clean up the tempdir while the other still has a reference to the tarball sitting in the tempdir, so subsequent reads fail.

Instead, we need to re-instantiate the tarfs after we move it to the cache dir. This could be much more efficient (we re-scan the tar). I'm working on that in a separate branch, so left a TODO for now.