### PR TITLE
Mark base image as experimental

### DIFF
--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -88,7 +88,7 @@ type ImageContents struct {
 	// A list of packages to include in the image
 	Packages []string `json:"packages,omitempty" yaml:"packages,omitempty"`
 	// Optional: Base image to build on top of. Warning: Experimental.
-	BaseImage *BaseImageDescriptor `json:"baseimage,omitempty" yaml:"baseimage,omitempty"`
+	BaseImage *BaseImageDescriptor `json:"baseimage,omitempty" yaml:"baseimage,omitempty" apko:"experimental"`
 }
 
 // MarshalYAML implements yaml.Marshaler for ImageContents, redacting URLs in


### PR DESCRIPTION
This introduces an apko:experimental struct tag so that we can ignore it in our reflection-based terraform schema generation in terraform-provider-apko.

This wasn't a problem before because we ignored pointers, but when we moved GID to a *uint32, we started ignoring it in our terraform provider. Fixing that (by dereferencing pointers in the reflection code) had an unfortunate effect of bringing the base image stuff into the generated schema, which I don't want to do yet because it's experimental. Adding this tag lets me filter it out without hardcoding specific field names (ew).