### PR TITLE
fix newest-file selection for offline cache

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -278,9 +278,13 @@ func (t *cacheTransport) fetchOffline(cacheFile string) (*http.Response, error) 
 			return nil, err
 		}
 
-		if fi.ModTime().After(newest.ModTime()) {
+		if (fi.ModTime().After(newest.ModTime()) || newest.IsDir()) && !fi.IsDir() {
 			newest = fi
 		}
+	}
+
+	if newest.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", newest.Name())
 	}
 
 	f, err := os.Open(filepath.Join(cacheDir, newest.Name()))


### PR DESCRIPTION
This is a port of https://github.com/chainguard-dev/go-apk/pull/216

Copying the PR description here for brevity:

(Issue discovered while using https://github.com/chainguard-dev/rules_apko)

Given the following keyrings:

- https://packages.sgdev.org/sourcegraph-melange-prod.rsa.pub
- https://packages.sgdev.org/chainguard/chainguard-enterprise.rsa.pub

the following directory structure is created:

```
cache_wolfi_base_apko/https%3A%2F%2Fpackages.sgdev.org%2F/
├─ chainguard/
│  ├─ chainguard-enterprise.rsa.pub
├─ sourcegraph-melange-prod.rsa.pub
```

This is fine when looking for the public key file for https://packages.sgdev.org/chainguard/chainguard-enterprise.rsa.pub, but may fail for https://packages.sgdev.org/sourcegraph-melange-prod.rsa.pub if the directory chainguard/ has a newer timestamp than the public key file (I was not able to reproduce this locally on darwin, but reliably on linux CI machines).

This PR addresses this by not selecting directories as possible "newest" dir entries.
