### PR TITLE
Close response from index HEAD request

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - asciicheck
+    - bodyclose
     - errorlint
     - forbidigo
     - gocritic

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -135,6 +135,7 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		if err != nil {
 			return nil, err
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)


### PR DESCRIPTION
This was likely just an oversight. Enabling the respective linter as well to catch issues like these in the future.