### PR TITLE
version.go: Ignore soname-versioned provides/depends for shlibs

### DIFF
--- a/pkg/apk/apk/version_test.go
+++ b/pkg/apk/apk/version_test.go
@@ -935,6 +935,8 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 		{"name<=1.2.3", "name", "1.2.3", versionLessEqual, ""},
 		{"name@edge=1.2.3", "name@edge=1.2.3", "", versionAny, ""}, // wrong order, so just returns the whole thing
 		{"name=1.2.3@community", "name", "1.2.3", versionEqual, "community"},
+		{"so:libfoo.so.6=6", "so:libfoo.so.6", "0.6", versionEqual, ""},
+		{"so:libfoo.so.6=1.0-r3", "so:libfoo.so.6", "1.0-r3", versionEqual, ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, packages that ship shared libraries in the archive will have versioned provides for those shlibs.  These versions are calculated from the soname version, e.g.:

```
provides = so:libfoo.so.6=6
```

With the advent of
https://github.com/chainguard-dev/melange/pull/1871, the new versions will reflect the package version.  This can introduce a package resolution problem when the soname version is greater than the package version, e.g.:

```
  libfoo-4.0-r1
  provides = so:libfoo.so.6=6
```

vs.

```
  libfoo-4.0-r2
  provides = so:libfoo.so.6=4.0-r2
```

It's clear that we should select libfoo-4.0-r2 as the most recent package, but apko will currently select libfoo-4.0-r1 instead.

The solution proposed here is to ignore the versioned depends/provides *iff* the version that comes after "=" does NOT contain a release substring (`-rN`).  This will effectively make the case above be:

```
  libfoo-4.0-r1
  provides = so:libfoo.so.6
```

vs.

```
  libfoo-4.0-r2
  provides = so:libfoo.so.6=4.0-r2
```

which will force apko to select the latest package.

Thanks to @dannf, @justinvreeland  and @jonjohnsonjr for the brainstorm sessions.