### PR TITLE
Fixing the url escape for name of the package URL

### DIFF
--- a/pkg/apk/apk/repository.go
+++ b/pkg/apk/apk/repository.go
@@ -2,6 +2,7 @@ package apk
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -85,7 +86,7 @@ func NewRepositoryPackage(pkg *Package, repo *RepositoryWithIndex) *RepositoryPa
 }
 
 func (rp *RepositoryPackage) URL() string {
-	return fmt.Sprintf("%s/%s", rp.repository.URI, rp.Filename())
+	return fmt.Sprintf("%s/%s", rp.repository.URI, url.QueryEscape(rp.Filename()))
 }
 
 func (rp *RepositoryPackage) Repository() *RepositoryWithIndex {


### PR DESCRIPTION
This will fix the url-encoding for package URL, since for my object-storage(S3 protocol), it need safely escape URL for all path. And escaping the filename part for the URL is a general way for apk package fetching.