### PR TITLE
Implement generic layering

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -151,3 +151,74 @@ func (s *sentinel) RoundTrip(in *http.Request) (*http.Response, error) {
 	in.Header.Set("Magic", "SecretValue")
 	return s.rt.RoundTrip(in)
 }
+
+func TestPublishLayering(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	// Set up a registry that requires we see a magic header.
+	// This allows us to make sure that remote options are getting passed
+	// around to anything that hits the registry.
+	r := registry.New()
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, req.Header.Get("Magic"), "SecretValue")
+		r.ServeHTTP(w, req)
+	})
+	s := httptest.NewServer(h)
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	st := &sentinel{s.Client().Transport}
+	dst := fmt.Sprintf("%s/test/publish", u.Host)
+
+	config := filepath.Join("testdata", "layering.yaml")
+
+	outputRefs := ""
+	archs := types.ParseArchitectures([]string{"amd64", "arm64"})
+	ropt := []remote.Option{remote.WithTransport(st)}
+	opts := []build.Option{
+		build.WithConfig(config, []string{}),
+		build.WithTags(dst),
+		build.WithSBOMFormats(sbom.DefaultOptions.Formats),
+		build.WithAnnotations(map[string]string{"foo": "bar"}),
+	}
+	publishOpts := []cli.PublishOption{cli.WithTags(dst)}
+
+	sbomPath := filepath.Join(tmp, "sboms")
+	err = os.MkdirAll(sbomPath, 0o750)
+	require.NoError(t, err)
+
+	err = cli.PublishCmd(ctx, outputRefs, archs, ropt, sbomPath, opts, publishOpts)
+	require.NoError(t, err)
+
+	ref, err := name.ParseReference(dst)
+	require.NoError(t, err)
+
+	idx, err := remote.Index(ref, ropt...)
+	require.NoError(t, err)
+
+	// Not strictly necessary, but this will validate that the index is well-formed.
+	require.NoError(t, validate.Index(idx))
+
+	digest, err := idx.Digest()
+	require.NoError(t, err)
+
+	// This test will fail if we ever make a change in apko that changes the image.
+	// Sometimes, this is intentional, and we need to change this and bump the version.
+	want := "sha256:e4854bdd74aca1534a30da899edef2ad46b9a7e088ceae2094d85a287a20891a"
+	require.Equal(t, want, digest.String())
+
+	im, err := idx.IndexManifest()
+	require.NoError(t, err)
+
+	for _, m := range im.Manifests {
+		child, err := idx.Image(m.Digest)
+		require.NoError(t, err)
+
+		cm, err := child.Manifest()
+		require.NoError(t, err)
+
+		require.Equal(t, 2, len(cm.Layers))
+	}
+}

--- a/internal/cli/testdata/layering.yaml
+++ b/internal/cli/testdata/layering.yaml
@@ -1,0 +1,18 @@
+contents:
+  keyring:
+    - ./testdata/melange.rsa.pub
+  repositories:
+    - ./testdata/packages
+  packages:
+    - replayout
+
+entrypoint:
+  command: /bin/sh -l
+
+archs:
+- x86_64
+- aarch64
+
+layering:
+  strategy: origin
+  budget: 2

--- a/pkg/apk/apk/install_test.go
+++ b/pkg/apk/apk/install_test.go
@@ -171,7 +171,7 @@ func TestInstallAPKFiles(t *testing.T) {
 				{overwriteFilename, 0o755, false, finalContent, nil},
 			})
 
-			err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
+			_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
 			require.Error(t, err, "some double-write error")
 
 			actual, err := src.ReadFile(overwriteFilename)
@@ -200,7 +200,7 @@ func TestInstallAPKFiles(t *testing.T) {
 				{overwriteFilename, 0755, false, finalContent, nil},
 			})
 
-			err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
+			_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
 			require.NoError(t, err)
 
 			actual, err := src.ReadFile(overwriteFilename)
@@ -229,7 +229,7 @@ func TestInstallAPKFiles(t *testing.T) {
 				{overwriteFilename, 0o755, false, finalContent, nil},
 			})
 
-			err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
+			_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
 			require.NoError(t, err)
 
 			actual, err := src.ReadFile(overwriteFilename)
@@ -257,7 +257,7 @@ func TestInstallAPKFiles(t *testing.T) {
 				{overwriteFilename, 0o755, false, originalContent, nil},
 			})
 
-			err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
+			_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
 			require.NoError(t, err)
 
 			actual, err := src.ReadFile(overwriteFilename)
@@ -286,7 +286,7 @@ func TestInstallAPKFiles(t *testing.T) {
 				{overwriteFilename, 0755, false, finalContent, nil},
 			})
 
-			err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
+			_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fp1, fp2})
 			require.NoError(t, err)
 
 			actual, err := src.ReadFile(overwriteFilename)

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -987,12 +987,12 @@ func makeResolver(provs, deps map[string][]string) *PkgResolver {
 	packages := make(map[string]*Package, max(len(provs), len(deps)))
 
 	for pkgver := range provs {
-		parsed := resolvePackageNameVersionPin(pkgver)
-		packages[pkgver] = &Package{Name: parsed.name, Version: parsed.version}
+		parsed := ResolvePackageNameVersionPin(pkgver)
+		packages[pkgver] = &Package{Name: parsed.Name, Version: parsed.version}
 	}
 	for pkgver := range deps {
-		parsed := resolvePackageNameVersionPin(pkgver)
-		packages[pkgver] = &Package{Name: parsed.name, Version: parsed.version}
+		parsed := ResolvePackageNameVersionPin(pkgver)
+		packages[pkgver] = &Package{Name: parsed.Name, Version: parsed.version}
 	}
 
 	for pkgver, pkgProvs := range provs {

--- a/pkg/apk/apk/version_test.go
+++ b/pkg/apk/apk/version_test.go
@@ -941,8 +941,8 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			constraint := resolvePackageNameVersionPin(tt.input)
-			require.Equal(t, tt.name, constraint.name)
+			constraint := ResolvePackageNameVersionPin(tt.input)
+			require.Equal(t, tt.name, constraint.Name)
 			require.Equal(t, tt.version, constraint.version)
 			require.Equal(t, tt.dep, constraint.dep)
 			require.Equal(t, tt.pin, constraint.pin)

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -30,7 +30,24 @@ import (
 	"chainguard.dev/apko/pkg/build/types"
 )
 
-func TestBuildLayer(t *testing.T) {
+func TestBuildLayers(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []build.Option{
+		build.WithConfig("layering.yaml", []string{"testdata"}),
+	}
+
+	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layers, err := bc.BuildLayers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Len(t, layers, 2)
 }
 
 func TestBuildImage(t *testing.T) {

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -1,0 +1,416 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"archive/tar"
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path"
+	"slices"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+
+	"github.com/chainguard-dev/clog"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func (bc *Context) buildLayers(ctx context.Context) ([]v1.Layer, error) {
+	log := clog.FromContext(ctx)
+
+	if strategy := bc.ic.Layering.Strategy; strategy != "origin" {
+		return nil, fmt.Errorf("unrecognized layering strategy %q", strategy)
+	}
+
+	if bc.ic.Contents.BaseImage != nil {
+		return nil, fmt.Errorf("layering with %q is unsupported", "baseimage")
+	}
+
+	// Build a single fs.FS, the normal way (this writes to bc.fs).
+	pkgs, err := bc.buildImage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("building filesystem: %w", err)
+	}
+
+	// Use our layering strategy to partition packages into a set of Budget groups.
+	groups, err := groupByOriginAndSize(pkgs, bc.ic.Layering.Budget)
+	if err != nil {
+		return nil, fmt.Errorf("grouping packages: %w", err)
+	}
+	log.Infof("Building %d layers with budget %d", len(groups), bc.ic.Layering.Budget)
+
+	for i, g := range groups {
+		log.Infof("  layer[%d]:", i)
+
+		for _, pkg := range g.pkgs {
+			log.Infof("    - %s=%s", pkg.Name, pkg.Version)
+		}
+	}
+
+	// Then partition that single fs.FS into multiple layers based on our layering strategy.
+	return splitLayers(ctx, bc.fs, groups, bc.o.TempDir())
+}
+
+func replacesGroup(rep string, g *group) (bool, error) {
+	constraint := apk.ResolvePackageNameVersionPin(rep)
+
+	// Look for the package to make sure the version satisfies Replaces.
+	for _, pkg := range g.pkgs {
+		if pkg.Name != constraint.Name {
+			// This is not the package we're looking for.
+			continue
+		}
+
+		ver, err := apk.ParseVersion(pkg.Version)
+		if err != nil {
+			return false, fmt.Errorf("parsing %s version %s: %w", pkg.Name, pkg.Version, err)
+		}
+
+		ok, err := constraint.SatisfiedBy(ver)
+		if err != nil {
+			return false, fmt.Errorf("checking %s satisfies %s: %w", pkg.Version, constraint.Name, err)
+		}
+
+		if ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func groupByOriginAndSize(pkgs []*apk.Package, budget int) ([]*group, error) {
+	// First, we're going to group packages by their origin.
+	byOrigin := map[string]*group{}
+	for _, pkg := range pkgs {
+		origin := pkg.Origin
+		if _, ok := byOrigin[origin]; !ok {
+			byOrigin[origin] = &group{}
+		}
+
+		g, ok := byOrigin[origin]
+		if !ok {
+			panic(fmt.Errorf("byOrigin[%q] missing", origin))
+		}
+
+		g.pkgs = append(g.pkgs, pkg)
+	}
+
+	// Then we need to merge any packages that replace each other.
+	byPackage := map[string]*group{}
+	for _, g := range byOrigin {
+		for _, pkg := range g.pkgs {
+			byPackage[pkg.Name] = g
+		}
+	}
+
+	replaceMap := map[string][]string{}
+	for _, g := range byPackage {
+		for _, pkg := range g.pkgs {
+			if len(pkg.Replaces) == 0 {
+				continue
+			}
+
+			replaceMap[pkg.Name] = pkg.Replaces
+		}
+	}
+
+	for pkg, replaces := range replaceMap {
+		for _, rep := range replaces {
+			constraint := apk.ResolvePackageNameVersionPin(rep)
+
+			replacee, ok := byPackage[constraint.Name]
+			if !ok {
+				// Whatever this package replaces is not in the image, that's normal.
+				continue
+			}
+
+			if ok, err := replacesGroup(rep, replacee); err != nil {
+				return nil, fmt.Errorf("checking %s replaces %s: %w", pkg, constraint.Name, err)
+			} else if !ok {
+				continue
+			}
+
+			g, ok := byPackage[pkg]
+			if !ok {
+				panic(fmt.Errorf("byPackage[%q] missing", pkg))
+			}
+
+			// If they're already merged, nothing to do.
+			if replacee == g {
+				continue
+			}
+
+			// Otherwise, we need to merge the two groups.
+			merged := merge(g, replacee)
+
+			// Update our maps so we can test identity above.
+			for _, pkg := range merged.pkgs {
+				byPackage[pkg.Name] = merged
+				byOrigin[pkg.Origin] = merged
+			}
+		}
+	}
+
+	// Now we need to pick the best groups to keep.
+	// First pass we'll set the size of each group to the sum of the installed size of all its packages.
+	groups := make([]*group, 0, budget)
+	seen := map[*group]struct{}{}
+	for v := range maps.Values(byOrigin) {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		groups = append(groups, v)
+	}
+	for _, g := range groups {
+		for _, pkg := range g.pkgs {
+			g.size += pkg.InstalledSize
+			g.tiebreaker = max(g.tiebreaker, pkg.Name)
+		}
+	}
+
+	// Then we'll sort by the size and take the top $budget, merging the remainders.
+	slices.SortFunc(groups, func(a, b *group) int {
+		return cmp.Or(
+			cmp.Compare(b.size, a.size),             // Descending size.
+			cmp.Compare(a.tiebreaker, b.tiebreaker)) // In the rare case where we have identical sizes.
+	})
+
+	if len(groups) > budget {
+		cutoff := max(budget-1, 0) // Even if budget == 0, we want 1 group.
+
+		remainder := groups[cutoff:]
+		groups = groups[:cutoff]
+
+		groups = append(groups, merge(remainder...))
+	}
+
+	// Sort packages too just so they're in a consistent order.
+	for _, g := range groups {
+		slices.SortFunc(g.pkgs, func(a, b *apk.Package) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+	}
+
+	return groups, nil
+}
+
+type group struct {
+	pkgs []*apk.Package
+
+	size uint64
+
+	// This is silly but in the event that two groups have identical size,
+	// we want a predictable sort order _somehow_.
+	tiebreaker string
+}
+
+func merge(groups ...*group) *group {
+	merged := &group{}
+	for _, g := range groups {
+		merged.pkgs = slices.Concat(merged.pkgs, g.pkgs)
+		merged.size += g.size
+		merged.tiebreaker = max(merged.tiebreaker, g.tiebreaker)
+	}
+	return merged
+}
+
+func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, tmpdir string) ([]v1.Layer, error) {
+	buf := make([]byte, 1<<20)
+
+	// We'll create a writer for each layer and a map to quickly access the writer given a package or group.
+	packageToWriter := map[string]*layerWriter{}
+	groupToWriter := map[*group]*layerWriter{}
+
+	for _, g := range groups {
+		f, err := os.CreateTemp(tmpdir, "layer-*.tar.gz")
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		w := newLayerWriter(f)
+		groupToWriter[g] = w
+
+		for _, pkg := range g.pkgs {
+			packageToWriter[pkg.Name] = w
+		}
+	}
+
+	// The top layer holds anything that doesn't belong to a package.
+	f, err := os.CreateTemp(tmpdir, "layer-*.tar.gz")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	top := newLayerWriter(f)
+
+	// In a tar file, it is customary to include directories before files in those directories.
+	// In order to know which directories we need to include, we maintain a directory stack for each layer.
+	// We compare those stacks to the full FS that we're walking whenever we create a new tar entry.
+	// If the main stack doesn't match the layer's stack, we update the layer's stack and add
+	// any missing directory entries to the layer before we write the actual file entry.
+	stack := []*file{}
+
+	for f, err := range walkFS(ctx, fsys) {
+		if err != nil {
+			return nil, err
+		}
+
+		// Maintain our "main" stack.
+		if f.header.Typeflag == tar.TypeDir {
+			// Pop off any directories that are not parents of the current file's directory.
+			for i := len(stack) - 1; i >= 0; i-- {
+				if stack[i].path == path.Dir(f.path) {
+					break
+				}
+
+				stack = stack[:i]
+			}
+
+			// Push the current file onto the stack.
+			stack = append(stack, f)
+		}
+
+		// By default, all files go into the top layer.
+		w := top
+
+		// However, if a file implements an extension interface that tells us what package owns it,
+		// we can use that to determine which layer it belongs to (if any).
+		if pkger, ok := f.info.(interface {
+			Package() *apk.Package
+		}); ok {
+			if pkg := pkger.Package(); pkg != nil {
+				w, ok = packageToWriter[pkg.Name]
+				if !ok {
+					panic(fmt.Errorf("packageToWriter[%q] missing", pkg.Name))
+				}
+			}
+		}
+
+		// As described above, bring the layer's stack up to date with the main stack.
+		for _, todo := range w.alignStacks(stack) {
+			// We need to write any missing directories returned by alignStacks.
+			// But sometimes the result of alignStacks will include the file we're
+			// about to write (f) after this loop. In those cases, make sure we
+			// don't write it twice by skipping over it here.
+			if todo.header == f.header {
+				continue
+			}
+
+			if err := w.w.WriteHeader(todo.header); err != nil {
+				return nil, fmt.Errorf("writing header %s: %w", todo.header.Name, err)
+			}
+		}
+
+		// Now we're back to normal tar stuff.
+		if err := w.w.WriteHeader(f.header); err != nil {
+			return nil, fmt.Errorf("writing header %s: %w", f.header.Name, err)
+		}
+
+		if f.header.Typeflag == tar.TypeReg && f.header.Size > 0 {
+			data, err := fsys.Open(f.path)
+			if err != nil {
+				return nil, fmt.Errorf("opening %s: %w", f.path, err)
+			}
+
+			if _, err := io.CopyBuffer(w.w, data, buf); err != nil {
+				return nil, fmt.Errorf("copying %s: %w", f.path, err)
+			}
+
+			// Should never fail in practice.
+			if err := data.Close(); err != nil {
+				return nil, fmt.Errorf("closing %s: %w", f.path, err)
+			}
+		}
+	}
+
+	// Once we're done walking the FS, we need to finalize each layer...
+	layers := make([]v1.Layer, 0, len(groups)+1)
+	for i, g := range groups {
+		w := groupToWriter[g]
+		l, err := w.finalize()
+		if err != nil {
+			return nil, fmt.Errorf("finalizing group[%d] layer: %w", i, err)
+		}
+		layers = append(layers, l)
+	}
+
+	// ...including the top layer.
+	topLayer, err := top.finalize()
+	if err != nil {
+		return nil, fmt.Errorf("finalizing top layer: %w", err)
+	}
+
+	layers = append(layers, topLayer)
+
+	return layers, nil
+}
+
+// alignStacks ensures that w.stack is aligned with the passed in "main" stack
+// by updating w.stack and returning any directories w hasn't already seen written.
+// This relies on the fact that WalkDir iterates in lexicographic order, so we will
+// only ever write a tar entry the first time we see a dir (for a given layer).
+//
+// Examples...
+//
+// stack:   [etc]
+// w.stack: []
+// return:  [etc]
+//
+// stack:   [usr, usr/lib]
+// w.stack: [etc, etc/apk, etc/apk/keys]
+// return:  [usr, usr/lib]
+//
+// stack:   [usr, usr/lib]
+// w.stack: [usr]
+// return:  [usr/lib]
+//
+// stack:   [usr, usr/lib]
+// w.stack: [usr, usr/bin]
+// return:  [usr/lib]
+
+// stack:   [usr, usr/lib]
+// w.stack: [usr, usr/lib, usr/lib/foo]
+// return:  []
+func (w *layerWriter) alignStacks(stack []*file) []*file {
+	for i := 0; i < max(len(w.stack), len(stack)); i++ {
+		// The layer's stack is taller than the main stack, truncate layer's stack.
+		if i >= len(stack) {
+			w.stack = w.stack[:i]
+			return nil
+		}
+
+		// Otherwise skip over any entries that are the same.
+		if i < len(w.stack) && w.stack[i] == stack[i] {
+			continue
+		}
+
+		// For anything left that's not the same, we'll truncate w.stack,
+		// then append the main stack and return the difference.
+		w.stack = w.stack[:i]
+		w.stack = append(w.stack, stack[i:]...)
+		return w.stack[i:]
+	}
+
+	return nil
+}

--- a/pkg/build/layers_test.go
+++ b/pkg/build/layers_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+)
+
+func size(pkgs ...*apk.Package) uint64 {
+	var total uint64
+	for _, pkg := range pkgs {
+		total += pkg.InstalledSize
+	}
+	return total
+}
+
+func TestGroupByOriginAndSize(t *testing.T) {
+	crane := &apk.Package{Name: "crane", Origin: "crane", InstalledSize: 100}
+
+	glibc := &apk.Package{Name: "glibc", Origin: "glibc", InstalledSize: 6113087}
+	posix := &apk.Package{Name: "glibc-locale-posix", Origin: "glibc", InstalledSize: 417444}
+
+	libcrypt1 := &apk.Package{Name: "libcrypt1", Origin: "glibc", Version: "2.38-r14", InstalledSize: 23508}
+	libxcrypt := &apk.Package{Name: "libxcrypt", Origin: "libxcrypt", InstalledSize: 235761, Replaces: []string{"libcrypt1<2.38-r15"}}
+
+	newcrypt1 := &apk.Package{Name: "libcrypt1", Origin: "glibc", Version: "2.38-r16", InstalledSize: 23508}
+
+	repxcrypt := &apk.Package{Name: "libxcrypt", Origin: "libxcrypt", InstalledSize: 235761, Replaces: []string{"libcrypt1"}}
+	for _, tc := range []struct {
+		pkgs   []*apk.Package
+		budget int
+		want   []*group
+		err    error
+	}{{
+		pkgs:   []*apk.Package{crane},
+		budget: 1,
+		want:   []*group{{pkgs: []*apk.Package{crane}, size: size(crane), tiebreaker: "crane"}},
+	}, {
+		// glibc and glibc-locale-posix should be grouped by origin
+		pkgs:   []*apk.Package{crane, glibc, posix},
+		budget: 2,
+		want: []*group{
+			{pkgs: []*apk.Package{glibc, posix}, size: size(glibc, posix), tiebreaker: "glibc-locale-posix"},
+			{pkgs: []*apk.Package{crane}, size: size(crane), tiebreaker: "crane"},
+		},
+	}, {
+		// reasonable default if budget is unspecified
+		pkgs: []*apk.Package{crane, glibc, posix},
+		want: []*group{
+			{pkgs: []*apk.Package{crane, glibc, posix}, size: size(crane, glibc, posix), tiebreaker: "glibc-locale-posix"},
+		},
+	}, {
+		// libxcrypt replace libcrypt1, so it should be merged into the glibc origin
+		pkgs:   []*apk.Package{crane, glibc, posix, libcrypt1, libxcrypt},
+		budget: 5,
+		want: []*group{
+			{pkgs: []*apk.Package{glibc, posix, libcrypt1, libxcrypt}, size: size(glibc, libcrypt1, libxcrypt, posix), tiebreaker: "libxcrypt"},
+			{pkgs: []*apk.Package{crane}, size: size(crane), tiebreaker: "crane"},
+		},
+	}, {
+		// libxcrypt replaces does not match the version constraint for "newcrypt1", so it doesn't get merged.
+		pkgs:   []*apk.Package{crane, glibc, posix, newcrypt1, libxcrypt},
+		budget: 5,
+		want: []*group{
+			{pkgs: []*apk.Package{glibc, posix, newcrypt1}, size: size(glibc, newcrypt1, posix), tiebreaker: "libcrypt1"},
+			{pkgs: []*apk.Package{libxcrypt}, size: size(libxcrypt), tiebreaker: "libxcrypt"},
+			{pkgs: []*apk.Package{crane}, size: size(crane), tiebreaker: "crane"},
+		},
+	}, {
+		// "repxcrypt" replaces has no version, so it _does_ merge with "newcrypt1".
+		pkgs:   []*apk.Package{crane, glibc, posix, newcrypt1, repxcrypt},
+		budget: 5,
+		want: []*group{
+			{pkgs: []*apk.Package{glibc, posix, newcrypt1, repxcrypt}, size: size(glibc, newcrypt1, posix, repxcrypt), tiebreaker: "libxcrypt"},
+			{pkgs: []*apk.Package{crane}, size: size(crane), tiebreaker: "crane"},
+		},
+	}, {
+		// should be 3 groups but budget constricts that to 2
+		pkgs:   []*apk.Package{crane, glibc, posix, newcrypt1, libxcrypt},
+		budget: 2,
+		want: []*group{
+			{pkgs: []*apk.Package{glibc, posix, newcrypt1}, size: size(glibc, newcrypt1, posix), tiebreaker: "libcrypt1"},
+			{pkgs: []*apk.Package{crane, libxcrypt}, size: size(crane, libxcrypt), tiebreaker: "libxcrypt"},
+		},
+	}} {
+		got, err := groupByOriginAndSize(tc.pkgs, tc.budget)
+		if err != nil && tc.err != nil {
+			continue
+		}
+
+		if err != nil && tc.err == nil {
+			t.Errorf("groupByOriginAndSize(%v, %d) unexpected error: %v", tc.pkgs, tc.budget, err)
+		} else if err == nil && tc.err != nil {
+			t.Errorf("groupByOriginAndSize(%v, %d) expected error: %v", tc.pkgs, tc.budget, tc.err)
+		}
+
+		if err := compareGroups(got, tc.want); err != nil {
+			t.Errorf("groupByOriginAndSize(%v, %d) mismatch: %v", tc.pkgs, tc.budget, err)
+
+			for i, g := range got {
+				t.Logf("got[%d]: %v", i, g.pkgs)
+			}
+			for i, g := range tc.want {
+				t.Logf("want[%d]: %v", i, g.pkgs)
+			}
+		}
+	}
+}
+
+func compareGroups(a, b []*group) error {
+	if len(a) != len(b) {
+		return fmt.Errorf("len(a) = %d; len(b) = %d", len(a), len(b))
+	}
+	for i := range a {
+		aa, bb := a[i], b[i]
+		if len(aa.pkgs) != len(bb.pkgs) {
+			return fmt.Errorf("len(a[%d].pkgs) = %d; len(b[%d].pkgs) = %d", i, len(aa.pkgs), i, len(bb.pkgs))
+		}
+
+		for j := range aa.pkgs {
+			if aa.pkgs[j].Name != bb.pkgs[j].Name {
+				return fmt.Errorf("a[%d].pkgs[%d] = %s; b[%d].pkgs[%d] = %s", i, j, aa.pkgs[j].Name, i, j, bb.pkgs[j].Name)
+			}
+		}
+
+		if aa.size != bb.size {
+			return fmt.Errorf("a[%d].size = %d; b[%d].size = %d", i, aa.size, i, bb.size)
+		}
+		if aa.tiebreaker != bb.tiebreaker {
+			return fmt.Errorf("a[%d].tiebreaker = %s; b[%d].tiebreaker = %s", i, aa.tiebreaker, i, bb.tiebreaker)
+		}
+	}
+
+	return nil
+}
+
+func TestAlignStacks(t *testing.T) {
+	usr := []*file{{
+		path: "usr",
+	}, {
+		path: "usr/lib",
+	}}
+	etc := []*file{{
+		path: "etc",
+	}, {
+		path: "etc/apk",
+	}, {
+		path: "etc/apk/key",
+	}}
+	for i, tc := range []struct {
+		stack  []*file
+		before []*file
+		diff   []*file
+		after  []*file
+	}{{
+		stack:  usr,
+		before: usr,
+		after:  usr,
+	}, {
+		stack: usr,
+		after: usr,
+		diff:  usr,
+	}, {
+		stack:  usr,
+		before: etc,
+		after:  usr,
+		diff:   usr,
+	}, {
+		stack:  etc,
+		before: usr,
+		after:  etc,
+		diff:   etc,
+	}, {
+		stack:  etc[:2],
+		before: etc,
+		after:  etc[:2],
+	}, {
+		stack:  etc,
+		before: etc[:2],
+		after:  etc,
+		diff:   etc[2:],
+	}} {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			// clone to avoid mutating the usr and etc slices directly
+			w := &layerWriter{stack: slices.Clone(tc.before)}
+
+			if err := compareStacks(w.alignStacks(tc.stack), tc.diff); err != nil {
+				t.Errorf("alignStacks() mismatch: %v", err)
+			}
+			if err := compareStacks(w.stack, tc.after); err != nil {
+				t.Errorf("w.stack mismatch: %v", err)
+			}
+		})
+	}
+}
+
+// NB: this only cares about path
+func compareStacks(a, b []*file) error {
+	if len(a) != len(b) {
+		return fmt.Errorf("len(a) = %d; len(b) = %d", len(a), len(b))
+	}
+
+	for i := range len(a) {
+		if a[i].path != b[i].path {
+			return fmt.Errorf("a[%d] = %s; b[%d] = %s", i, a[i].path, i, b[i].path)
+		}
+	}
+
+	return nil
+}

--- a/pkg/build/oci/image.go
+++ b/pkg/build/oci/image.go
@@ -52,6 +52,12 @@ func BuildImageFromLayers(ctx context.Context, baseImage v1.Image, layers []v1.L
 		return nil, err
 	}
 
+	comment := "This is an apko single-layer image"
+	if len(layers) > 1 {
+		// TODO: Consider plumbing per-layer info here?
+		comment = ""
+	}
+
 	adds := make([]mutate.Addendum, 0, len(layers))
 	for _, layer := range layers {
 		digest, err := layer.Digest()
@@ -71,9 +77,9 @@ func BuildImageFromLayers(ctx context.Context, baseImage v1.Image, layers []v1.L
 			Layer: layer,
 			History: v1.History{
 				Author:    "apko",
-				Comment:   "This is an apko single-layer image", // TODO: Update this once we confirm no other changes.
+				Comment:   comment,
 				CreatedBy: "apko",
-				Created:   v1.Time{Time: created},
+				Created:   v1.Time{Time: created}, // TODO: Consider per-layer creation time?
 			},
 		})
 	}

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -119,6 +119,9 @@ func (ic *ImageConfiguration) MergeInto(target *ImageConfiguration) error {
 	if target.WorkDir == "" {
 		target.WorkDir = ic.WorkDir
 	}
+	if target.Layering == nil {
+		target.Layering = ic.Layering
+	}
 	if len(target.Archs) == 0 {
 		target.Archs = ic.Archs
 	}

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -130,6 +130,10 @@
           },
           "type": "array",
           "description": "Optional: A list of volumes to configure\n\nThis is _not_ the same as Paths, but refers to the OCI spec \"volumes\"\nfield used by some container runtimes (docker) to create volumes at\nruntime. For most use cases, this is not needed, but consider using this\nwhen the image requires special volume configuration at runtime for\nsupported container runtimes."
+        },
+        "layering": {
+          "$ref": "#/$defs/Layering",
+          "description": "Experimental: Optional: Configuration to control layering of the OCI image."
         }
       },
       "additionalProperties": false,
@@ -192,6 +196,18 @@
             "type": "string"
           },
           "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Layering": {
+      "properties": {
+        "strategy": {
+          "type": "string"
+        },
+        "budget": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -193,6 +193,9 @@ type ImageConfiguration struct {
 	// when the image requires special volume configuration at runtime for
 	// supported container runtimes.
 	Volumes []string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+
+	// Experimental: Optional: Configuration to control layering of the OCI image.
+	Layering *Layering `json:"layering,omitempty" yaml:"layering,omitempty" apko:"experimental"`
 }
 
 // Architecture represents a CPU architecture for the container image.
@@ -406,4 +409,9 @@ type SBOM struct {
 	Path   string
 	Format string
 	Digest v1.Hash
+}
+
+type Layering struct {
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Budget   int    `json:"budget,omitempty" yaml:"budget,omitempty"`
 }

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -1033,3 +1033,12 @@ func (m *memFileInfo) Sys() any {
 
 	return th
 }
+
+// This is a bit janky, but we need a way to know who owns this.
+func (m *memFileInfo) Package() *apk.Package {
+	if m.node.te == nil {
+		return nil
+	}
+
+	return m.node.te.pkg
+}


### PR DESCRIPTION
This uses a "simple" strategy of merging origins and replaces, then
taking the largest $budget groups of packages, merging the remainder.

This should not have any effect on apko configs that don't opt into
layering via the "layering" field, which is marked experimental:

```yaml
layering:
    strategy: "origin"
    budget: 10
```

This will split packages into up to 10 different layers (+1 for
everything that doesn't belong to a package).
