### PR TITLE
Ignore scripts that aren't executable

### DIFF
--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -154,6 +154,13 @@ func (a *APK) updateScriptsTar(pkg *Package, controlTarGz io.Reader, sourceDateE
 			continue
 		}
 
+		// Ignore files that aren't executable.
+		// This is mostly to ignore .melange.yaml files in the control section,
+		// but apk itself has hardcoded list of scripts that we might want to do too.
+		if header.FileInfo().Mode().Perm()&0555 != 0555 {
+			continue
+		}
+
 		origName := header.Name
 		header.Name = fmt.Sprintf("%s-%s.Q1%s%s", pkg.Name, pkg.Version, base64.StdEncoding.EncodeToString(pkg.Checksum), origName)
 

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -149,7 +149,6 @@ func TestUpdateScriptsTar(t *testing.T) {
 		".post-install": []byte("echo 'post install'"),
 		".pre-upgrade":  []byte("echo 'pre upgrade'"),
 		".post-upgrade": []byte("echo 'post upgrade'"),
-		".PKGINFO":      []byte(pkginfo),
 	}
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
@@ -157,11 +156,18 @@ func TestUpdateScriptsTar(t *testing.T) {
 	for name, content := range scripts {
 		_ = tw.WriteHeader(&tar.Header{
 			Name: name,
-			Mode: 0o644,
+			Mode: 0o755,
 			Size: int64(len(content)),
 		})
 		_, _ = tw.Write(content)
 	}
+
+	_ = tw.WriteHeader(&tar.Header{
+		Name: ".PKGINFO",
+		Mode: 0o644,
+		Size: int64(len([]byte(pkginfo))),
+	})
+	_, _ = tw.Write([]byte(pkginfo))
 	tw.Close()
 	gw.Close()
 


### PR DESCRIPTION
This should probably be an allowlist like apk does, but this is a smaller diff and I'm worried about breaking more things.