### PR TITLE
Use an LRU cache for indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.13.0
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -154,7 +154,7 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			entry, ok = i.indexes.Get(key)
 			if ok {
 				// If there is an entry now, there was a race to the Get above. We can just return now.
-				i.indexesMux.Lock()
+				i.indexesMux.Unlock()
 				return entry()
 			}
 


### PR DESCRIPTION
For the index cache (which is always global currently), we don't set an upper bound as to how many indexes can be cached. That's likely benign in local cases but causes an arbitray amount of memory to be consumed if used as a service. This introduces an LRU cache instead, which can be configured using APKO_INDEX_CACHE_SIZE.

I think this also fixes a race in the existing implementation where we'd leak indexes with outdated etags if two HEAD requests would race outside of the critical section of adjusting the etag pointers.