### PR TITLE
For multi-layer images, include all layers

### DIFF
--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -95,14 +95,10 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 		return nil, fmt.Errorf("getting %s manifest: %w", arch, err)
 	}
 
-	if bc.baseimg == nil && len(m.Layers) != 1 {
-		return nil, fmt.Errorf("unexpected layers in %s manifest: %d", arch, len(m.Layers))
-	}
-
 	s := newSBOM(ctx, bc.fs, bc.o, bc.ic, bde)
 	log.Debug("Generating image SBOM")
 
-	s.ImageInfo.LayerDigest = m.Layers[0].Digest.String()
+	s.ImageInfo.Layers = m.Layers
 
 	info, err := readReleaseData(bc.fs)
 	if err != nil {

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/release-utils/command"
 
@@ -34,6 +35,9 @@ import (
 
 // TODO: clean this up and make consistent with the other test cases
 var testOpts = &options.Options{
+	ImageInfo: options.ImageInfo{
+		Layers: []v1.Descriptor{{}},
+	},
 	OS: options.OSInfo{
 		Name:    "unknown",
 		ID:      "unknown",
@@ -78,6 +82,9 @@ func TestSPDX_Generate(t *testing.T) {
 		{
 			name: "custom-license",
 			opts: &options.Options{
+				ImageInfo: options.ImageInfo{
+					Layers: []v1.Descriptor{{}},
+				},
 				OS: options.OSInfo{
 					Name:    "unknown",
 					ID:      "unknown",
@@ -97,6 +104,9 @@ func TestSPDX_Generate(t *testing.T) {
 		{
 			name: "no-supplier",
 			opts: &options.Options{
+				ImageInfo: options.ImageInfo{
+					Layers: []v1.Descriptor{{}},
+				},
 				OS: options.OSInfo{
 					Name:    "Apko Images, Plc",
 					ID:      "apko-images",
@@ -116,6 +126,9 @@ func TestSPDX_Generate(t *testing.T) {
 		{
 			name: "package-deduplicating",
 			opts: &options.Options{
+				ImageInfo: options.ImageInfo{
+					Layers: []v1.Descriptor{{}},
+				},
 				OS: options.OSInfo{
 					Name:    "unknown",
 					ID:      "unknown",

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -68,8 +68,8 @@ type ImageInfo struct {
 	Tag             string
 	Name            string
 	Repository      string
-	LayerDigest     string
 	ImageDigest     string
+	Layers          []v1.Descriptor
 	VCSUrl          string
 	IndexMediaType  ggcrtypes.MediaType
 	ImageMediaType  ggcrtypes.MediaType
@@ -149,16 +149,9 @@ func (pq PurlQualifiers) String() string {
 
 // LayerPurlQualifiers reurns the qualifiers for the purl, they are based
 // on the image with the corresponding mediatype
-func (o *Options) LayerPurlQualifiers() (qualifiers PurlQualifiers) {
+func (o *Options) LayerPurlQualifiers(layer v1.Descriptor) (qualifiers PurlQualifiers) {
 	qualifiers = o.ImagePurlQualifiers()
-	switch o.ImageInfo.ImageMediaType {
-	case ggcrtypes.OCIManifestSchema1:
-		qualifiers["mediaType"] = string(ggcrtypes.OCILayer)
-	case ggcrtypes.DockerManifestSchema2:
-		qualifiers["mediaType"] = string(ggcrtypes.DockerLayer)
-	default:
-		qualifiers["mediaType"] = ""
-	}
+	qualifiers["mediaType"] = string(layer.MediaType)
 	return qualifiers
 }
 


### PR DESCRIPTION
    Our image SBOMs currently embeds "the" (singular) layer digest and its
    mediaType as a purl. For multi-layer images, this is no longer
    reasonable. Instead, we'll include all the layers in the SBOM.
    
    This is a bit tricky because the code in written to assume there is
    always exactly one layer, but most of the tests pass exactly 0 layers,
    and we want to support greater than one layer.
    
    I've fixed up the tests and code to make the tests keep passing, but
    we'll probably want to revisit what SBOMs look like when we start
    shipping multiple layers (and write tests to enforce that).