### PR TITLE
Improve conflict error

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -793,7 +793,7 @@ func (p *PkgResolver) getPackageDependencies(ctx context.Context, pkg *Repositor
 				}
 
 				// We already selected something to satisfy "name" and it does not match the "version" we need now.
-				return nil, nil, fmt.Errorf("we already selected %q=%q which conflicts with %q=%q", picked.Name, picked.Version, name, version)
+				return nil, nil, fmt.Errorf("we already selected \"%s=%s\" which conflicts with %q", picked.Name, picked.Version, dep)
 			}
 
 			// first see if it is a name of a package


### PR DESCRIPTION
The newly added path that fails when we're picking something that conflicts with something we already selected would do name=version instead of using the original constraint, which means it's wrong in cases where we use e.g. `<`.

Before:

│ we already selected "ruby3.2-fluentd-1.18"="1.18.0-r1" which conflicts with "ruby3.2-fluentd"="1.18"

After:

│ we already selected "ruby3.2-fluentd-1.18=1.18.0-r1" which conflicts with "ruby3.2-fluentd<1.18"