### PR TITLE
Add support for the =~ constraint

### DIFF
--- a/pkg/apk/apk/version.go
+++ b/pkg/apk/apk/version.go
@@ -270,12 +270,12 @@ func CompareVersions(actual, required Version) int {
 
 // includesVersion returns true if the actual version is a strict subset of the required version
 func includesVersion(actual, required Version) bool {
-	// if more required numbers than actual numbers, than require is more specific,
+	// if more required numbers than actual numbers, then require is more specific,
 	// so no match
 	if len(actual.numbers) < len(required.numbers) {
 		return false
 	}
-	for i := 0; i < len(required.numbers); i++ {
+	for i := range len(required.numbers) {
 		if actual.numbers[i] != required.numbers[i] {
 			return false
 		}
@@ -324,10 +324,11 @@ const (
 	versionGreaterEqual
 	versionLessEqual
 	versionTilde
+	versionTildeFuzzy
 )
 
 func (v versionDependency) satisfies(actualVersion, requiredVersion Version) bool {
-	if v == versionTilde {
+	if v == versionTilde || v == versionTildeFuzzy {
 		return includesVersion(actualVersion, requiredVersion)
 	}
 	c := CompareVersions(actualVersion, requiredVersion)
@@ -420,6 +421,8 @@ func ResolvePackageNameVersionPin(pkgName string) ParsedConstraint {
 			p.dep = versionLessEqual
 		case "~":
 			p.dep = versionTilde
+		case "=~":
+			p.dep = versionTildeFuzzy
 		default:
 			p.dep = versionAny
 		}

--- a/pkg/apk/apk/version_test.go
+++ b/pkg/apk/apk/version_test.go
@@ -833,6 +833,9 @@ func TestCompareVersion(t *testing.T) {
 		{"0.0_git20230331", less, "0.0_git20230508"},
 		{"2.0.0", less, "2.0.6-r0"},
 		{"6.4_p20231125-r0", greater, "6.4-r2"},
+		{"0.14.0-r3", less, "0.15.0-r0"},
+		{"0.14.0", less, "0.15.0"},
+		{"0.14", less, "0.15.0"},
 	}
 	for _, tt := range tests {
 		var exp string
@@ -868,6 +871,8 @@ func TestResolveVersion(t *testing.T) {
 		testNamedPackageFromVersionAndPin("1.7.1-r0", ""),
 		testNamedPackageFromVersionAndPin("1.7.1-r1", ""),
 		testNamedPackageFromVersionAndPin("2.0.6-r0", ""),
+		testNamedPackageFromVersionAndPin("0.14.0-r3", ""),
+		testNamedPackageFromVersionAndPin("0.15.0-r0", ""),
 		pinPackage,
 	}
 	tests := []struct {
@@ -894,6 +899,14 @@ func TestResolveVersion(t *testing.T) {
 		{"1.7", versionTilde, "", nil, "1.7.1-r1", "fits within"},
 		{"1.7.1", versionTilde, "", nil, "1.7.1-r1", "fits within"},
 		{"1.7.1-r2", versionTilde, "", nil, "", "no match"},
+		{"0.14", versionTilde, "", nil, "0.14.0-r3", "fits within"},
+		{"0.14.0", versionTilde, "", nil, "0.14.0-r3", "fits within"},
+		{"0.14", versionTildeFuzzy, "", nil, "0.14.0-r3", "fits within"},
+		{"0.14.0", versionTildeFuzzy, "", nil, "0.14.0-r3", "fits within"},
+		{"0.15", versionTilde, "", nil, "0.15.0-r0", "fits within"},
+		{"0.15.0", versionTilde, "", nil, "0.15.0-r0", "fits within"},
+		{"0.15", versionTildeFuzzy, "", nil, "0.15.0-r0", "fits within"},
+		{"0.15.0", versionTildeFuzzy, "", nil, "0.15.0-r0", "fits within"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -933,6 +946,8 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 		{"name<1.2.3", "name", "1.2.3", versionLess, ""},
 		{"name>=1.2.3", "name", "1.2.3", versionGreaterEqual, ""},
 		{"name<=1.2.3", "name", "1.2.3", versionLessEqual, ""},
+		{"name~1.2.3", "name", "1.2.3", versionTilde, ""},
+		{"name=~1.2.3", "name", "1.2.3", versionTildeFuzzy, ""},
 		{"name@edge=1.2.3", "name@edge=1.2.3", "", versionAny, ""}, // wrong order, so just returns the whole thing
 		{"name=1.2.3@community", "name", "1.2.3", versionEqual, "community"},
 		{"so:libfoo.so.6=6", "so:libfoo.so.6", "0.6", versionEqual, ""},


### PR DESCRIPTION
We were trying to use this constraint which should be [valid](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Package_pinning):
```
"foo=~X.Y.Z",
```
but this was not a valid matcher so we defaulted to `versionAny` which would instead pull in the latest version.

This PR adds the `=~` constraint and treats it like `~` so that we correctly resolve versions via `includesVersion` and updates a few tests to validate both the `~` and `=~` constraints.


