### PR TITLE
Drop experimental tag from layering

### DIFF
--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -133,7 +133,7 @@
         },
         "layering": {
           "$ref": "#/$defs/Layering",
-          "description": "Experimental: Optional: Configuration to control layering of the OCI image."
+          "description": "Optional: Configuration to control layering of the OCI image."
         }
       },
       "additionalProperties": false,

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -194,8 +194,8 @@ type ImageConfiguration struct {
 	// supported container runtimes.
 	Volumes []string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 
-	// Experimental: Optional: Configuration to control layering of the OCI image.
-	Layering *Layering `json:"layering,omitempty" yaml:"layering,omitempty" apko:"experimental"`
+	// Optional: Configuration to control layering of the OCI image.
+	Layering *Layering `json:"layering,omitempty" yaml:"layering,omitempty"`
 }
 
 // Architecture represents a CPU architecture for the container image.


### PR DESCRIPTION
This is opt-in but I'm sufficiently convinced this is ready to pull into terraform-provider-apko, which ignores experimental fields.