### PR TITLE
fix(tar): make writeTar reproducible for apko

### DIFF
--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/chainguard-dev/clog"
 
-	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/tarfs"
 )
 
 func buildMinirootFS() *cobra.Command {
@@ -81,8 +81,7 @@ func BuildMinirootFSCmd(ctx context.Context, opts ...build.Option) error {
 	}
 	defer os.RemoveAll(wd)
 
-	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
-	bc, err := build.New(ctx, fs, opts...)
+	bc, err := build.New(ctx, tarfs.New(), opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -326,11 +326,12 @@ func (m *memFS) Mknod(path string, mode uint32, dev int) error {
 		return os.ErrExist
 	}
 	anode.children[base] = &node{
-		name:   base,
-		mode:   fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
-		major:  unix.Major(uint64(dev)),
-		minor:  unix.Minor(uint64(dev)),
-		xattrs: map[string][]byte{},
+		name:    base,
+		mode:    fs.FileMode(mode) | os.ModeCharDevice | os.ModeDevice,
+		major:   unix.Major(uint64(dev)),
+		minor:   unix.Minor(uint64(dev)),
+		xattrs:  map[string][]byte{},
+		modTime: anode.modTime,
 	}
 
 	return nil
@@ -405,6 +406,7 @@ func (m *memFS) Symlink(oldname, newname string) error {
 		mode:       0o777 | os.ModeSymlink,
 		linkTarget: oldname,
 		xattrs:     map[string][]byte{},
+		modTime:    anode.modTime,
 	}
 	return nil
 }

--- a/pkg/build/busybox.go
+++ b/pkg/build/busybox.go
@@ -53,7 +53,8 @@ var busyboxLinks map[string][]string
 
 func installBusyboxLinks(fsys apkfs.FullFS, installed []*apk.InstalledPackage) error {
 	// does busybox exist? if not, do not bother with symlinks
-	if _, err := fsys.Stat(busybox); err != nil {
+	busyboxInfo, err := fsys.Stat(busybox)
+	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -116,6 +117,10 @@ func installBusyboxLinks(fsys apkfs.FullFS, installed []*apk.InstalledPackage) e
 		if err := fsys.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", dir, err)
 		}
+		if err := fsys.Chtimes(dir, busyboxInfo.ModTime(), busyboxInfo.ModTime()); err != nil {
+			return fmt.Errorf("error chtimes on %s: %w", dir, err)
+		}
+
 		if err := fsys.Symlink(busybox, link); err != nil {
 			// sometimes the list generates links twice, so do not error on that
 			if errors.Is(err, os.ErrExist) {

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -120,6 +120,9 @@ func (m *memFS) WriteHeader(hdr tar.Header, tfs fs.FS, pkg *apk.Package) (bool, 
 		if err := m.MkdirAll(hdr.Name, hdr.FileInfo().Mode().Perm()); err != nil {
 			return false, fmt.Errorf("error creating directory %s: %w", hdr.Name, err)
 		}
+		if err := m.Chtimes(hdr.Name, hdr.AccessTime, hdr.ModTime); err != nil {
+			return false, fmt.Errorf("error chtime on directory %s: %w", hdr.Name, err)
+		}
 
 		for k, v := range hdr.PAXRecords {
 			if !strings.HasPrefix(k, xattrTarPAXRecordsPrefix) {
@@ -604,6 +607,7 @@ func (m *memFS) Mknod(path string, mode uint32, dev int) error {
 		minor:     unix.Minor(uint64(dev)),
 		xattrs:    map[string][]byte{},
 		hardlinks: map[string]*tar.Header{},
+		modTime:   anode.modTime,
 	}
 
 	return nil
@@ -679,6 +683,7 @@ func (m *memFS) Symlink(oldname, newname string) error {
 		linkTarget: oldname,
 		xattrs:     map[string][]byte{},
 		hardlinks:  map[string]*tar.Header{},
+		modTime:    anode.modTime,
 	}
 	return nil
 }


### PR DESCRIPTION
Right now, the apko tar artifact is not reproducible, if I use `build-minirootfs` twice, on the same rendered yaml file (with locks) it still does not make two identical tars

This is because of `mkdir` and symlinks evaluated when assembling the rootfs:

![image](https://github.com/user-attachments/assets/feb1dd99-9970-41e5-a95b-fbaedcf1a508)
![image](https://github.com/user-attachments/assets/1a705611-6cfa-4e02-bd4f-e0c81ad34c91)

As you can see this affects only directories and symlinks, but the files provided by the packages will keep their timestamp.

This PR will reset file's modinfo time, if it is in a range of the "last minute"
this is just an heuristic to detect stuff done by this process.

The result is now a fully reproducible tar.gz build, from the same locked yaml file:


![image](https://github.com/user-attachments/assets/dd67aa5c-9c79-4227-aa4c-8ca077b6c761)

![image](https://github.com/user-attachments/assets/f66b7947-2098-4b54-b57f-984fa3d28c06)

thanks to @jonjohnsonjr there is a prettier solution