### PR TITLE
Undeprecate including other configurations

### DIFF
--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -182,8 +182,6 @@ func (ic *ImageConfiguration) readLocal(imageconfigPath string, includePaths []s
 // Load - loads an image configuration given a configuration file path.
 // Populates configHasher with the configuration data loaded from the imageConfigPath and the other referenced files.
 // You can pass any dummy hasher (like fnv.New32()), if you don't care about the hash of the configuration.
-//
-// Deprecated: This will be removed in a future release.
 func (ic *ImageConfiguration) Load(ctx context.Context, imageConfigPath string, includePaths []string, configHasher hash.Hash) error {
 	data, err := ic.readLocal(imageConfigPath, includePaths)
 	if err != nil {

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -122,7 +122,7 @@
         },
         "include": {
           "type": "string",
-          "description": "Optional: Path to a local file containing additional image configuration\n\nThe included configuration is deep merged with the parent configuration\n\nDeprecated: This will be removed in a future release."
+          "description": "Optional: Path to a local file containing additional image configuration\n\nThe included configuration is deep merged with the parent configuration\n"
         },
         "volumes": {
           "items": {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -182,7 +182,6 @@ type ImageConfiguration struct {
 	//
 	// The included configuration is deep merged with the parent configuration
 	//
-	// Deprecated: This will be removed in a future release.
 	Include string `json:"include,omitempty" yaml:"include,omitempty"`
 
 	// Optional: A list of volumes to configure


### PR DESCRIPTION
This was deprecated in https://github.com/chainguard-dev/apko/pull/1522

> deprecate some stuff we don't use and shouldn't recommend

I'd like to use it, and while yaml might not have a defined include it's useful for defining images that are the same with additional package or similiar.