### PR TITLE
Write a partial installed db to every layer

### DIFF
--- a/docs/layering.md
+++ b/docs/layering.md
@@ -376,3 +376,11 @@ Because layers are tarballs, there's no cheap mechanism to overwrite _just_ file
 We'd have to overwrite the entire thing, which doesn't feel worth doing.
 
 Luckily, these kinds of path mutations aren't that common, just be aware that modifying permissions of a file in one image may mean it won't see any deduplication with similar layers in other images without said modifications.
+
+### usr/lib/apk/db/installed
+
+In order to associate files with packages, security scanners look at `usr/lib/apk/db/installed` (or "idb" for _installed database_).
+We've run into some scanners that look at each layer individually rather than the entire filesystem.
+For those scanners, having all of our operating system metadata files (including this idb file) in the top layer violated some of their assumptions around valid layers.
+In order to avoid breaking those scanners, we duplicate relevant portions of the idb file in each package-ful layer.
+These files are small relative to the size of most packages, so it doesn't cost much to do this for broader compatibility with security scanners.

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -167,7 +167,7 @@ func TestPublishLayering(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the image.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	want := "sha256:d5fe88a41005bc378fc42d3066d4762b2c082e528cd2856e27f4e005031bfd35"
+	want := "sha256:88a8065a9ccb964f27ca842a3e297e152997ddae2997fe68ae7535653c1ebc46"
 	require.Equal(t, want, digest.String())
 
 	im, err := idx.IndexManifest()

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -85,7 +85,7 @@ func TestAddInstalledPackage(t *testing.T) {
 		}}, // should generate extra a: perms line
 	}
 	// AddInstalledPackage(pkg *Package, files []tar.Header) error
-	err = a.AddInstalledPackage(newPkg, newFiles)
+	_, err = a.AddInstalledPackage(newPkg, newFiles)
 	require.NoErrorf(t, err, "unable to add installed package: %v", err)
 	// check that the new packages were added
 	pkgs, err := a.GetInstalled()

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -130,7 +130,7 @@ func newLayerWriter(out *os.File) *layerWriter {
 	}
 }
 
-func (bc *Context) buildImage(ctx context.Context) ([]*apk.Package, error) {
+func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) {
 	log := clog.FromContext(ctx)
 
 	// When using base image for the build, apko adds new layer on top of the base. This means
@@ -141,7 +141,7 @@ func (bc *Context) buildImage(ctx context.Context) ([]*apk.Package, error) {
 		// Index for loop to make golang-ci happy.
 		// See https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
 		for index := range basePkgs {
-			err := bc.apk.AddInstalledPackage(&basePkgs[index].Package, basePkgs[index].Files)
+			_, err := bc.apk.AddInstalledPackage(&basePkgs[index].Package, basePkgs[index].Files)
 			if err != nil {
 				return nil, err
 			}
@@ -149,7 +149,7 @@ func (bc *Context) buildImage(ctx context.Context) ([]*apk.Package, error) {
 	}
 
 	var (
-		pkgs []*apk.Package
+		pkgs []apk.InstalledDiff
 		err  error
 	)
 	if bc.o.Lockfile != "" {

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -16,6 +16,7 @@ package build
 
 import (
 	"archive/tar"
+	"bytes"
 	"cmp"
 	"context"
 	"fmt"
@@ -44,9 +45,16 @@ func (bc *Context) buildLayers(ctx context.Context) ([]v1.Layer, error) {
 	}
 
 	// Build a single fs.FS, the normal way (this writes to bc.fs).
-	pkgs, err := bc.buildImage(ctx)
+	diffs, err := bc.buildImage(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("building filesystem: %w", err)
+	}
+
+	pkgs := make([]*apk.Package, 0, len(diffs))
+	pkgToDiff := map[*apk.Package][]byte{}
+	for _, pkgDiff := range diffs {
+		pkgs = append(pkgs, pkgDiff.Package)
+		pkgToDiff[pkgDiff.Package] = pkgDiff.Diff
 	}
 
 	// We don't pass around repositories cleanly between apko and the library
@@ -77,7 +85,7 @@ func (bc *Context) buildLayers(ctx context.Context) ([]v1.Layer, error) {
 	}
 
 	// Then partition that single fs.FS into multiple layers based on our layering strategy.
-	return splitLayers(ctx, bc.fs, groups, bc.o.TempDir())
+	return splitLayers(ctx, bc.fs, groups, pkgToDiff, bc.o.TempDir())
 }
 
 func replacesGroup(rep string, g *group) (bool, error) {
@@ -245,7 +253,7 @@ func merge(groups ...*group) *group {
 	return merged
 }
 
-func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, tmpdir string) ([]v1.Layer, error) {
+func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, pkgToDiff map[*apk.Package][]byte, tmpdir string) ([]v1.Layer, error) {
 	buf := make([]byte, 1<<20)
 
 	// We'll create a writer for each layer and a map to quickly access the writer given a package or group.
@@ -275,6 +283,10 @@ func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, tmpdir
 	defer f.Close()
 
 	top := newLayerWriter(f)
+
+	// We want to match the file info from the top layer's idb file below,
+	// so when we run into it, just stash it for later.
+	var idb tar.Header
 
 	// In a tar file, it is customary to include directories before files in those directories.
 	// In order to know which directories we need to include, we maintain a directory stack for each layer.
@@ -369,12 +381,38 @@ func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, tmpdir
 				return nil, fmt.Errorf("closing %s: %w", f.path, err)
 			}
 		}
+
+		if f.header.Name == "usr/lib/apk/db/installed" {
+			idb = *f.header
+		}
 	}
 
 	// Once we're done walking the FS, we need to finalize each layer...
 	layers := make([]v1.Layer, 0, len(groups)+1)
 	for i, g := range groups {
 		w := groupToWriter[g]
+
+		// Add a partial installed db to satisfy scanners.
+		{
+			var buf bytes.Buffer
+			for _, pkg := range g.pkgs {
+				if _, err := buf.Write(pkgToDiff[pkg]); err != nil {
+					return nil, err
+				}
+			}
+
+			// Only the size should be different across layers.
+			idb.Size = int64(buf.Len())
+
+			if err := w.w.WriteHeader(&idb); err != nil {
+				return nil, err
+			}
+
+			if _, err := io.Copy(w.w, &buf); err != nil {
+				return nil, err
+			}
+		}
+
 		l, err := w.finalize()
 		if err != nil {
 			return nil, fmt.Errorf("finalizing group[%d] layer: %w", i, err)


### PR DESCRIPTION
Some scanners operate on a per-layer basis, so having our installed database only exist in the top-most layer leads to false positives.

By including the portion of the installed db that is relevant to each layer, we can appease those scanners at the cost of a small amount of duplication in each layer. I don't love this, but it's an option.