### PR TITLE
Apko keyrings to recognize key suffixes when lost during fetch:

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -262,7 +262,7 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 			if err != nil {
 				redacted := redact(IndexURL(repoURL, arch))
 				if errors.Is(err, fs.ErrNotExist) {
-					// This can happen for locaqql repos, just log and continue.
+					// This can happen for local repos, just log and continue.
 					clog.WarnContextf(ctx, "getting local index %s: %v", redacted, err)
 					return nil
 				}

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -35,7 +37,6 @@ import (
 	"github.com/klauspost/compress/gzip"
 	"go.lsp.dev/uri"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"chainguard.dev/apko/pkg/apk/auth"
@@ -261,7 +262,7 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 			if err != nil {
 				redacted := redact(IndexURL(repoURL, arch))
 				if errors.Is(err, fs.ErrNotExist) {
-					// This can happen for local repos, just log and continue.
+					// This can happen for locaqql repos, just log and continue.
 					clog.WarnContextf(ctx, "getting local index %s: %v", redacted, err)
 					return nil
 				}
@@ -367,6 +368,7 @@ func parseRepositoryIndex(ctx context.Context, u string, keys map[string][]byte,
 		tarReader := tar.NewReader(gzipReader)
 
 		sigs := make([]Signature, 0, len(keys))
+
 		for {
 			// read the signature(s)
 			signatureFile, err := tarReader.Next()
@@ -383,7 +385,17 @@ func parseRepositoryIndex(ctx context.Context, u string, keys map[string][]byte,
 				return nil, fmt.Errorf("failed to find key name in signature file name: %s", signatureFile.Name)
 			}
 			keyfile := matches[2]
-			if _, ok := keys[keyfile]; !ok {
+
+			trimmedKeyFile := strings.TrimSuffix(keyfile, ".rsa.pub")
+			if _, ok := keys[keyfile]; ok {
+				// We found a matching key
+			} else if _, ok := keys[trimmedKeyFile]; ok {
+				// When we download keys from proxy servers - like artifactory, we ignore the 'content-disposition' header
+				// (that would be difficult to cache as well), and the header is responsible for providing key name with
+				// proper extension. Here we accept matching keys without proper extension.
+				keyfile = trimmedKeyFile
+			} else {
+				clog.FromContext(ctx).Warnf("skipping signature %s due to missing keyfile: %s", signatureFile.Name, keyfile)
 				// Ignore this signature if we don't have the key
 				continue
 			}
@@ -415,7 +427,7 @@ func parseRepositoryIndex(ctx context.Context, u string, keys map[string][]byte,
 			})
 		}
 		if len(sigs) == 0 {
-			return nil, fmt.Errorf("no signature with known key found in repository index")
+			return nil, fmt.Errorf("no signature with known key (one of: %v) found in repository index", slices.Collect(maps.Keys(keys)))
 		}
 		// we now have the signature bytes and name, get the contents of the rest;
 		// this should be everything else in the raw gzip file as is.


### PR DESCRIPTION
When download keys from Artifactory, such URLs for e.g. are being used:

https://artifactory.{redacted}.com/artifactory/api/security/keypair/public/repositories/development-wolfi-virtual

The URL returns:
```
   content-disposition: attachment; filename=keyname.rsa.pub ,
```

The keyname can be configured to be e.g. 'development-wolfi-virtual'.

Before this patch there was a mismatch on INDEX files signatures verification.
The verification expected: development-wolfi-virtual.rsa.pub,
but as Apko ignores the content-disposition header, it observes just `development-wolfi-virtual.rsa.pub`
that does not match.

In this PR I enabled matching that recognized development-wolfi-virtual ~= development-wolfi-virtual.rsa.pub.

Alternatively we could consider:
  a) changing fetcher to recognize content-disposition -> but this becomes tricky to handle with --offline or caching modes.
  b) when we fetch the keys... always assume they have .rsa.pub extension -> and add it. In theory it could be a breaking change
     (if there are valid ?? scenarios for keys without .rsa.pub extension).
