### PR TITLE
Use contextualized loggers everywhere

### DIFF
--- a/internal/cli/build-cpio.go
+++ b/internal/cli/build-cpio.go
@@ -79,7 +79,7 @@ func BuildCPIOCmd(ctx context.Context, dest string, opts ...build.Option) error 
 	}
 	defer os.RemoveAll(wd)
 
-	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+	fs := apkfs.DirFS(ctx, wd, apkfs.WithCreateDir())
 	bc, err := build.New(ctx, fs, opts...)
 	if err != nil {
 		return err

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -253,8 +252,8 @@ func buildImageComponents(ctx context.Context, workDir string, archs []types.Arc
 			}
 
 			arch := types.ParseArchitecture(arch)
-			log := clog.New(slog.Default().Handler()).With("arch", arch.ToAPK())
-			ctx := clog.WithLogger(ctx, log)
+			log := log.With("arch", arch.ToAPK())
+			ctx = clog.WithLogger(ctx, log)
 
 			opts := slices.Clone(opts)
 			opts = append(opts, build.WithArch(arch), build.WithImageConfiguration(*ic))

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -129,7 +129,7 @@ func DotCmd(ctx context.Context, configFile string, archs []types.Architecture, 
 	wd = filepath.Join(wd, arch.ToAPK())
 	bopts := slices.Clone(opts)
 	bopts = append(bopts, build.WithArch(arch))
-	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+	fs := apkfs.DirFS(ctx, wd, apkfs.WithCreateDir())
 	bc, err := build.New(ctx, fs, bopts...)
 	if err != nil {
 		return err

--- a/internal/cli/install-keys.go
+++ b/internal/cli/install-keys.go
@@ -21,7 +21,7 @@ func installKeys() *cobra.Command {
 			ctx := cmd.Context()
 			log := clog.FromContext(ctx)
 
-			a, err := apk.New()
+			a, err := apk.New(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -172,13 +171,14 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 	// TODO: If the archs can't agree on package versions (e.g., arm builds are ahead of x86) then we should fail instead of producing inconsistent locks.
 	for _, arch := range archs {
 		arch := arch
-		log := clog.New(slog.Default().Handler()).With("arch", arch.ToAPK())
+
+		log := log.With("arch", arch.ToAPK())
 		ctx = clog.WithLogger(ctx, log)
 
 		// working directory for this architecture
 		wd := filepath.Join(wd, arch.ToAPK())
 		bopts := append(slices.Clone(opts), build.WithArch(arch))
-		fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+		fs := apkfs.DirFS(ctx, wd, apkfs.WithCreateDir())
 		bc, err := build.New(ctx, fs, bopts...)
 		if err != nil {
 			return err

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -71,7 +71,7 @@ func ShowConfigCmd(ctx context.Context, opts ...build.Option) error {
 	}
 	defer os.RemoveAll(wd)
 
-	fs := apkfs.DirFS(wd, apkfs.WithCreateDir())
+	fs := apkfs.DirFS(ctx, wd, apkfs.WithCreateDir())
 
 	bc, err := build.New(ctx, fs, opts...)
 	if err != nil {

--- a/pkg/apk/apk/common_test.go
+++ b/pkg/apk/apk/common_test.go
@@ -15,6 +15,7 @@ package apk
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/fs"
 	"net/http"
@@ -98,7 +99,7 @@ func testGetTestAPK() (*APK, apkfs.FullFS, error) {
 	}); walkErr != nil {
 		return nil, nil, walkErr
 	}
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(context.Background(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -85,7 +85,7 @@ type APK struct {
 	ByArch map[string]*APK
 }
 
-func New(options ...Option) (*APK, error) {
+func New(ctx context.Context, options ...Option) (*APK, error) {
 	opt := defaultOpts()
 	for _, o := range options {
 		if err := o(opt); err != nil {
@@ -95,13 +95,13 @@ func New(options ...Option) (*APK, error) {
 
 	if opt.fs == nil {
 		// This is expensive so we only want to do it if we aren't passed WithFS.
-		opt.fs = apkfs.DirFS("/")
+		opt.fs = apkfs.DirFS(ctx, "/")
 	}
 
 	client := retryablehttp.NewClient()
 
 	client.HTTPClient = &http.Client{Transport: opt.transport}
-	client.Logger = clog.FromContext(context.Background())
+	client.Logger = clog.FromContext(ctx)
 
 	return &APK{
 		client:             client.StandardClient(),

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -65,7 +65,7 @@ var (
 
 func TestInitDB(t *testing.T) {
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 	err = apk.InitDB(context.Background())
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestInitDB(t *testing.T) {
 
 func TestInitDB_ChainguardDiscovery(t *testing.T) {
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 
 	err = apk.InitDB(context.Background(), "https://apk.cgr.dev/chainguard")
@@ -149,7 +149,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("no lib", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("existing lib", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("existing lib apk", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("existing lib apk dirs", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("existing lib apk dir files", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("linked lib", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestResolveApkDB(t *testing.T) {
 
 	t.Run("linked lib apk", func(t *testing.T) {
 		src := apkfs.NewMemFS()
-		apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 		err = apk.InitDB(ctx)
 		require.NoError(t, err)
@@ -312,7 +312,7 @@ func TestResolveApkDB(t *testing.T) {
 func TestSetWorld(t *testing.T) {
 	ctx := context.Background()
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 	// for initialization
 	err = src.MkdirAll("etc/apk", 0o755)
@@ -335,7 +335,7 @@ func TestSetWorld(t *testing.T) {
 func TestSetWorldWithVersions(t *testing.T) {
 	ctx := context.Background()
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 	// for initialization
 	err = src.MkdirAll("etc/apk", 0o755)
@@ -358,7 +358,7 @@ func TestSetWorldWithVersions(t *testing.T) {
 func TestSetRepositories(t *testing.T) {
 	ctx := context.Background()
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 	// for initialization
 
@@ -380,7 +380,7 @@ func TestSetRepositories(t *testing.T) {
 func TestSetRepositories_Empty(t *testing.T) {
 	ctx := context.Background()
 	src := apkfs.NewMemFS()
-	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	apk, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 	// for initialization
 
@@ -394,7 +394,7 @@ func TestSetRepositories_Empty(t *testing.T) {
 
 func TestInitKeyring(t *testing.T) {
 	src := apkfs.NewMemFS()
-	a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	a, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err)
 
 	dir, err := os.MkdirTemp("", "go-apk")
@@ -462,7 +462,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("usr/lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /usr/lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
+			a, err := New(ctx, WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -477,7 +477,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("usr/lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /usr/lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
+			a, err := New(ctx, WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestLoadSystemKeyring(t *testing.T) {
 	t.Run("non-existent dir", func(t *testing.T) {
 		ctx := context.Background()
 		src := apkfs.NewMemFS()
-		a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		a, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 
 		// Read the empty dir, passing a non-existent location should err
@@ -503,7 +503,7 @@ func TestLoadSystemKeyring(t *testing.T) {
 	t.Run("empty dir", func(t *testing.T) {
 		ctx := context.Background()
 		src := apkfs.NewMemFS()
-		a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		a, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 		require.NoError(t, err)
 
 		// Read the empty dir, passing only one empty location should err
@@ -525,7 +525,7 @@ func TestLoadSystemKeyring(t *testing.T) {
 			ctx := context.Background()
 			arch := ArchToAPK(runtime.GOARCH)
 			src := apkfs.NewMemFS()
-			a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+			a, err := New(ctx, WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 			require.NoError(t, err)
 
 			// Write some dummy keyfiles in a random location
@@ -588,7 +588,7 @@ func TestFetchPackage(t *testing.T) {
 		if cache != "" {
 			opts = append(opts, WithCache(cache, false, NewCache(false)))
 		}
-		a, err := New(opts...)
+		a, err := New(ctx, opts...)
 		require.NoError(t, err, "unable to create APK")
 		err = a.InitDB(ctx)
 		require.NoError(t, err)
@@ -771,7 +771,7 @@ func TestAuth_good(t *testing.T) {
 	err := src.MkdirAll("usr/lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /usr/lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
+	a, err := New(ctx, WithFS(src), WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)
@@ -803,7 +803,7 @@ func TestAuth_bad(t *testing.T) {
 	err := src.MkdirAll("usr/lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /usr/lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
+	a, err := New(ctx, WithFS(src), WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -117,7 +117,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		if cache != "" {
 			opts = append(opts, WithCache(cache, false, NewCache(false)))
 		}
-		a, err := New(opts...)
+		a, err := New(t.Context(), opts...)
 		require.NoError(t, err, "unable to create APK")
 
 		// set a client so we use local testdata instead of heading out to the Internet each time
@@ -323,7 +323,7 @@ func TestIndexAuth_good(t *testing.T) {
 
 	ctx := context.Background()
 
-	a, err := New(WithFS(apkfs.NewMemFS()),
+	a, err := New(ctx, WithFS(apkfs.NewMemFS()),
 		WithArch("x86_64"),
 		WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
 	require.NoErrorf(t, err, "unable to create APK")
@@ -352,7 +352,7 @@ func TestIndexAuth_bad(t *testing.T) {
 
 	ctx := context.Background()
 
-	a, err := New(WithFS(apkfs.NewMemFS()),
+	a, err := New(ctx, WithFS(apkfs.NewMemFS()),
 		WithArch("x86_64"),
 		WithAuthenticator(auth.StaticAuth(host, "baduser", "badpass")))
 	require.NoErrorf(t, err, "unable to create APK")

--- a/pkg/apk/apk/world_test.go
+++ b/pkg/apk/apk/world_test.go
@@ -30,7 +30,7 @@ func TestGetWorld(t *testing.T) {
 	packages := []string{"package1", "package2", "package3"}
 	err = src.WriteFile(worldFilePath, []byte(strings.Join(packages, "\n")), 0o644)
 	require.NoError(t, err, "unable to write world file")
-	a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	a, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
 	require.NoError(t, err, "unable to create APK")
 	pkgs, err := a.GetWorld()
 	require.NoError(t, err, "unable to get world packages")

--- a/pkg/apk/auth/chainguard.go
+++ b/pkg/apk/auth/chainguard.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"chainguard.dev/sdk/sts"
+	"github.com/chainguard-dev/clog"
 	"golang.org/x/time/rate"
 	"google.golang.org/api/idtoken"
 )
@@ -54,7 +54,7 @@ func (a *cgAuth) AddAuth(ctx context.Context, req *http.Request) error {
 			a.cgerr = fmt.Errorf("creating token source: %w", err)
 			return
 		}
-		slog.Default().With("iss", a.iss, "aud", a.aud).Info("Exchanging GCP token for Chainguard identity " + a.id)
+		clog.FromContext(ctx).With("iss", a.iss, "aud", a.aud).Info("Exchanging GCP token for Chainguard identity " + a.id)
 		tok, err := ts.Token()
 		if err != nil {
 			a.cgerr = fmt.Errorf("getting token: %w", err)
@@ -114,7 +114,7 @@ func (k *k8sAuth) AddAuth(ctx context.Context, req *http.Request) error {
 			k.cgerr = fmt.Errorf("reading token: %w", err)
 			return
 		}
-		slog.Default().With("iss", k.iss, "aud", k.aud).Info("Exchanging K8s token for Chainguard identity " + k.id)
+		clog.FromContext(ctx).With("iss", k.iss, "aud", k.aud).Info("Exchanging K8s token for Chainguard identity " + k.id)
 		ctok, err := sts.ExchangePair(ctx, k.iss, k.aud, string(b), sts.WithIdentity(k.id))
 		if err != nil {
 			k.cgerr = fmt.Errorf("exchanging token: %w", err)

--- a/pkg/apk/fs/rwosfs_test.go
+++ b/pkg/apk/fs/rwosfs_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestEmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	fs := DirFS(dir)
+	fs := DirFS(t.Context(), dir)
 	require.NotNil(t, fs, "fs should be created")
 }
 
@@ -57,7 +57,7 @@ func TestExistingDir(t *testing.T) {
 		}
 	}
 
-	fs := DirFS(dir)
+	fs := DirFS(t.Context(), dir)
 	require.NotNil(t, fs, "fs should be created")
 
 	for _, f := range files {
@@ -72,7 +72,7 @@ func TestExistingDir(t *testing.T) {
 
 func TestMissingDir(t *testing.T) {
 	dir := t.TempDir()
-	fs := DirFS(dir)
+	fs := DirFS(t.Context(), dir)
 	require.NotNil(t, fs, "fs should be created")
 	err := fs.WriteFile("foo/bar/world", []byte("world"), 0o600)
 	require.Error(t, err, "expected error writing file foo/bar/world when foo/bar dir does not exist")
@@ -98,7 +98,7 @@ func TestCaseInsensitive(t *testing.T) {
 
 	dir := t.TempDir()
 	// force underlying filesystem to be treated as case insensitive
-	fs := DirFS(dir, DirFSWithCaseSensitive(false))
+	fs := DirFS(t.Context(), dir, DirFSWithCaseSensitive(false))
 	require.NotNil(t, fs, "fs should be created")
 
 	// create the files in the fs
@@ -142,7 +142,7 @@ func TestCaseInsensitive(t *testing.T) {
 func TestDirFSConsistentOrdering(t *testing.T) {
 	dir := t.TempDir()
 	// force underlying filesystem to be treated as case insensitive
-	fsys := DirFS(dir)
+	fsys := DirFS(t.Context(), dir)
 	entries := []testDirEntry{
 		{"dir1", 0o777, true, nil},
 		{"dir1/subdir1", 0o777, true, nil},

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -319,7 +319,7 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		apkOpts = append(apkOpts, apk.WithNoSignatureIndexes(bc.baseimg.APKIndexPath()))
 	}
 
-	apkImpl, err := apk.New(apkOpts...)
+	apkImpl, err := apk.New(ctx, apkOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -74,7 +73,7 @@ func newSBOM(ctx context.Context, fsys apkfs.FullFS, o options.Options, ic types
 }
 
 func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architecture, img v1.Image) ([]types.SBOM, error) {
-	log := clog.New(slog.Default().Handler()).With("arch", arch.ToAPK())
+	log := clog.FromContext(ctx).With("arch", arch.ToAPK())
 	ctx = clog.WithLogger(ctx, log)
 
 	_, span := otel.Tracer("apko").Start(ctx, "GenerateImageSBOM")

--- a/pkg/passwd/group_test.go
+++ b/pkg/passwd/group_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestGroupParser(t *testing.T) {
-	fsys := apkfs.DirFS("testdata")
+	fsys := apkfs.DirFS(t.Context(), "testdata")
 	gf, err := ReadOrCreateGroupFile(fsys, "group")
 	require.NoError(t, err)
 
@@ -40,7 +40,7 @@ func TestGroupParser(t *testing.T) {
 }
 
 func TestGroupWriter(t *testing.T) {
-	fsys := apkfs.DirFS("testdata")
+	fsys := apkfs.DirFS(t.Context(), "testdata")
 	gf, err := ReadOrCreateGroupFile(fsys, "group")
 	require.NoError(t, err)
 


### PR DESCRIPTION
This drops all references to default handlers except for the very top-level entrypoints and instead uses loggers from context everywhere throughout the stack. This ensures the respective context that might be carried through is present on all the log lines appropriately.