### PR TITLE
fix: lower DirFS' new file permissions

### DIFF
--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -352,7 +352,7 @@ func (f *dirFS) Create(name string) (File, error) {
 	if f.createOnDisk(name) {
 		// close the memory one
 		_ = file.Close()
-		file, err = os.Create(filepath.Join(f.base, name))
+		file, err = os.OpenFile(filepath.Join(f.base, name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Explanation

Lower permissions of newly created file. 
- [os.Create](https://pkg.go.dev/os#Create) creates a file with `0666` permissions. This update lowers permission to `0644`
- DirFS is used to create files in APKs (by melange) and the image. If SBOMs are created using DirFS, they are world editable which violates compliance standards.