### PR TITLE
Fix OPERATING-SYSTEM primaryPackagePurpose

### DIFF
--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -63,7 +63,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: Replaces",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -63,7 +63,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: Replaces",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-pretend-baselayout-1.0.0-r0",

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -637,7 +637,7 @@ func addOperatingSystem(doc *Document, opts *options.Options) {
 		FilesAnalyzed:    false,
 		Description:      "Operating System",
 		DownloadLocation: NOASSERTION,
-		PrimaryPurpose:   "OPERATING-SYSTEM",
+		PrimaryPurpose:   "OPERATING_SYSTEM",
 	}
 
 	doc.Packages = append(doc.Packages, osPackage)

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
@@ -40,7 +40,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: unknown",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-font-ubuntu-0.869-r1",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
@@ -40,7 +40,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: Apko Images, Plc",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-libattr1-2.5.1-r2",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
@@ -40,7 +40,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: unknown",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-logstash-8-8.15.3-r4",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
@@ -40,7 +40,7 @@
       "description": "Operating System",
       "downloadLocation": "NOASSERTION",
       "supplier": "Organization: unknown",
-      "primaryPackagePurpose": "OPERATING-SYSTEM"
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
     },
     {
       "SPDXID": "SPDXRef-Package-unbound-libs-1.23.0-r0",


### PR DESCRIPTION
I've found a couple places that expect OPERATING-SYSTEM and a couple others that expect OPERATING_SYSTEM. Our own CI checks are failing with OPERATING-SYSTEM, so I'm going to go underscore for now.

We will probably need to fix this again later.