### PR TITLE
spdx: add attributionText field

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -579,6 +579,7 @@ type Package struct {
 	Supplier         string                   `json:"supplier,omitempty"`
 	SourceInfo       string                   `json:"sourceInfo,omitempty"`
 	CopyrightText    string                   `json:"copyrightText,omitempty"`
+	AttributionText  string                   `json:"attributionText,omitempty"`
 	PrimaryPurpose   string                   `json:"primaryPackagePurpose,omitempty"`
 	Checksums        []Checksum               `json:"checksums,omitempty"`
 	ExternalRefs     []ExternalRef            `json:"externalRefs,omitempty"`


### PR DESCRIPTION
Add attributionText field, that can be empty, such that melange can
start setting it.
