### PR TITLE
Cache DiscoverKeys calls via the shared cache

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -930,7 +930,16 @@ func DiscoverKeys(ctx context.Context, client *http.Client, auth auth.Authentica
 }
 
 func (a *APK) DiscoverKeys(ctx context.Context, repository string) ([]Key, error) {
-	return DiscoverKeys(ctx, a.client, a.auth, repository)
+	client := a.client
+	if a.cache != nil {
+		client = a.cache.client(client, false)
+
+		return a.cache.shared.discoverKeys.Do(repository, func() ([]Key, error) {
+			return DiscoverKeys(ctx, client, a.auth, repository)
+		})
+	}
+
+	return DiscoverKeys(ctx, client, a.auth, repository)
 }
 
 // fetchChainguardKeys fetches the public keys for the repositories in the APK database.


### PR DESCRIPTION
I discovered this slowdown recently when trying to do a whole bunch of apko solves, which should be fast, but they were taking a while. I hadn't profiled where we spend our time since we added this key discovery mechanism, so I missed it.

This is probably incorrect for a very, very long-running process because we'd miss advertised key updates but I don't expect that to happen over long enough timespans to matter...