### PR TITLE
apk: fix cached APKINDEX to be world readable

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -431,6 +431,13 @@ func (t *cacheTransport) retrieveAndSaveFile(ctx context.Context, request *http.
 	if err != nil {
 		return "", fmt.Errorf("unable to create a temporary cache file: %w", err)
 	}
+	// Now that symlinks are used to advertise cached files,
+	// CreateTemp permissions are no longer suitable default,
+	// update to world readable, group/user writable.
+	err = tmp.Chmod(os.FileMode(0664))
+	if err != nil {
+		return "", fmt.Errorf("unable to chmod temporary cache file: %w", err)
+	}
 	if err := func() error {
 		defer tmp.Close()
 		defer resp.Body.Close()


### PR DESCRIPTION
Currently APKINDEX.tar.gz cache is not world readable, but the
individual apk streams are.

```
$ ls -latr https%3A%2F%2Fpackages.wolfi.dev%2Fos/aarch64/APKINDEX/*
lrwxrwxrwx 1 xnox xnox       14 Apr 13 23:23 'https%3A%2F%2Fpackages.wolfi.dev%2Fos/aarch64/APKINDEX/GY3WENJZGRTGEYJVHE2TQZBTGQ2GMMTFGNRTMMLGGRSTONRQGVQQ====.tar.gz' -> 3496108094.tmp
-rw------- 1 xnox xnox 11595802 Apr 13 23:23  https%3A%2F%2Fpackages.wolfi.dev%2Fos/aarch64/APKINDEX/3496108094.tmp

$ ls -latr https%3A%2F%2Fpackages.wolfi.dev%2Fos/aarch64/git-2.49.0-r1/expand-apk821189521/
total 27032
-rw-rw-r-- 1 xnox xnox     5550 Apr 13 23:23 stream-0.tar.gz
drwx------ 2 xnox xnox     4096 Apr 13 23:23 .
-rw-rw-r-- 1 xnox xnox  9096589 Apr 13 23:23 stream-1.tar.gz
-rw-rw-r-- 1 xnox xnox 18566144 Apr 13 23:23 stream-1.tar
drwxr-xr-x 3 xnox xnox     4096 Apr 13 23:23 ..
```

Fix this by chmoding the temp file to 0664, such that it too becomes
world readable.

Related:
- https://github.com/chainguard-dev/apko/pull/1564

Fixes: https://github.com/chainguard-dev/internal-dev/issues/11199
