### PR TITLE
improve error messages in expandApk

### DIFF
--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -258,7 +258,7 @@ var errExpandApkWriterMaxStreams = errors.New("expandApkWriter max streams reach
 func (w *expandApkWriter) Next() error {
 	if w.f != nil {
 		if err := w.CloseFile(); err != nil {
-			return fmt.Errorf("failed to Close file before Next: %v", err)
+			return fmt.Errorf("failing to Close file before Next: %v", err)
 		}
 	}
 
@@ -268,18 +268,18 @@ func (w *expandApkWriter) Next() error {
 	if w.streamId == 0 {
 		f, err := os.Open(w.f.Name())
 		if err != nil {
-			return fmt.Errorf("failed to open: %v", err)
+			return fmt.Errorf("failing to open: %v", err)
 		}
 		defer f.Close()
 		gzipRead, err := gzip.NewReader(f)
 		if err != nil {
-			return fmt.Errorf("failed to create gzip reader: %v", err)
+			return fmt.Errorf("failing to create gzip reader: %v", err)
 		}
 		defer gzipRead.Close()
 		tarRead := tar.NewReader(gzipRead)
 		hdr, err := tarRead.Next()
 		if err != nil {
-			return fmt.Errorf("failed to read tar header: %v", err)
+			return fmt.Errorf("failing to read tar header: %v", err)
 		}
 		if strings.HasPrefix(hdr.Name, ".SIGN.") {
 			w.maxStreams = 3
@@ -290,7 +290,7 @@ func (w *expandApkWriter) Next() error {
 	p := fmt.Sprintf("%s-%d.%s", filepath.Join(w.parentDir, w.baseName), w.streamId, w.ext)
 	file, err := os.Create(p)
 	if err != nil {
-		return fmt.Errorf("failed to create stream file: %w", err)
+		return fmt.Errorf("failing to create stream file: %w", err)
 	}
 	w.f = file
 

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -258,7 +258,7 @@ var errExpandApkWriterMaxStreams = errors.New("expandApkWriter max streams reach
 func (w *expandApkWriter) Next() error {
 	if w.f != nil {
 		if err := w.CloseFile(); err != nil {
-			return fmt.Errorf("failing to Close file before Next: %v", err)
+			return fmt.Errorf("closing file before Next: %v", err)
 		}
 	}
 
@@ -268,18 +268,18 @@ func (w *expandApkWriter) Next() error {
 	if w.streamId == 0 {
 		f, err := os.Open(w.f.Name())
 		if err != nil {
-			return fmt.Errorf("failing to open: %v", err)
+			return fmt.Errorf("opening: %v", err)
 		}
 		defer f.Close()
 		gzipRead, err := gzip.NewReader(f)
 		if err != nil {
-			return fmt.Errorf("failing to create gzip reader: %v", err)
+			return fmt.Errorf("creating gzip reader: %v", err)
 		}
 		defer gzipRead.Close()
 		tarRead := tar.NewReader(gzipRead)
 		hdr, err := tarRead.Next()
 		if err != nil {
-			return fmt.Errorf("failing to read tar header: %v", err)
+			return fmt.Errorf("reading tar header: %v", err)
 		}
 		if strings.HasPrefix(hdr.Name, ".SIGN.") {
 			w.maxStreams = 3
@@ -290,7 +290,7 @@ func (w *expandApkWriter) Next() error {
 	p := fmt.Sprintf("%s-%d.%s", filepath.Join(w.parentDir, w.baseName), w.streamId, w.ext)
 	file, err := os.Create(p)
 	if err != nil {
-		return fmt.Errorf("failing to create stream file: %w", err)
+		return fmt.Errorf("creating stream file: %w", err)
 	}
 	w.f = file
 

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -258,7 +258,7 @@ var errExpandApkWriterMaxStreams = errors.New("expandApkWriter max streams reach
 func (w *expandApkWriter) Next() error {
 	if w.f != nil {
 		if err := w.CloseFile(); err != nil {
-			return fmt.Errorf("expandApkWriter.Next error 1: %v", err)
+			return fmt.Errorf("failed to Close file before Next: %v", err)
 		}
 	}
 
@@ -268,18 +268,18 @@ func (w *expandApkWriter) Next() error {
 	if w.streamId == 0 {
 		f, err := os.Open(w.f.Name())
 		if err != nil {
-			return fmt.Errorf("expandApkWriter.Next error 2: %v", err)
+			return fmt.Errorf("failed to open: %v", err)
 		}
 		defer f.Close()
 		gzipRead, err := gzip.NewReader(f)
 		if err != nil {
-			return fmt.Errorf("expandApkWriter.Next error 3: %v", err)
+			return fmt.Errorf("failed to create gzip reader: %v", err)
 		}
 		defer gzipRead.Close()
 		tarRead := tar.NewReader(gzipRead)
 		hdr, err := tarRead.Next()
 		if err != nil {
-			return fmt.Errorf("expandApkWriter.Next error 4: %v", err)
+			return fmt.Errorf("failed to read tar header: %v", err)
 		}
 		if strings.HasPrefix(hdr.Name, ".SIGN.") {
 			w.maxStreams = 3
@@ -290,7 +290,7 @@ func (w *expandApkWriter) Next() error {
 	p := fmt.Sprintf("%s-%d.%s", filepath.Join(w.parentDir, w.baseName), w.streamId, w.ext)
 	file, err := os.Create(p)
 	if err != nil {
-		return fmt.Errorf("expandApkWriter.Next error 5: %w", err)
+		return fmt.Errorf("failed to create stream file: %w", err)
 	}
 	w.f = file
 

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -258,7 +258,7 @@ var errExpandApkWriterMaxStreams = errors.New("expandApkWriter max streams reach
 func (w *expandApkWriter) Next() error {
 	if w.f != nil {
 		if err := w.CloseFile(); err != nil {
-			return fmt.Errorf("closing file before Next: %v", err)
+			return fmt.Errorf("closing file before Next: %w", err)
 		}
 	}
 
@@ -268,18 +268,18 @@ func (w *expandApkWriter) Next() error {
 	if w.streamId == 0 {
 		f, err := os.Open(w.f.Name())
 		if err != nil {
-			return fmt.Errorf("opening: %v", err)
+			return fmt.Errorf("opening: %w", err)
 		}
 		defer f.Close()
 		gzipRead, err := gzip.NewReader(f)
 		if err != nil {
-			return fmt.Errorf("creating gzip reader: %v", err)
+			return fmt.Errorf("creating gzip reader: %w", err)
 		}
 		defer gzipRead.Close()
 		tarRead := tar.NewReader(gzipRead)
 		hdr, err := tarRead.Next()
 		if err != nil {
-			return fmt.Errorf("reading tar header: %v", err)
+			return fmt.Errorf("reading tar header: %w", err)
 		}
 		if strings.HasPrefix(hdr.Name, ".SIGN.") {
 			w.maxStreams = 3


### PR DESCRIPTION
I'm not sure where the numbered error codes comes from, I think it was ported somewhat literally from apk's code.