### PR TITLE
Add an OperatingSystem package to our image SBOMs

### DIFF
--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -56,6 +56,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-OperatingSystem-replaces",
+      "name": "replaces",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: Replaces",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -56,6 +56,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-OperatingSystem-replaces",
+      "name": "replaces",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: Replaces",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",
       "name": "pretend-baselayout",
       "versionInfo": "1.0.0-r0",

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -629,7 +629,7 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 // addOperatingSystem adds a package describing the operating system
 func addOperatingSystem(doc *Document, opts *options.Options) {
 	osPackage := Package{
-		ID:               fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(opts.OS.ID)),
+		ID:               fmt.Sprintf("SPDXRef-OperatingSystem-%s", stringToIdentifier(opts.OS.ID)),
 		Name:             opts.OS.ID,
 		Version:          opts.OS.Version,
 		Supplier:         supplier(opts),
@@ -640,11 +640,6 @@ func addOperatingSystem(doc *Document, opts *options.Options) {
 	}
 
 	doc.Packages = append(doc.Packages, osPackage)
-	// For now I do not think we need to add the OS package to the
-	// documentDescribes field as it is not a primary package, but
-	// the documentation of this field is not too clear about its
-	// full purpose.
-	// doc.DocumentDescribes = append(doc.DocumentDescribes, osPackage.ID)
 }
 
 // addSourcePackage creates a package describing the source code

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -134,6 +134,9 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 		doc.DocumentDescribes = []string{imagePackage.ID}
 	}
 
+	// Add the operating system package
+	addOperatingSystem(doc, opts)
+
 	if opts.ImageInfo.VCSUrl != "" {
 		if opts.ImageInfo.ImageDigest != "" {
 			addSourcePackage(opts.ImageInfo.VCSUrl, doc, imagePackage, opts)
@@ -621,6 +624,24 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 	}
 
 	return nil
+}
+
+// addOperatingSystem adds a package describing the operating system
+func addOperatingSystem(doc *Document, opts *options.Options) {
+	// Add the operating system package
+	osPackage := Package{
+		ID:               fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(opts.OS.Name)),
+		Name:             opts.OS.Name,
+		Version:          opts.OS.Version,
+		Supplier:         supplier(opts),
+		FilesAnalyzed:    false,
+		Description:      "Operating System",
+		DownloadLocation: NOASSERTION,
+		PrimaryPurpose:   "OPERATING-SYSTEM",
+	}
+
+	doc.Packages = append(doc.Packages, osPackage)
+	doc.DocumentDescribes = append(doc.DocumentDescribes, osPackage.ID)
 }
 
 // addSourcePackage creates a package describing the source code

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -628,10 +628,9 @@ func (sx *SPDX) GenerateIndex(opts *options.Options, path string) error {
 
 // addOperatingSystem adds a package describing the operating system
 func addOperatingSystem(doc *Document, opts *options.Options) {
-	// Add the operating system package
 	osPackage := Package{
-		ID:               fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(opts.OS.Name)),
-		Name:             opts.OS.Name,
+		ID:               fmt.Sprintf("SPDXRef-Package-%s", stringToIdentifier(opts.OS.ID)),
+		Name:             opts.OS.ID,
 		Version:          opts.OS.Version,
 		Supplier:         supplier(opts),
 		FilesAnalyzed:    false,
@@ -641,7 +640,11 @@ func addOperatingSystem(doc *Document, opts *options.Options) {
 	}
 
 	doc.Packages = append(doc.Packages, osPackage)
-	doc.DocumentDescribes = append(doc.DocumentDescribes, osPackage.ID)
+	// For now I do not think we need to add the OS package to the
+	// documentDescribes field as it is not a primary package, but
+	// the documentation of this field is not too clear about its
+	// full purpose.
+	// doc.DocumentDescribes = append(doc.DocumentDescribes, osPackage.ID)
 }
 
 // addSourcePackage creates a package describing the source code

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-Package-unknown",
+      "SPDXID": "SPDXRef-OperatingSystem-unknown",
       "name": "unknown",
       "versionInfo": "3.0",
       "filesAnalyzed": false,

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
@@ -33,6 +33,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-Package-unknown",
+      "name": "unknown",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-font-ubuntu-0.869-r1",
       "name": "font-ubuntu",
       "versionInfo": "0.869-r1",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
@@ -33,6 +33,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-Package-apko-images",
+      "name": "apko-images",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: Apko Images, Plc",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-libattr1-2.5.1-r2",
       "name": "libattr1",
       "versionInfo": "2.5.1-r2",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-Package-apko-images",
+      "SPDXID": "SPDXRef-OperatingSystem-apko-images",
       "name": "apko-images",
       "versionInfo": "3.0",
       "filesAnalyzed": false,

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-Package-unknown",
+      "SPDXID": "SPDXRef-OperatingSystem-unknown",
       "name": "unknown",
       "versionInfo": "3.0",
       "filesAnalyzed": false,

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
@@ -33,6 +33,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-Package-unknown",
+      "name": "unknown",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-logstash-8-8.15.3-r4",
       "name": "logstash-8",
       "versionInfo": "8.15.3-r4",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-Package-unknown",
+      "SPDXID": "SPDXRef-OperatingSystem-unknown",
       "name": "unknown",
       "versionInfo": "3.0",
       "filesAnalyzed": false,

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
@@ -33,6 +33,16 @@
       ]
     },
     {
+      "SPDXID": "SPDXRef-Package-unknown",
+      "name": "unknown",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    },
+    {
       "SPDXID": "SPDXRef-Package-unbound-libs-1.23.0-r0",
       "name": "unbound-libs",
       "versionInfo": "1.23.0-r0",


### PR DESCRIPTION
We are missing some information in our image SBOMs that cause trivy to generate warnings. The missing piece is a package declaring what operating system our images are using.