### PR TITLE
fix: ensure parent directory exists in layer tar for installed DB

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -167,7 +167,7 @@ func TestPublishLayering(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the image.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	want := "sha256:88a8065a9ccb964f27ca842a3e297e152997ddae2997fe68ae7535653c1ebc46"
+	want := "sha256:c810e0f261d12cbb26e473f766f48b3ce44208cf6dd8fcaf62297f6e01dff80b"
 	require.Equal(t, want, digest.String())
 
 	im, err := idx.IndexManifest()

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -404,7 +404,7 @@ func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, pkgToD
 
 			// Ensure parent directory exists in the tar.
 			if err := w.w.WriteHeader(&tar.Header{
-				Name:     filepath.Dir(idb.Name),
+				Name:     path.Dir(idb.Name),
 				Typeflag: tar.TypeDir,
 				Mode:     idb.Mode,
 				ModTime:  idb.ModTime,

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 
 	"chainguard.dev/apko/pkg/apk/apk"
@@ -399,6 +400,16 @@ func splitLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, pkgToD
 				if _, err := buf.Write(pkgToDiff[pkg]); err != nil {
 					return nil, err
 				}
+			}
+
+			// Ensure parent directory exists in the tar.
+			if err := w.w.WriteHeader(&tar.Header{
+				Name:     filepath.Dir(idb.Name),
+				Typeflag: tar.TypeDir,
+				Mode:     idb.Mode,
+				ModTime:  idb.ModTime,
+			}); err != nil {
+				return nil, fmt.Errorf("writing header for usr/lib/apk/db/: %w", err)
 			}
 
 			// Only the size should be different across layers.

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -24,7 +24,6 @@ import (
 	"maps"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 
 	"chainguard.dev/apko/pkg/apk/apk"

--- a/pkg/build/layers_test.go
+++ b/pkg/build/layers_test.go
@@ -238,7 +238,7 @@ func TestSplitLayersDirectoryCreation(t *testing.T) {
 	if err := fsys.MkdirAll("usr/lib/apk/db", 0755); err != nil {
 		t.Fatalf("failed to create parent directories: %v", err)
 	}
-	
+
 	// Create the installed DB file with some content
 	idbContent := []byte("test db content")
 	if err := fsys.WriteFile("usr/lib/apk/db/installed", idbContent, 0644); err != nil {
@@ -351,7 +351,7 @@ func TestSplitLayersDirectoryCreation(t *testing.T) {
 
 		// The critical test: in a valid tar, directories must come before files
 		// If the directory creation code is missing, the tar will be malformed
-		var dirIndex, fileIndex int = -1, -1
+		var dirIndex, fileIndex = -1, -1
 		for j, entry := range entries {
 			if entry == "usr/lib/apk/db" {
 				dirIndex = j


### PR DESCRIPTION
## Summary
- Fix issue where parent directory `usr/lib/apk/db` was not explicitly created in multi-layer tar before writing the installed DB file
- Add regression test to verify proper directory and file creation in each package layer
- Ensure tar structure follows proper ordering (directories before files)

## Test plan
- [x] Added `TestSplitLayersDirectoryCreation` test that validates the fix
- [x] Test fails when directory creation code is removed (regression protection)
- [x] Test passes with the fix in place
- [x] All existing layer tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)