### PR TITLE
fix(spdx): more helpful error message on license merge

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -344,7 +344,7 @@ func mergeLicensingInfos(sourceDoc, targetDoc *Document) error {
 		for _, targetinfo := range targetDoc.LicensingInfos {
 			if targetinfo.LicenseID == sourceinfo.LicenseID {
 				if targetinfo.ExtractedText != sourceinfo.ExtractedText {
-					return fmt.Errorf("source & target LicenseID %s differ in Text", targetinfo.LicenseID)
+					return fmt.Errorf("source & target LicenseID %s differ in Text; perhaps multiple versions of the package have different contents of files provided in license-path", targetinfo.LicenseID)
 				}
 				found = true
 				break


### PR DESCRIPTION
To point out why multiple extracted license texts might differ when the image is built.

cc: @wojciechka 