### PR TITLE
Do not retry with jitter when discoveringKeys in offline mode.

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -829,7 +829,7 @@ type Key struct {
 }
 
 // DiscoverKeys fetches the public keys for the repositories in the APK database using chainguard-style discovery.
-func DiscoverKeys(ctx context.Context, client *http.Client, auth auth.Authenticator, repository string, offline bool) ([]Key, error) {
+func DiscoverKeys(ctx context.Context, client *http.Client, auth auth.Authenticator, repository string) ([]Key, error) {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "DiscoverKeys")
 	defer span.End()
 
@@ -850,17 +850,7 @@ func DiscoverKeys(ctx context.Context, client *http.Client, auth auth.Authentica
 		return nil, err
 	}
 
-	var nc *http.Client
-	if !offline {
-		rc := retryablehttp.NewClient()
-		rc.HTTPClient = client
-		rc.Logger = clog.FromContext(ctx)
-		nc = rc.StandardClient()
-	} else {
-		nc = client
-	}
-
-	discoveryResponse, err := nc.Do(discoveryRequest)
+	discoveryResponse, err := client.Do(discoveryRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform key discovery: %w", err)
 	}
@@ -941,12 +931,19 @@ func (a *APK) DiscoverKeys(ctx context.Context, repository string) ([]Key, error
 	if a.cache != nil {
 		client = a.cache.client(client, false)
 
+		if !a.cache.offline {
+			rc := retryablehttp.NewClient()
+			rc.HTTPClient = client
+			rc.Logger = clog.FromContext(ctx)
+			client = rc.StandardClient()
+		}
+
 		return a.cache.shared.discoverKeys.Do(repository, func() ([]Key, error) {
-			return DiscoverKeys(ctx, client, a.auth, repository, a.cache.offline)
+			return DiscoverKeys(ctx, client, a.auth, repository)
 		})
 	}
 
-	return DiscoverKeys(ctx, client, a.auth, repository, false)
+	return DiscoverKeys(ctx, client, a.auth, repository)
 }
 
 // fetchChainguardKeys fetches the public keys for the repositories in the APK database.


### PR DESCRIPTION
Addresses: https://github.com/chainguard-dev/apko/issues/1330

Apko in offline mode was attempting to fetch keys... The code in case of
offline mode was doing a shortcut to check whether a file exists.
But the code was wrapped in a retryable http wrapper that introduced ~(4 x 30s) jitter
into the process.

In this PR -> in offline mode -> we turn off the retries around the fetch.
This way -> if file exists in the cache -> we use it.
If it doesn't - we accept it. And most likely we will use key provided explicitly using --extra_keys flag.


After fix the process finishes instantly: 
```
apko % go run . build --offline ../../container-images/bazel/gcbi/baseimages/static_glibc.apko.yaml foo /tmp
2025/04/10 15:44:18 WARN ignoring missing keys for https://{redacted}/artifactory/development-apk.cgr.dev-virtual: failed to perform key discovery: Get "https://{redacted}/artifactory/development-apk.cgr.dev-virtual/apk-configuration": failed to read "/Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory/development-apk.cgr.dev-virtual/apk-configuration" in offline cache: open /Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory/development-apk.cgr.dev-virtual/apk-configuration: no such file or directory
2025/04/10 15:44:18 WARN ignoring missing keys for https://{redacted}/artifactory/development-wolfi-virtual/os: failed to perform key discovery: Get "https://{redacted}/artifactory/development-wolfi-virtual/os/apk-configuration": failed to read "/Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fdevelopment-wolfi-virtual/os/apk-configuration" in offline cache: open /Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fdevelopment-wolfi-virtual/os/apk-configuration: no such file or directory
Error: locking config: initializing apk: failed to initialize apk keyring: failed to fetch apk key: Get "https://{redacted}/artifactory/api/security/keypair/public/repositories/development-alpine-virtual": listing "/Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fapi%2Fsecurity%2Fkeypair%2Fpublic/repositories" for offline cache: open /Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fapi%2Fsecurity%2Fkeypair%2Fpublic/repositories: no such file or directory
2025/04/10 15:44:18 INFO error during command execution: locking config: initializing apk: failed to initialize apk keyring: failed to fetch apk key: Get "https://{redacted}/artifactory/api/security/keypair/public/repositories/development-alpine-virtual": listing "/Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fapi%2Fsecurity%2Fkeypair%2Fpublic/repositories" for offline cache: open /Users/{redacted}/Library/Caches/dev.chainguard.go-apk/https%3A%2F%2F{redacted}%2Fartifactory%2Fapi%2Fsecurity%2Fkeypair%2Fpublic/repositories: no such file or directory
exit status 1
```