### PR TITLE
add clean command to clear apk cache

### DIFF
--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/spf13/cobra"
+)
+
+func cleanCmd() *cobra.Command {
+	var cacheDir string
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clean the apko cache directory",
+		Long: `Clean the apko cache directory by removing all cached APK packages and APKINDEX files.
+
+If no cache directory is specified, the default cache directory is used:
+  - On Linux: ~/.cache/dev.chainguard.go-apk
+  - On macOS: ~/Library/Caches/dev.chainguard.go-apk
+  - On Windows: %LocalAppData%\dev.chainguard.go-apk`,
+		Example: `  apko clean
+  apko clean --cache-dir /custom/cache/path
+  apko clean --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return CleanImpl(cmd.Context(), cacheDir, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory containing the apk cache (defaults to system cache directory)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show cache size without deleting")
+
+	return cmd
+}
+
+func CleanImpl(ctx context.Context, cacheDir string, dryRun bool) error {
+	log := clog.FromContext(ctx)
+
+	// Determine cache directory
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.UserCacheDir()
+		if err != nil {
+			return fmt.Errorf("failed to determine user cache directory: %w", err)
+		}
+		cacheDir = filepath.Join(cacheDir, "dev.chainguard.go-apk")
+	} else {
+		var err error
+		cacheDir, err = filepath.Abs(cacheDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve cache directory path: %w", err)
+		}
+	}
+
+	log.Infof("Cleaning cache directory: %s", cacheDir)
+
+	// Check if the cache directory exists
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Infof("Cache directory does not exist, nothing to clean")
+			return nil
+		}
+		return fmt.Errorf("failed to stat cache directory: %w", err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("cache path is not a directory: %s", cacheDir)
+	}
+
+	// Calculate cache size
+	size, err := calculateDirSize(cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to calculate cache size: %w", err)
+	}
+
+	log.Infof("Cache size: %s", formatBytes(size))
+
+	if dryRun {
+		log.Infof("Dry run mode: cache directory will not be deleted")
+		return nil
+	}
+
+	// Remove the cache directory and all its contents
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return fmt.Errorf("failed to remove cache directory: %w", err)
+	}
+
+	log.Infof("Cache directory cleaned successfully")
+	return nil
+}
+
+// calculateDirSize recursively calculates the total size of a directory
+func calculateDirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
+// formatBytes formats bytes into human-readable format
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/cli/clean_test.go
+++ b/internal/cli/clean_test.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanImpl(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clean existing cache", func(t *testing.T) {
+		// Create a temporary cache directory
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "cache")
+		err := os.MkdirAll(cacheDir, 0755)
+		require.NoError(t, err)
+
+		// Create some dummy cache files
+		testFiles := []string{
+			"https%3A%2F%2Fdl-cdn.alpinelinux.org%2Falpine%2Fv3.18/x86_64/APKINDEX.tar.gz",
+			"https%3A%2F%2Fdl-cdn.alpinelinux.org%2Falpine%2Fv3.18/x86_64/package1.apk",
+			"https%3A%2F%2Fdl-cdn.alpinelinux.org%2Falpine%2Fv3.18/x86_64/package2.apk",
+		}
+
+		for _, file := range testFiles {
+			dir := filepath.Dir(filepath.Join(cacheDir, file))
+			err := os.MkdirAll(dir, 0755)
+			require.NoError(t, err)
+			
+			err = os.WriteFile(filepath.Join(cacheDir, file), []byte("dummy content"), 0644)
+			require.NoError(t, err)
+		}
+
+		// Verify cache exists
+		_, err = os.Stat(cacheDir)
+		require.NoError(t, err)
+
+		// Clean the cache
+		err = CleanImpl(ctx, cacheDir, false)
+		require.NoError(t, err)
+
+		// Verify cache is gone
+		_, err = os.Stat(cacheDir)
+		require.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("dry run does not delete cache", func(t *testing.T) {
+		// Create a temporary cache directory
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "cache")
+		err := os.MkdirAll(cacheDir, 0755)
+		require.NoError(t, err)
+
+		// Create a dummy cache file
+		testFile := filepath.Join(cacheDir, "test.apk")
+		err = os.WriteFile(testFile, []byte("dummy content"), 0644)
+		require.NoError(t, err)
+
+		// Run clean with dry-run
+		err = CleanImpl(ctx, cacheDir, true)
+		require.NoError(t, err)
+
+		// Verify cache still exists
+		_, err = os.Stat(cacheDir)
+		require.NoError(t, err)
+		_, err = os.Stat(testFile)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-existent cache directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "non-existent")
+
+		// Clean should not error on non-existent directory
+		err := CleanImpl(ctx, cacheDir, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("cache path is file not directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "file")
+		err := os.WriteFile(cacheFile, []byte("not a directory"), 0644)
+		require.NoError(t, err)
+
+		// Should error when cache path is a file
+		err = CleanImpl(ctx, cacheFile, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a directory")
+	})
+}
+
+func TestCalculateDirSize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create files with known sizes
+	files := map[string]int{
+		"file1.txt": 100,
+		"file2.txt": 200,
+		"subdir/file3.txt": 300,
+	}
+
+	totalSize := int64(0)
+	for path, size := range files {
+		fullPath := filepath.Join(tmpDir, path)
+		dir := filepath.Dir(fullPath)
+		err := os.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+
+		content := make([]byte, size)
+		err = os.WriteFile(fullPath, content, 0644)
+		require.NoError(t, err)
+		totalSize += int64(size)
+	}
+
+	// Calculate directory size
+	size, err := calculateDirSize(tmpDir)
+	require.NoError(t, err)
+	require.Equal(t, totalSize, size)
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{100, "100 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+		{1099511627776, "1.0 TB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatBytes(tt.bytes)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -62,6 +62,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(lock())
 	cmd.AddCommand(resolve())
 	cmd.AddCommand(installKeys())
+	cmd.AddCommand(cleanCmd())
 	cmd.AddCommand(version.Version())
 
 	cmd.PersistentFlags().StringVarP(&workDir, "workdir", "C", cwd, "working dir (default is current dir where executed)")


### PR DESCRIPTION
```
$ go run ./ clean --dry-run
2025/07/07 19:17:04 INFO Cleaning cache directory: /Users/jason/Library/Caches/dev.chainguard.go-apk
2025/07/07 19:17:04 INFO Cache size: 40.4 GB
2025/07/07 19:17:04 INFO Dry run mode: cache directory will not be deleted
```

```
$ go run ./ clean          
2025/07/07 19:17:12 INFO Cleaning cache directory: /Users/jason/Library/Caches/dev.chainguard.go-apk
2025/07/07 19:17:12 INFO Cache size: 40.4 GB
2025/07/07 19:17:16 INFO Cache directory cleaned successfully
```

```
$ go run ./ clean --dry-run
2025/07/07 19:17:17 INFO Cleaning cache directory: /Users/jason/Library/Caches/dev.chainguard.go-apk
2025/07/07 19:17:17 INFO Cache directory does not exist, nothing to clean
```