### PR TITLE
returns structured errors when origins conflict

### DIFF
--- a/pkg/apk/apk/errors.go
+++ b/pkg/apk/apk/errors.go
@@ -49,7 +49,7 @@ type FileConflictError struct {
 }
 
 func (f FileConflictError) Error() string {
-	return fmt.Sprintf("file %s has conflicting origins: %v", f.Path, f.Origins)
+	return fmt.Sprintf("packages %v has conflicting file: %q", f.Origins, f.Path)
 }
 
 func (f FileConflictError) Is(target error) bool {

--- a/pkg/apk/apk/errors.go
+++ b/pkg/apk/apk/errors.go
@@ -32,3 +32,27 @@ func (f FileExistsError) Is(target error) bool {
 	var targetError FileExistsError
 	return errors.As(target, &targetError)
 }
+
+// FileConflictError is returned when a file has conflicting origins.
+//
+// Generally, this is a user Config error. However, since this can happen
+// both during Config resolution, and building - it is hard for users using
+// chainguard.dev/apko as a library to flag this to the user as a user error.
+//
+// To help with that, we create this structure error.
+type FileConflictError struct {
+	// The full path of the file that has conflicting origins.
+	Path string
+
+	// The origins of the file, as a map from the package name to the origin
+	Origins map[string]string
+}
+
+func (f FileConflictError) Error() string {
+	return fmt.Sprintf("file %s has conflicting origins: %v", f.Path, f.Origins)
+}
+
+func (f FileConflictError) Is(target error) bool {
+	var targetError FileConflictError
+	return errors.As(target, &targetError)
+}

--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -141,7 +141,13 @@ func (a *APK) installRegularFile(header *tar.Header, tr *tar.Reader, tmpDir stri
 		// Otherwise, we can only overwrite the file if it's in the same origin or if it replaces the existing package.
 		_, isReplaced := replaceMap[pk.Name]
 		if pk.Origin != pkg.Origin && !isReplaced {
-			return false, fmt.Errorf("unable to install file over existing one, different contents: %s", header.Name)
+			return false, FileConflictError{
+				Path: header.Name,
+				Origins: map[string]string{
+					pk.Name:  pk.Origin,
+					pkg.Name: pkg.Origin,
+				},
+			}
 		}
 
 		if err := a.writeOneFile(header, r, true); err != nil {

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -512,7 +512,13 @@ func (m *memFS) writeHeader(name string, te tarEntry) (bool, error) {
 
 	// At this point we know the files conflict, but it's okay if this file replaces that one.
 	if !sameOrigin && !replaces {
-		return false, fmt.Errorf("conflicting file %q in %q has different origin %q != %q in %q", name, got.pkg.Name, got.pkg.Origin, want.pkg.Origin, want.pkg.Name)
+		return false, apk.FileConflictError{
+			Path: name,
+			Origins: map[string]string{
+				got.pkg.Name:  got.pkg.Origin,
+				want.pkg.Name: want.pkg.Origin,
+			},
+		}
 	}
 
 	anode := &node{


### PR DESCRIPTION
Generally, this is a user Config error. However, since this can happen both during Config resolution, and building - it is hard for users using chainguard.dev/apko as a library to flag this to the user as a user error.

This PR converts these errors to use a type to make it easier for library users to do so.