### PR TITLE
fix: /etc/ld.so.cache file permissions

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -257,6 +257,9 @@ func updateCache(ctx context.Context, fsys apkfs.FullFS) error {
 	if err := cacheFile.Write(lsc); err != nil {
 		return fmt.Errorf("writing /etc/ld.so.cache: %w", err)
 	}
+	if err := fsys.Chmod("etc/ld.so.cache", 0644); err != nil {
+		return fmt.Errorf("chmod /etc/ld.so.cache: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
`/etc/ld.so.cache` is created with `os.Create` internally which creates a file with `0666` permissions ([dag](https://oci.dag.dev/fs/cgr.dev/chainguard/bash@sha256:b53e7f70cc3ac51b9c2a52fc4bfeb264ca6a560919a3e8228639e6890247196d/etc/))
```bash
-rw-rw-rw- 0/0            6528 1970-01-01 00:00 ld.so.cache
```

This PR lowers the permission of file to `0644` 