### PR TITLE
refactor: slim down interface requirements for fetching packages

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -1211,7 +1211,7 @@ func expandPackage(ctx context.Context, a *APK, pkg InstallablePackage) (*expand
 	return a.cachePackage(ctx, pkg, exp, cacheDir)
 }
 
-func packageAsURI(pkg InstallablePackage) (uri.URI, error) {
+func packageAsURI(pkg LocatablePackage) (uri.URI, error) {
 	u := pkg.URL()
 
 	if strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "http://") {
@@ -1221,7 +1221,7 @@ func packageAsURI(pkg InstallablePackage) (uri.URI, error) {
 	return uri.New(u), nil
 }
 
-func packageAsURL(pkg InstallablePackage) (*url.URL, error) {
+func packageAsURL(pkg LocatablePackage) (*url.URL, error) {
 	asURI, err := packageAsURI(pkg)
 	if err != nil {
 		return nil, err
@@ -1230,7 +1230,7 @@ func packageAsURL(pkg InstallablePackage) (*url.URL, error) {
 	return url.Parse(string(asURI))
 }
 
-func (a *APK) FetchPackage(ctx context.Context, pkg InstallablePackage) (io.ReadCloser, error) {
+func (a *APK) FetchPackage(ctx context.Context, pkg FetchablePackage) (io.ReadCloser, error) {
 	log := clog.FromContext(ctx)
 	log.Debugf("fetching %s", pkg)
 

--- a/pkg/apk/apk/package.go
+++ b/pkg/apk/apk/package.go
@@ -60,6 +60,40 @@ func PackageToInstalled(pkg *Package) (out []string) {
 	return
 }
 
+// LocatablePackage represents a minimal set of information needed to locate a
+// package for retrieval over a network.
+type LocatablePackage interface {
+	URL() string
+}
+
+// FetchablePackage represents a minimal set of information needed to fetch a package.
+type FetchablePackage interface {
+	URL() string
+	PackageName() string
+}
+
+type fetchablePackage struct {
+	pkgName string
+	url     string
+}
+
+func (f fetchablePackage) URL() string {
+	return f.url
+}
+
+func (f fetchablePackage) PackageName() string {
+	return f.pkgName
+}
+
+// NewFetchablePackage creates and returns a minimal implementation of
+// FetchablePackage.
+func NewFetchablePackage(pkgName, url string) FetchablePackage {
+	return &fetchablePackage{
+		pkgName: pkgName,
+		url:     url,
+	}
+}
+
 // InstallablePackage represents a minimal set of information needed to install a package within an Image.
 type InstallablePackage interface {
 	URL() string


### PR DESCRIPTION
We didn't actually need a whole implementation of `InstallablePackage` just to fetch a package. This PR creates less needy interfaces and inserts them when appropriate into our fetching implementation. This also adds a convenience function for creating a minimally fetchable package, which is useful if you don't already have such an implementation in the context of your code.