### PR TITLE
Hook up logger in spdx generation

### DIFF
--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -134,7 +134,7 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 		}
 
 		filename := filepath.Join(s.OutputDir, s.FileName+"."+gen.Ext())
-		if err := gen.Generate(&s, filename); err != nil {
+		if err := gen.Generate(ctx, &s, filename); err != nil {
 			return nil, fmt.Errorf("generating %s sbom: %w", format, err)
 		}
 		sboms = append(sboms, types.SBOM{

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -15,6 +15,8 @@
 package generator
 
 import (
+	"context"
+
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
@@ -24,7 +26,7 @@ import (
 type Generator interface {
 	Key() string
 	Ext() string
-	Generate(*options.Options, string) error
+	Generate(context.Context, *options.Options, string) error
 	GenerateIndex(*options.Options, string) error
 }
 

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -15,6 +15,7 @@
 package spdx
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,7 +25,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/charmbracelet/log"
+	"github.com/chainguard-dev/clog"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	purl "github.com/package-url/packageurl-go"
 	"sigs.k8s.io/release-utils/version"
@@ -81,7 +82,7 @@ func hashToString(h v1.Hash) string {
 }
 
 // Generate writes an SPDX SBOM in path
-func (sx *SPDX) Generate(opts *options.Options, path string) error {
+func (sx *SPDX) Generate(ctx context.Context, opts *options.Options, path string) error {
 	// The default document name makes no attempt to avoid
 	// clashes. Ensuring a unique name requires a digest
 	documentName := "sbom"
@@ -157,7 +158,7 @@ func (sx *SPDX) Generate(opts *options.Options, path string) error {
 			seenIDs[doc.Packages[i].ID] = struct{}{}
 			dedupedPackages = append(dedupedPackages, doc.Packages[i])
 		} else {
-			log.Info("duplicate package ID found in SBOM, deduplicating package...", "ID", doc.Packages[i].ID)
+			clog.FromContext(ctx).Info("duplicate package ID found in SBOM, deduplicating package...", "ID", doc.Packages[i].ID)
 		}
 	}
 	doc.Packages = dedupedPackages

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -69,7 +69,7 @@ func TestGenerate(t *testing.T) {
 	fsys := apkfs.NewMemFS()
 	sx := New(fsys)
 	path := filepath.Join(dir, testOpts.FileName+"."+sx.Ext())
-	err := sx.Generate(testOpts, path)
+	err := sx.Generate(t.Context(), testOpts, path)
 	require.NoError(t, err)
 	require.FileExists(t, path)
 }
@@ -208,7 +208,7 @@ func TestSPDX_Generate(t *testing.T) {
 			sx := New(fsys)
 			imageSBOMName := fmt.Sprintf("%s.spdx.json", tt.name)
 			imageSBOMDestPath := filepath.Join(t.TempDir(), imageSBOMName)
-			err = sx.Generate(tt.opts, imageSBOMDestPath)
+			err = sx.Generate(t.Context(), tt.opts, imageSBOMDestPath)
 			require.NoError(t, err)
 
 			actual, err := os.ReadFile(imageSBOMDestPath)
@@ -252,7 +252,7 @@ func TestReproducible(t *testing.T) {
 	d := [][]byte{}
 	for i := 0; i < 2; i++ {
 		path := filepath.Join(dir, fmt.Sprintf("sbom%d.%s", i, sx.Ext()))
-		require.NoError(t, sx.Generate(testOpts, path))
+		require.NoError(t, sx.Generate(t.Context(), testOpts, path))
 		require.FileExists(t, path)
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestValidateSPDX(t *testing.T) {
 	fsys := apkfs.NewMemFS()
 	sx := New(fsys)
 	path := filepath.Join(dir, testOpts.FileName+"."+sx.Ext())
-	err := sx.Generate(testOpts, path)
+	err := sx.Generate(t.Context(), testOpts, path)
 	require.NoError(t, err)
 	require.FileExists(t, path)
 	require.NoError(t, command.New(


### PR DESCRIPTION
Currently, SPDX generation uses a completely different logger than the rest of the process, causing context to not be present in the respective log lines.