### PR TITLE
Add SubFS implementation for Melange

### DIFF
--- a/pkg/apk/fs/fs.go
+++ b/pkg/apk/fs/fs.go
@@ -45,6 +45,7 @@ type FullFS interface {
 	GetXattr(path string, attr string) ([]byte, error)
 	RemoveXattr(path string, attr string) error
 	ListXattrs(path string) (map[string][]byte, error)
+	Sub(path string) (FullFS, error)
 }
 
 // File is an interface for a file. It includes Read, Write, Close.

--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -524,6 +524,36 @@ func (m *memFS) ListXattrs(path string) (map[string][]byte, error) {
 	return ret, nil
 }
 
+func Sub(fsys FullFS, dir string) (FullFS, error) {
+	if !fs.ValidPath(dir) {
+		return nil, &fs.PathError{Op: "sub", Path: dir, Err: fs.ErrInvalid}
+	}
+	if dir == "." {
+		return fsys, nil
+	}
+	return &SubFS{fsys, dir}, nil
+}
+
+func (m *memFS) Sub(path string) (FullFS, error) {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." {
+		return m, nil
+	}
+
+	info, err := m.Stat(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, errors.New("not a directory")
+	}
+
+	return &SubFS{
+		FS:   m,
+		Root: cleanPath,
+	}, nil
+}
+
 type memFile struct {
 	node     *node
 	fs       *memFS

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -547,6 +547,9 @@ func (f *dirFS) RemoveXattr(path string, attr string) error {
 func (f *dirFS) ListXattrs(path string) (map[string][]byte, error) {
 	return f.overrides.ListXattrs(path)
 }
+func (f *dirFS) Sub(path string) (FullFS, error) {
+	return f.overrides.Sub(path)
+}
 
 // sanitize ensures that we never go beyond the root of the filesystem
 func (f *dirFS) sanitizePath(p string) (v string, err error) {

--- a/pkg/apk/fs/sub.go
+++ b/pkg/apk/fs/sub.go
@@ -1,0 +1,148 @@
+package fs
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"time"
+)
+
+type SubFS struct {
+	FS   FullFS
+	Root string
+}
+
+func (s *SubFS) Open(path string) (fs.File, error) {
+	if !fs.ValidPath(path) {
+		return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrInvalid}
+	}
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Open(fullPath)
+}
+
+func (s *SubFS) OpenReaderAt(path string) (File, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.OpenReaderAt(fullPath)
+}
+
+func (s *SubFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.OpenFile(fullPath, flag, perm)
+}
+func (s *SubFS) Create(name string) (File, error) {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.Create(fullPath)
+}
+
+func (s *SubFS) ReadFile(name string) ([]byte, error) {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.ReadFile(fullPath)
+}
+func (s *SubFS) WriteFile(name string, b []byte, mode fs.FileMode) error {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.WriteFile(fullPath, b, mode)
+}
+
+func (s *SubFS) Mkdir(path string, perm fs.FileMode) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Mkdir(fullPath, perm)
+}
+func (s *SubFS) MkdirAll(path string, perm fs.FileMode) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.MkdirAll(fullPath, perm)
+}
+func (s *SubFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.ReadDir(fullPath)
+}
+
+func (s *SubFS) Stat(path string) (fs.FileInfo, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Stat(fullPath)
+}
+func (s *SubFS) Lstat(path string) (fs.FileInfo, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Lstat(fullPath)
+}
+
+func (s *SubFS) Remove(name string) error {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.Remove(fullPath)
+}
+func (s *SubFS) Chmod(path string, perm fs.FileMode) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Chmod(fullPath, perm)
+}
+func (s *SubFS) Chown(path string, uid int, gid int) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Chown(fullPath, uid, gid)
+}
+func (s *SubFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Chtimes(fullPath, atime, mtime)
+}
+
+func (s *SubFS) Symlink(oldname, newname string) error {
+	return s.FS.Symlink(oldname, newname)
+}
+func (s *SubFS) Link(oldname, newname string) error {
+	return s.FS.Link(oldname, newname)
+}
+func (s *SubFS) Readlink(name string) (string, error) {
+	fullPath := filepath.Join(s.Root, name)
+	return s.FS.Readlink(fullPath)
+}
+
+func (s *SubFS) Mknod(path string, mode uint32, dev int) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Mknod(fullPath, mode, dev)
+}
+func (s *SubFS) Readnod(path string) (int, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.Readnod(fullPath)
+}
+
+func (s *SubFS) SetXattr(path string, attr string, data []byte) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.SetXattr(fullPath, attr, data)
+}
+func (s *SubFS) GetXattr(path string, attr string) ([]byte, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.GetXattr(fullPath, attr)
+}
+
+func (s *SubFS) RemoveXattr(path string, attr string) error {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.RemoveXattr(fullPath, attr)
+}
+
+func (s *SubFS) ListXattrs(path string) (map[string][]byte, error) {
+	fullPath := filepath.Join(s.Root, path)
+	return s.FS.ListXattrs(fullPath)
+}
+
+func (s *SubFS) Sub(path string) (FullFS, error) {
+	if !fs.ValidPath(path) {
+		return nil, &fs.PathError{Op: "sub", Path: path, Err: fs.ErrInvalid}
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	if cleanPath == "." {
+		return s, nil
+	}
+
+	fullPath := filepath.Join(s.Root, cleanPath)
+	info, err := s.FS.Stat(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, errors.New("not a directory")
+	}
+
+	return &SubFS{
+		FS:   s.FS,
+		Root: fullPath,
+	}, nil
+}

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -801,6 +801,27 @@ func (m *memFS) ListXattrs(path string) (map[string][]byte, error) {
 	return ret, nil
 }
 
+func (m *memFS) Sub(path string) (apkfs.FullFS, error) {
+	cleanPath := filepath.Clean(path)
+
+	if cleanPath == "." {
+		return m, nil
+	}
+
+	info, err := m.Stat(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, errors.New("not a directory")
+	}
+
+	return &apkfs.SubFS{
+		FS:   m,
+		Root: cleanPath,
+	}, nil
+}
+
 type memFile struct {
 	node     *node
 	fs       *memFS


### PR DESCRIPTION
Relates to: https://github.com/chainguard-dev/melange/pull/1804
Relates to: https://github.com/chainguard-dev/melange/issues/1731

This PR is part 1 of 2 (the second part is the Melange counterpart).

We need a SubFS implementation in order to correctly identify packages that are built by Melange when using the memFS filesystem.

Previously, we were doing `readlinkFS(pc.WorkspaceSubDir()` but now we need to maintain a FullFS type throughout the build. Using `fs.Sub` on the Melange side won't work because of this type assertion: https://github.com/chainguard-dev/apko/blob/3e63d01bb69480954b6040f5470197aead3f81da/pkg/apk/tarball/write.go#L250

If that assertion fails, then xattrs are not preserved.

If there's an easier way to orchestrate this outside of adding an entire SubFS implementation please let myself or @stevebeattie know!