### PR TITLE
Preserve symlinks in DirFS

### DIFF
--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -148,11 +148,8 @@ func DirFS(dir string, opts ...DirFSOption) FullFS {
 			fullPerm := os.ModeDir | perm
 			err = f.overrides.Mkdir(path, fullPerm)
 		case fs.ModeSymlink:
-			var target string
-			target, err = os.Readlink(filepath.Join(dir, path))
-			if err != nil {
-				err = f.overrides.Symlink(target, path)
-			}
+			target, _ := os.Readlink(filepath.Join(dir, path))
+			err = f.overrides.Symlink(target, path)
 		case fs.ModeCharDevice:
 			var dev int
 			sys := fi.Sys()

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -148,8 +148,11 @@ func DirFS(dir string, opts ...DirFSOption) FullFS {
 			fullPerm := os.ModeDir | perm
 			err = f.overrides.Mkdir(path, fullPerm)
 		case fs.ModeSymlink:
-			target, _ := os.Readlink(filepath.Join(dir, path))
-			err = f.overrides.Symlink(target, path)
+			var target string
+			target, err = os.Readlink(filepath.Join(dir, path))
+			if err == nil {
+				err = f.overrides.Symlink(target, path)
+			}
 		case fs.ModeCharDevice:
 			var dev int
 			sys := fi.Sys()


### PR DESCRIPTION
I noticed that symlinks were being dropped when testing the changes in https://github.com/chainguard-dev/melange/pull/1836.

For example --
In `WorkspaceDir`:
```
.
melange-out
melange-out/greeter
melange-out/greeter/usr
melange-out/greeter/usr/bin
melange-out/greeter/usr/bin/greeter
melange-out/greeter-english
melange-out/greeter-english/usr
melange-out/greeter-english/usr/bin
melange-out/greeter-english/usr/bin/hello
melange-out/greeter-hawaiian
melange-out/greeter-hawaiian/usr
melange-out/greeter-hawaiian/usr/bin
melange-out/greeter-hawaiian/usr/bin/aloha
melange-out/greeter-latvian
melange-out/greeter-latvian/usr
melange-out/greeter-latvian/usr/bin
melange-out/greeter-latvian/usr/bin/sveiki
```
Opening `b.WorkspaceDir` via DirFS:
```
2025/03/12 12:40:44 INFO retrieving workspace from builder: 309554d0a6a5fcd60f174efd81ac71b3cf450c3b2a9c4b100d773a2b50874df2
.
melange-out
melange-out/greeter
melange-out/greeter/usr
melange-out/greeter/usr/bin
melange-out/greeter/usr/bin/greeter
melange-out/greeter-english
melange-out/greeter-english/usr
melange-out/greeter-english/usr/bin
melange-out/greeter-hawaiian
melange-out/greeter-hawaiian/usr
melange-out/greeter-hawaiian/usr/bin
melange-out/greeter-latvian
melange-out/greeter-latvian/usr
melange-out/greeter-latvian/usr/bin
```

None of the `aloha`, `hello`, or `sveiki` symlinks are present.

This PR always adds the target to `f.overrides.Symlink` when opening a directory via `DirFS`.