### PR TITLE
build.go: Export APK from build context

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -389,3 +389,7 @@ func (bc *Context) Arch() types.Architecture {
 func (bc *Context) WantSBOM() bool {
 	return len(bc.o.SBOMFormats) != 0
 }
+
+func (bc *Context) APK() *apk.APK {
+	return bc.apk
+}


### PR DESCRIPTION
Melange will need access to an APK in order to instantiate a PkgResolver during its buildGuest routine.