### PR TITLE
lock: support config-less locking, support --cache-dir

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -60,7 +60,6 @@ func New() *cobra.Command {
 	cmd.AddCommand(showPackages())
 	cmd.AddCommand(dotcmd())
 	cmd.AddCommand(lock())
-	cmd.AddCommand(resolve())
 	cmd.AddCommand(installKeys())
 	cmd.AddCommand(version.Version())
 


### PR DESCRIPTION
```
apko lock \              
  --repository-append=https://packages.wolfi.dev/os \
  --repository-append=https://packages.cgr.dev/extras \
  --keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
  --keyring-append=https://packages.cgr.dev/extras/chainguard-extras.rsa.pub \
  --arch=x86_64,aarch64 \
  --cache-dir=$TMPDIR
```

This will "lock" an empty image config with the given APKINDEXes (for each arch) into the specified `--cache-dir`. This also writes a meaningless `apko.lock.json` file, which is probably not the best:

```
{
  "version": "v1",
  "config": {},
  "contents": {
    "keyring": [],
    "build_repositories": [],
    "repositories": [],
    "packages": []
  }
}
```

This is hoping to act as a convenient CLI to invoke to lock/cache a set of APKINDEXes, to feed into other tools that should all agree on the same APKINDEX.

This also un-hides `apko lock`, removes the deprecated `apko resolve`, and cleans up some code that unblocked.