### PR TITLE
Use a lazy layerWriter for writing tar files

### DIFF
--- a/docs/build-process.md
+++ b/docs/build-process.md
@@ -32,7 +32,6 @@ As described above, after everything is setup, the actual build occurs inside th
 The build is in [`build.Context.BuildLayer()`](../pkg/build/build.go#L80-109), which consists of:
 
 1. `Context.BuildImage()`: building the image
-1. `Context.BuildTarball()`: build the tarball for the layer
 1. `Context.GenerateSBOM()` optionally generate the SBoM
 
 The actual building of the image via `BuildImage()` just wraps [`buildImage()`](../pkg/build/build_implementation.go#L195-247).

--- a/pkg/build/tarball.go
+++ b/pkg/build/tarball.go
@@ -34,11 +34,10 @@ const xattrTarPAXRecordsPrefix = "SCHILY.xattr."
 
 // writeTar writes a tarball to the provided io.Writer from the provided fs.FS.
 // The etc/passwd and etc/group file provide username and group name mappings for the tar.
-func writeTar(ctx context.Context, dst io.Writer, fsys apkfs.FullFS) error { //nolint:gocyclo
+func writeTar(ctx context.Context, tw *tar.Writer, fsys apkfs.FullFS) error { //nolint:gocyclo
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "writeTar")
 	defer span.End()
 
-	tw := tar.NewWriter(dst)
 	buf := make([]byte, 1<<20)
 
 	for f, err := range walkFS(ctx, fsys) {

--- a/pkg/build/tarball_test.go
+++ b/pkg/build/tarball_test.go
@@ -28,8 +28,11 @@ func TestWriteTar(t *testing.T) {
 	require.NoError(t, err, "error setting xattr on %s", dir)
 	err = m.SetXattr(file, "user.file", []byte("bar"))
 	require.NoError(t, err, "error setting xattr on %s", file)
-	err = writeTar(context.Background(), &buf, m)
+	tw := tar.NewWriter(&buf)
+	err = writeTar(context.Background(), tw, m)
 	require.NoError(t, err, "error writing tar")
+	err = tw.Close()
+	require.NoError(t, err, "error closing tar writer")
 
 	// now should be able to read the tar and check the xattrs
 	tr := tar.NewReader(&buf)


### PR DESCRIPTION
Instead of writing out the entire layer in one shot, layerWriter exposes a tar.Writer so that it's possible to construct a layerWriter, write to it a bunch of times, then finalize the layerWriter to produce a layer.

This PR should be a no-op, but we'll take advantage of this for multiple layers when we walk the filesystem and have multiple possible layerWriters to choose from.