### PR TITLE
chore(typos): fix typos in comments and documentation

### DIFF
--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -74,7 +74,7 @@ func showPackages() *cobra.Command {
 		Use:   "show-packages",
 		Short: "Show the packages and versions that would be installed by a configuration",
 		Long: `Show the packages and versions that would be installed by a configuration.
-The result is identical to the first stages of a build, but does not actuall install anything.
+The result is identical to the first stages of a build, but does not actually install anything.
 
 The output is one of several pre-defined formats, or can be customized to any go template, using
 the provided vars. See https://pkg.go.dev/text/template for more information. Available vars are

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -420,7 +420,7 @@ func (p *PkgResolver) pick(pkg *RepositoryPackage) error {
 func (p *PkgResolver) disqualify(dq map[*RepositoryPackage]string, pkg *RepositoryPackage, reason string) {
 	dq[pkg] = reason
 
-	// TODO: Ripple up and disqualify anything that is no longer solveable.
+	// TODO: Ripple up and disqualify anything that is no longer solvable.
 }
 
 // constrain looks through a list of constraints and disqualifies anything that would
@@ -518,7 +518,7 @@ func (p *PkgResolver) GetPackagesWithDependencies(ctx context.Context, packages 
 		// do not add it to toInstall, as we want to have it in the correct order with dependencies
 		dependenciesMap[pkg.Name] = pkg
 
-		// Remove it from contraints.
+		// Remove it from constraints.
 		constraints = slices.DeleteFunc(constraints, func(s string) bool {
 			return s == next
 		})
@@ -788,7 +788,7 @@ func (p *PkgResolver) getPackageDependencies(ctx context.Context, pkg *Repositor
 				}
 
 				// See if any virtual packages of packages we've already
-				// selected satisfy this contraint.
+				// selected satisfy this constraint.
 				satisfiedByProvide := false
 				for _, provide := range picked.Provides {
 					prostraint := cachedResolvePackageNameVersionPin(provide)

--- a/pkg/apk/apk/repository.go
+++ b/pkg/apk/apk/repository.go
@@ -60,12 +60,12 @@ func (r *RepositoryWithIndex) Packages() []*RepositoryPackage {
 	return r.pkgs
 }
 
-// Count returns the amout of packages that are available in this repository
+// Count returns the amount of packages that are available in this repository
 func (r *RepositoryWithIndex) Count() int {
 	return len(r.index.Packages)
 }
 
-// RepoAbbr returns a short name of this repository consiting of the repo name
+// RepoAbbr returns a short name of this repository consisting of the repo name
 // and the architecture.
 func (r *RepositoryWithIndex) RepoAbbr() string {
 	parts := strings.Split(r.URI, "/")

--- a/pkg/build/accounts_test.go
+++ b/pkg/build/accounts_test.go
@@ -36,7 +36,7 @@ func Test_userToUserEntry_UID_GID_mapping(t *testing.T) {
 		expectedGID uint32
 	}{
 		{
-			desc: "Unique GID gets propogated",
+			desc: "Unique GID gets propagated",
 			user: types.User{
 				UID: id1234,
 				GID: id1235T,

--- a/pkg/build/lock.go
+++ b/pkg/build/lock.go
@@ -167,7 +167,7 @@ func unify(originals []string, inputs []resolved) (map[string][]string, map[stri
 		pinned := ""
 
 		// The function we want from go-apk is private, but these are all the
-		// special characters that delimit the package name from the cosntraint
+		// special characters that delimit the package name from the constraint
 		// so lop off the package name and stick the rest of the constraint into
 		// the versions map.
 		if idx := strings.IndexAny(orig, "=<>~"); idx >= 0 {

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -229,7 +229,7 @@ func GenerateIndexSBOM(ctx context.Context, o options.Options, ic types.ImageCon
 
 	s.ImageInfo.IndexMediaType = ggcrtypes.OCIImageIndex
 
-	// Make sure we have a determinstic for iterating over imgs.
+	// Make sure we have a deterministic for iterating over imgs.
 	archs := make([]types.Architecture, 0, len(imgs))
 	for arch := range imgs {
 		archs = append(archs, arch)

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -100,7 +100,7 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Optional: Envionment variables to set in the container image"
+          "description": "Optional: Environment variables to set in the container image"
         },
         "paths": {
           "items": {

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -170,7 +170,7 @@ type ImageConfiguration struct {
 	//
 	// The list of supported architectures is: 386, amd64, arm64, arm/v6, arm/v7, ppc64le, riscv64, s390x, loong64
 	Archs []Architecture `json:"archs,omitempty" yaml:"archs,omitempty"`
-	// Optional: Envionment variables to set in the container image
+	// Optional: Environment variables to set in the container image
 	Environment map[string]string `json:"environment,omitempty" yaml:"environment,omitempty"`
 	// Optional: List of paths mutations
 	Paths []PathMutation `json:"paths,omitempty" yaml:"paths,omitempty"`

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -113,7 +113,7 @@ func Test_YAML_Unmarshalling_UID_GID_mapping(t *testing.T) {
 		rawYAML     string
 	}{
 		{
-			desc:        "Unique GID gets propogated",
+			desc:        "Unique GID gets propagated",
 			expectedUID: id1234,
 			expectedGID: id1235T,
 			rawYAML: `

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -58,7 +58,7 @@ func AdvertiseCachedFile(src, dst string) error {
 	// Create the symlink.
 	if err := os.Symlink(rel, dst); err != nil {
 		// Ignore already exists errors. We don't even want to do clean up here even when
-		// the symlink is pointing somewhere elese, to avoid relying too much on file system
+		// the symlink is pointing somewhere else, to avoid relying too much on file system
 		// remantics/eventual consistency, etc.
 		if errors.Is(err, os.ErrExist) {
 			return nil

--- a/pkg/sbom/options/options_test.go
+++ b/pkg/sbom/options/options_test.go
@@ -33,7 +33,7 @@ func TestPurlQualifierString(t *testing.T) {
 			"mediaType=application%2Fvnd.oci.image.index.v1%2Bjson",
 		},
 		{
-			// Mutiple value pairs
+			// Multiple value pairs
 			PurlQualifiers{
 				"arch":      "386",
 				"mediaType": "application/vnd.oci.image.manifest.v1+json",


### PR DESCRIPTION
Fixed some typos using [`typos`](https://github.com/crate-ci/typos/)