### PR TITLE
CacheDir support for `apko lock`

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -71,7 +71,6 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	var includePaths []string
 	var ignoreSignatures bool
 	var cacheDir string
-	var offline bool
 
 	cmd := &cobra.Command{
 		Use: cmdName,
@@ -98,7 +97,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 					build.WithExtraRuntimeRepos(extraRuntimeRepos),
 					build.WithIncludePaths(includePaths),
 					build.WithIgnoreSignatures(ignoreSignatures),
-					build.WithCache(cacheDir, offline, apk.NewCache(true))
+					build.WithCache(cacheDir, false, apk.NewCache(true)),
 				},
 			)
 		},
@@ -112,7 +111,6 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append")
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
-	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 
 	return cmd
 }

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -1078,7 +1078,7 @@ func (a *APK) cachedPackage(ctx context.Context, pkg InstallablePackage, cacheDi
 		if err != nil {
 			return nil, err
 		}
-		signatureHash := sha1.Sum(signatureData)
+		signatureHash := sha1.Sum(signatureData) //nolint:gosec // this is what apk tools is using
 		exp.SignatureHash = signatureHash[:]
 	}
 

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -532,18 +532,12 @@ func (a *APK) CalculateWorld(ctx context.Context, allpkgs []*RepositoryPackage) 
 		i, pkg := i, pkg
 
 		g.Go(func() error {
-			r, err := a.FetchPackage(ctx, pkg)
-			if err != nil {
-				return fmt.Errorf("fetching %s: %w", pkg.Name, err)
-			}
-			res, err := ResolveApk(ctx, r)
-			if err != nil {
-				return fmt.Errorf("resolving %s: %w", pkg.Name, err)
-			}
+			expanded, err := a.expandPackage(ctx, pkg)
 
-			res.Package = pkg
-			resolved[i] = res
-
+			if err != nil {
+				return fmt.Errorf("expanding %s: %w", pkg.Name, err)
+			}
+			resolved[i] = NewAPKResolved(pkg, expanded)
 			return nil
 		})
 	}

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // this is what apk tools is using
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"

--- a/pkg/apk/apk/resolveapk.go
+++ b/pkg/apk/apk/resolveapk.go
@@ -1,29 +1,88 @@
 //nolint:all
 package apk
 
-import "chainguard.dev/apko/pkg/apk/expandapk"
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+
+	"chainguard.dev/apko/pkg/apk/expandapk"
+
+	"go.opentelemetry.io/otel"
+)
 
 type APKResolved struct {
 	Package *RepositoryPackage
 
-	SignatureSize int64
+	SignatureSize int
 	SignatureHash []byte
 
-	ControlSize int64
+	ControlSize int
 	ControlHash []byte
 
-	DataSize int64
+	DataSize int
 	DataHash []byte
+}
+
+func ResolveApk(ctx context.Context, source io.Reader) (*APKResolved, error) {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "ResolveApk")
+	defer span.End()
+
+	resolved := &APKResolved{}
+
+	split, err := expandapk.Split(source)
+	if err != nil {
+		return nil, fmt.Errorf("splitting apk: %w", err)
+	}
+	if len(split) < 2 {
+		return nil, fmt.Errorf("splitting apk: expected at least 2 streams, got %d", len(split))
+	}
+
+	control, data := split[0], split[1]
+	if len(split) == 3 {
+		// When it's signed the control section is the second stream
+		control, data = split[1], split[2]
+
+		var h hash.Hash = sha1.New() //nolint:gosec
+		size, err := io.Copy(h, split[0])
+		if err != nil {
+			return nil, fmt.Errorf("hashing signature: %w", err)
+		}
+		resolved.SignatureSize = int(size)
+		resolved.SignatureHash = h.Sum(nil)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, control); err != nil {
+		return nil, fmt.Errorf("hashing control: %w", err)
+	}
+	resolved.ControlSize = buf.Len()
+	ctrlHash := sha1.Sum(buf.Bytes())
+	resolved.ControlHash = ctrlHash[:]
+
+	dataHash := sha256.New()
+	size, err := io.Copy(dataHash, data)
+	if err != nil {
+		return nil, fmt.Errorf("hashing data: %w", err)
+	}
+	resolved.DataSize = int(size)
+	resolved.DataHash = dataHash.Sum(nil)
+
+	return resolved, nil
 }
 
 func NewAPKResolved(pkg *RepositoryPackage, expanded *expandapk.APKExpanded) *APKResolved {
 	return &APKResolved{
 		Package:       pkg,
-		ControlSize:   expanded.ControlSize,
+		ControlSize:   int(expanded.ControlSize),
 		ControlHash:   expanded.ControlHash,
 		SignatureHash: expanded.SignatureHash,
-		SignatureSize: expanded.SignatureSize,
+		SignatureSize: int(expanded.SignatureSize),
 		DataHash:      expanded.PackageHash,
-		DataSize:      expanded.PackageSize,
+		DataSize:      int(expanded.PackageSize),
 	}
 }

--- a/pkg/apk/apk/resolveapk.go
+++ b/pkg/apk/apk/resolveapk.go
@@ -1,76 +1,29 @@
 //nolint:all
 package apk
 
-import (
-	"bytes"
-	"context"
-	"crypto/sha1"
-	"crypto/sha256"
-	"fmt"
-	"hash"
-	"io"
-
-	"chainguard.dev/apko/pkg/apk/expandapk"
-
-	"go.opentelemetry.io/otel"
-)
+import "chainguard.dev/apko/pkg/apk/expandapk"
 
 type APKResolved struct {
 	Package *RepositoryPackage
 
-	SignatureSize int
+	SignatureSize int64
 	SignatureHash []byte
 
-	ControlSize int
+	ControlSize int64
 	ControlHash []byte
 
-	DataSize int
+	DataSize int64
 	DataHash []byte
 }
 
-func ResolveApk(ctx context.Context, source io.Reader) (*APKResolved, error) {
-	ctx, span := otel.Tracer("go-apk").Start(ctx, "ResolveApk")
-	defer span.End()
-
-	resolved := &APKResolved{}
-
-	split, err := expandapk.Split(source)
-	if err != nil {
-		return nil, fmt.Errorf("splitting apk: %w", err)
+func NewAPKResolved(pkg *RepositoryPackage, expanded *expandapk.APKExpanded) *APKResolved {
+	return &APKResolved{
+		Package:       pkg,
+		ControlSize:   expanded.ControlSize,
+		ControlHash:   expanded.ControlHash,
+		SignatureHash: expanded.SignatureHash,
+		SignatureSize: expanded.SignatureSize,
+		DataHash:      expanded.PackageHash,
+		DataSize:      expanded.PackageSize,
 	}
-	if len(split) < 2 {
-		return nil, fmt.Errorf("splitting apk: expected at least 2 streams, got %d", len(split))
-	}
-
-	control, data := split[0], split[1]
-	if len(split) == 3 {
-		// When it's signed the control section is the second stream
-		control, data = split[1], split[2]
-
-		var h hash.Hash = sha1.New() //nolint:gosec
-		size, err := io.Copy(h, split[0])
-		if err != nil {
-			return nil, fmt.Errorf("hashing signature: %w", err)
-		}
-		resolved.SignatureSize = int(size)
-		resolved.SignatureHash = h.Sum(nil)
-	}
-
-	buf := bytes.NewBuffer(nil)
-	if _, err := io.Copy(buf, control); err != nil {
-		return nil, fmt.Errorf("hashing control: %w", err)
-	}
-	resolved.ControlSize = buf.Len()
-	ctrlHash := sha1.Sum(buf.Bytes())
-	resolved.ControlHash = ctrlHash[:]
-
-	dataHash := sha256.New()
-	size, err := io.Copy(dataHash, data)
-	if err != nil {
-		return nil, fmt.Errorf("hashing data: %w", err)
-	}
-	resolved.DataSize = int(size)
-	resolved.DataHash = dataHash.Sum(nil)
-
-	return resolved, nil
 }

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -496,9 +496,10 @@ func ExpandApk(ctx context.Context, source io.Reader, cacheDir string) (*APKExpa
 		ControlFile: gzipStreams[controlDataIndex],
 		ControlHash: hashes[controlDataIndex],
 		ControlSize: sizes[controlDataIndex],
+
 		PackageFile: gzipStreams[packageIndex],
 		PackageHash: hashes[packageIndex],
-		PackageSize: sizes[controlDataIndex],
+		PackageSize: sizes[packageIndex],
 	}
 	if signed {
 		expanded.SignatureFile = gzipStreams[signatureIndex]

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -93,8 +93,13 @@ type APKExpanded struct {
 	// Exposes TarFile as an indexed FS implementation.
 	TarFS *tarfs.FS
 
-	ControlHash []byte
-	PackageHash []byte
+	ControlHash   []byte
+	PackageHash   []byte
+	SignatureHash []byte
+
+	ControlSize   int64
+	PackageSize   int64
+	SignatureSize int64
 
 	sync.Mutex
 	controlData []byte
@@ -456,25 +461,33 @@ func ExpandApk(ctx context.Context, source io.Reader, cacheDir string) (*APKExpa
 
 	// Calculate the total size of the apk (combo of all streams)
 	totalSize := int64(0)
+	sizes := []int64{}
 	for _, s := range gzipStreams {
 		info, err := os.Stat(s)
 		if err != nil {
 			return nil, fmt.Errorf("expandApk error 18: %w", err)
 		}
 		totalSize += info.Size()
+		sizes = append(sizes, info.Size())
 	}
 
-	var signed bool
+	var signatureIndex int
 	var controlDataIndex int
+	var packageIndex int
+
 	switch numGzipStreams {
 	case 3:
-		signed = true
+		signatureIndex = 0
 		controlDataIndex = 1
+		packageIndex = 2
 	case 2:
+		signatureIndex = -1
 		controlDataIndex = 0
+		packageIndex = 1
 	default:
 		return nil, fmt.Errorf("invalid number of tar streams: %d", numGzipStreams)
 	}
+	signed := signatureIndex >= 0
 
 	expanded := APKExpanded{
 		tempDir:     dir,
@@ -482,11 +495,15 @@ func ExpandApk(ctx context.Context, source io.Reader, cacheDir string) (*APKExpa
 		Size:        totalSize,
 		ControlFile: gzipStreams[controlDataIndex],
 		ControlHash: hashes[controlDataIndex],
-		PackageFile: gzipStreams[controlDataIndex+1],
-		PackageHash: hashes[controlDataIndex+1],
+		ControlSize: sizes[controlDataIndex],
+		PackageFile: gzipStreams[packageIndex],
+		PackageHash: hashes[packageIndex],
+		PackageSize: sizes[controlDataIndex],
 	}
 	if signed {
-		expanded.SignatureFile = gzipStreams[0]
+		expanded.SignatureFile = gzipStreams[signatureIndex]
+		expanded.SignatureHash = hashes[signatureIndex]
+		expanded.SignatureSize = sizes[signatureIndex]
 	}
 
 	control, err := expanded.ControlData()


### PR DESCRIPTION
Speedup and code alignment of 'apko-lock'. 

Before this change 'apko lock' was downloading all the packages every time and not utilising cacheDir.
After this change the cache is working. Also the fix should speedup apko resolution of packages for regular `apko build` (not lockaed) as
now `ResolveWorld` and Installation are sharing downloaded packages (and code).

Fixes: https://github.com/chainguard-dev/apko/issues/1475

