### PR TITLE
`apk/client`: add `LatestPackage` to get the latest named package in an index

### DIFF
--- a/pkg/apk/apk/package.go
+++ b/pkg/apk/apk/package.go
@@ -114,8 +114,12 @@ type Package struct {
 }
 
 func (p *Package) String() string {
+	if p == nil {
+		return "<nil>"
+	}
 	return fmt.Sprintf("%s (ver:%s arch:%s)", p.Name, p.Version, p.Arch)
 }
+
 func (p *Package) PackageName() string { return p.Name }
 
 // Filename returns the package filename as it's named in a repository.

--- a/pkg/apk/client/client_test.go
+++ b/pkg/apk/client/client_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"testing"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+)
+
+func TestLatestPackage(t *testing.T) {
+	arch := "x86_64"
+	idx := &apk.APKIndex{
+		Packages: []*apk.Package{
+			{Name: "foo", Version: "1.0.0", Arch: arch},
+			{Name: "foo", Version: "1.0.1", Arch: arch}, // latest
+			{Name: "bar", Version: "1.0.0", Arch: arch}, // only
+		},
+	}
+
+	for _, c := range []struct {
+		name string
+		want *apk.Package
+	}{
+		{"foo", &apk.Package{Name: "foo", Version: "1.0.1", Arch: arch}},
+		{"bar", &apk.Package{Name: "bar", Version: "1.0.0", Arch: arch}},
+		{"baz", nil}, // not found
+	} {
+		got := (&Client{}).LatestPackage(idx, c.name)
+		if got.String() != c.want.String() {
+			t.Errorf("LatestPackage(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
We do this enough places we should just standardize on it in this client.

This obviates

https://github.com/wolfi-dev/wolfictl/blob/e27049e6a932d35feb91238f0fd195a378c1bada/pkg/apk/apk.go#L32

and 

https://github.com/wolfi-dev/wolfictl/blob/e27049e6a932d35feb91238f0fd195a378c1bada/pkg/cli/apk.go#L323

both of which can use this instead now.

This is in `apk.Client` because it's expected to be used with the result of `client.GetRemoteIndex`:

```go
c := client.New(http.DefaultClient)
idx, err := c.GetRemoteIndex(ctx, "https://packages.wolfi.dev/os", "aarch64")
p := c.LatestPackage(idx, "ko")
```