### PR TITLE
Guard against empty inputs list in unify()

### DIFF
--- a/pkg/build/lock.go
+++ b/pkg/build/lock.go
@@ -146,7 +146,7 @@ type resolved struct {
 
 // unify returns (locked packages (per arch), missing packages (per arch), error)
 func unify(originals []string, inputs []resolved) (map[string][]string, map[string][]string, error) {
-	if len(originals) == 0 {
+	if len(originals) == 0 || len(inputs) == 0 {
 		// If there are no original packages, then we can't really do anything.
 		// This used to return nil but multi-arch unification assumes we always
 		// have an "index" entry, even if it's empty, so we return this now.

--- a/pkg/build/lock_test.go
+++ b/pkg/build/lock_test.go
@@ -34,6 +34,10 @@ func TestUnify(t *testing.T) {
 		name: "empty",
 		want: map[string][]string{"index": {}},
 	}, {
+		name:      "no inputs",
+		originals: []string{"foo", "bar", "baz"},
+		want:      map[string][]string{"index": {}},
+	}, {
 		name:      "simple single arch",
 		originals: []string{"foo", "bar", "baz"},
 		inputs: []resolved{{


### PR DESCRIPTION
This can panic if called incorrectly, return an empty list instead.