### PR TITLE
move some unnecessary logs to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _output
 
 # SBOM outputs from apko
 sbom-*
+
+.DS_Store

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -206,7 +206,7 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 		ic.Archs = types.AllArchs
 	}
 	// save the final set we will build
-	log.Infof("Building images for %d architectures: %+v", len(ic.Archs), ic.Archs)
+	log.Debugf("Building images for %d architectures: %+v", len(ic.Archs), ic.Archs)
 
 	// Probe the VCS URL if it is not set and we are asked to do so.
 	if o.WithVCS && ic.VCSUrl == "" {

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -849,6 +849,7 @@ func DiscoverKeys(ctx context.Context, client *http.Client, auth auth.Authentica
 
 	rc := retryablehttp.NewClient()
 	rc.HTTPClient = client
+	rc.Logger = clog.FromContext(ctx)
 	discoveryResponse, err := rc.StandardClient().Do(discoveryRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform key discovery: %w", err)

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -105,7 +105,7 @@ func (a *APK) SetRepositories(ctx context.Context, repos []string) error {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "SetRepositories")
 	defer span.End()
 
-	clog.InfoContextf(ctx, "setting apk repositories: %v", repos)
+	clog.DebugContextf(ctx, "setting apk repositories: %v", repos)
 
 	if len(repos) == 0 {
 		return fmt.Errorf("must provide at least one repository")

--- a/pkg/build/oci/publish.go
+++ b/pkg/build/oci/publish.go
@@ -56,9 +56,7 @@ func LoadImage(ctx context.Context, image oci.SignedImage, tags []string) (name.
 		if err != nil {
 			return name.Digest{}, err
 		}
-		if strings.HasPrefix(localSrcTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
-			log.Warnf("skipping local domain tagging %s as %s", localSrcTag.Name(), localDstTag.Name())
-		} else {
+		if !strings.HasPrefix(localSrcTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
 			log.Infof("tagging local image %s as %s", localSrcTag.Name(), localDstTag.Name())
 			if err := daemon.Tag(localSrcTag, localDstTag, daemon.WithContext(ctx)); err != nil {
 				return name.Digest{}, err

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -43,7 +43,7 @@ func WithConfig(configFile string, includePaths []string) Option {
 
 		var ic types.ImageConfiguration
 		hasher := sha2562.New()
-		if err := ic.Load(ctx, configFile, includePaths, hasher); err != nil {
+		if err := ic.Load(ctx, configFile, includePaths, hasher); err != nil { //nolint:staticcheck
 			return fmt.Errorf("failed to load image configuration: %w", err)
 		}
 

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -45,7 +45,7 @@ func (ic *ImageConfiguration) ProbeVCSUrl(ctx context.Context, imageConfigPath s
 
 	if url != "" {
 		ic.VCSUrl = url
-		log.Infof("detected %s as VCS URL", ic.VCSUrl)
+		log.Debugf("detected %s as VCS URL", ic.VCSUrl)
 	}
 }
 
@@ -179,6 +179,8 @@ func (ic *ImageConfiguration) readLocal(imageconfigPath string, includePaths []s
 // Load - loads an image configuration given a configuration file path.
 // Populates configHasher with the configuration data loaded from the imageConfigPath and the other referenced files.
 // You can pass any dummy hasher (like fnv.New32()), if you don't care about the hash of the configuration.
+//
+// Deprecated: This will be removed in a future release.
 func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string, includePaths []string, configHasher hash.Hash) error {
 	data, err := ic.readLocal(imageConfigPath, includePaths)
 	if err != nil {

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -122,7 +122,7 @@
         },
         "include": {
           "type": "string",
-          "description": "Optional: Path to a local file containing additional image configuration\n\nThe included configuration is deep merged with the parent configuration"
+          "description": "Optional: Path to a local file containing additional image configuration\n\nThe included configuration is deep merged with the parent configuration\n\nDeprecated: This will be removed in a future release."
         },
         "volumes": {
           "items": {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -225,8 +225,6 @@ var (
 
 // AllArchs contains the standard set of supported architectures, which are
 // used by `apko publish` when no architectures are specified.
-//
-// Deprecated: This will be removed in a future release.
 var AllArchs = []Architecture{
 	_386,
 	amd64,

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -181,6 +181,8 @@ type ImageConfiguration struct {
 	// Optional: Path to a local file containing additional image configuration
 	//
 	// The included configuration is deep merged with the parent configuration
+	//
+	// Deprecated: This will be removed in a future release.
 	Include string `json:"include,omitempty" yaml:"include,omitempty"`
 
 	// Optional: A list of volumes to configure
@@ -223,6 +225,8 @@ var (
 
 // AllArchs contains the standard set of supported architectures, which are
 // used by `apko publish` when no architectures are specified.
+//
+// Deprecated: This will be removed in a future release.
 var AllArchs = []Architecture{
 	_386,
 	amd64,


### PR DESCRIPTION
- don't log requests to `apk-configuration`
- don't log what architectures we're building for by default
- don't log what apk repositories we're using by default
- don't log "skipping local tagging" which isn't warn-worthy or even debug-worthy (we always do this)
- deprecate some stuff we don't use and shouldn't recommend