### PR TITLE
fix: Allow accounts to belong to GID 0

### DIFF
--- a/pkg/build/accounts.go
+++ b/pkg/build/accounts.go
@@ -38,9 +38,6 @@ func appendGroup(groups []passwd.GroupEntry, group types.Group) []passwd.GroupEn
 }
 
 func userToUserEntry(user types.User) passwd.UserEntry {
-	if user.GID == 0 {
-		user.GID = user.UID
-	}
 	if user.Shell == "" {
 		user.Shell = "/bin/sh"
 	}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -214,10 +214,6 @@ func (ic *ImageConfiguration) Validate() error {
 		if g.GroupName == "" {
 			return fmt.Errorf("configured group %v has no configured group name", g)
 		}
-
-		if g.GID == 0 {
-			return fmt.Errorf("configured group %v has GID 0", g)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, we block new users from belonging to GID 0. While this is a great practice, some images may expect that the configured user belong to GID 0 so remove the limitation