### PR TITLE
Use /usr/bin/s6-svscan if it exists

### DIFF
--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -251,6 +251,9 @@ func (ic *ImageConfiguration) Validate() error {
 // a service bundle.
 func (ic *ImageConfiguration) ValidateServiceBundle() error {
 	ic.Entrypoint.Command = "/bin/s6-svscan /sv"
+	if _, err := os.Stat("/usr/bin/s6-svscan"); err == nil {
+		ic.Entrypoint.Command = "/usr/bin/s6-svscan /sv"
+	}
 
 	// It's harmless to have a duplicate entry in /etc/apk/world,
 	// apk will fix it up when the fixate op happens.

--- a/pkg/s6/supervision_tree.go
+++ b/pkg/s6/supervision_tree.go
@@ -33,7 +33,7 @@ func (sc *Context) WriteSupervisionTree(ctx context.Context, services Services) 
 			return fmt.Errorf("could not make supervision directory: %w", err)
 		}
 
-		if err := sc.fs.WriteFile(filepath.Join(svcdir, "run"), fmt.Appendf(nil, "#!/bin/execlineb\n%s\n", svccmd), 0755); err != nil {
+		if err := sc.fs.WriteFile(filepath.Join(svcdir, "run"), fmt.Appendf(nil, "#!/usr/bin/execlineb\n%s\n", svccmd), 0755); err != nil {
 			return fmt.Errorf("could not write runfile: %w", err)
 		}
 	}


### PR DESCRIPTION
/bin/s6-svscan has been moved to `/usr/bin/s6-svscan` since Alpine 3.21  which results in errors when trying to run containers using service bundles with any repos after 3.20 

```
Error: crun: executable file `/bin/s6-svscan` not found: No such file or directory: OCI runtime attempted to invoke a command that was not found
```

If I set the alpine main repository to 3.20 it fixes the issue, however version mixing is unsupported