### PR TITLE
fix(publish): local tags

### DIFF
--- a/pkg/build/oci/publish.go
+++ b/pkg/build/oci/publish.go
@@ -53,7 +53,7 @@ func LoadImage(ctx context.Context, image v1.Image, tags []string) (name.Referen
 		if err != nil {
 			return name.Digest{}, err
 		}
-		if !strings.HasPrefix(localSrcTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
+		if !strings.HasPrefix(localDstTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
 			log.Infof("tagging local image %s as %s", localSrcTag.Name(), localDstTag.Name())
 			if err := daemon.Tag(localSrcTag, localDstTag, daemon.WithContext(ctx)); err != nil {
 				return name.Digest{}, err


### PR DESCRIPTION
local tagging doesn't work because the tag used to check is incorrect. The condition is always false, because the src tag always contains the LocalDomain.