### PR TITLE
apk/signature: remove support for creating new SHA1 signatures

### DIFF
--- a/pkg/apk/signature/rsa.go
+++ b/pkg/apk/signature/rsa.go
@@ -21,11 +21,15 @@ var (
 	errDigestLength = errors.New("digest has unexpected length")
 	errNoPassphrase = errors.New("key is encrypted but no passphrase was provided")
 	errNoRSAKey     = errors.New("key is not an RSA key")
+	errWeakDigest   = errors.New("creating sha1 signatures not supported")
 )
 
 // RSASignDigest signs the provided message digest. The key file must
 // be in the PEM format and can either be encrypted or not.
 func RSASignDigest(digest []byte, digestType crypto.Hash, keyFile, passphrase string) ([]byte, error) {
+	if digestType == crypto.SHA1 {
+		return nil, errWeakDigest
+	}
 	if len(digest) != digestType.Size() {
 		return nil, errDigestLength
 	}


### PR DESCRIPTION
Remove support for creating new SHA1 signatures.

Verification of SHA1 signatures remains until after Alpine migrates to
SHA256.

Using current melange, adding replace in go.mod to use this apko, and use the bypass environment variable to worse SHA1 signatures results in this runtime error:

```
SIGNING_DIGEST=SHA1 melange sign --signing-key *.rsa packages/x86_64/openssl-dev-3.4.0-r7.apk 
2025/01/25 03:45:52 INFO Processing apk packages/x86_64/openssl-dev-3.4.0-r7.apk
2025/01/25 03:45:52 ERRO creating sha1 signatures not supported
```

And similarly during package build

```
export SIGNING_DIGEST=SHA1
make package/wolfi-baselayout
2025/01/25 03:46:07 INFO   runtime:
2025/01/25 03:46:07 INFO     ca-certificates-bundle
2025/01/25 03:46:07 INFO   installed-size: 127332
2025/01/25 03:46:07 INFO   data.tar.gz digest: 08809c5352881593c0e3c70108ee8d8ef6f2a2e4dadd358df972bb42f60c0c42
2025/01/25 03:46:07 ERRO failed to build package: unable to emit package: emitting signature: creating sha1 signatures not supported
```

Thus any users of this public API will too get a nice error in case they are still trying to use SHA1 signatures.