### PR TITLE
DirFS implementations: make Create() default to safer permissions

### DIFF
--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -392,7 +392,9 @@ func (m *memFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
 }
 
 func (m *memFS) Create(name string) (File, error) {
-	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o666)
+	// we are not honoring umask here, so choose a safer default than
+	// 0o666 used by os.Create()
+	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 }
 
 func (m *memFS) Symlink(oldname, newname string) error {

--- a/pkg/apk/fs/memfs_test.go
+++ b/pkg/apk/fs/memfs_test.go
@@ -450,3 +450,16 @@ func TestMemFSConsistentOrdering(t *testing.T) {
 	}
 	// all results should be the same
 }
+func TestMemFSCreate(t *testing.T) {
+	var (
+		m   = NewMemFS()
+		err error
+	)
+	fd, err := m.Create("testfile")
+	require.NoError(t, err)
+	defer fd.Close()
+
+	fileInfo, err := fd.Stat()
+	require.NoError(t, err)
+	require.Equal(t, fileInfo.Mode(), fs.FileMode(0o644))
+}

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -662,7 +662,9 @@ func (m *memFS) Chtimes(path string, atime time.Time, mtime time.Time) error {
 }
 
 func (m *memFS) Create(name string) (apkfs.File, error) {
-	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o666)
+	// we are not honoring umask here, so choose a safer default than
+	// 0o666 used by os.Create()
+	return m.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 }
 
 func (m *memFS) Symlink(oldname, newname string) error {

--- a/pkg/tarfs/fs_test.go
+++ b/pkg/tarfs/fs_test.go
@@ -19,8 +19,11 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"io/fs"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"chainguard.dev/apko/pkg/apk/apk"
 
@@ -155,4 +158,17 @@ func TestTarFS(t *testing.T) {
 			t.Errorf("readlink: want %q, got %q", want, got)
 		}
 	}
+}
+
+func TestTarFSCreate(t *testing.T) {
+	var (
+		tfs = tarfs.New()
+		err error
+	)
+	fd, err := tfs.Create("testfile")
+	require.NoError(t, err)
+
+	fileInfo, err := fd.Stat()
+	require.NoError(t, err)
+	require.Equal(t, fileInfo.Mode(), fs.FileMode(0o644))
 }


### PR DESCRIPTION
The unsafe defaults for apko's DirFS implementations were the root cause for the ld.so.cache mode 0o666 issue. Unlike os.Create(), these implementations generally don't honor umask(), so make them have safer defaults, and require that things that need less restrictive permissions change them after the fact.

v2: add testcase for MemFS
v2: add testcase for TarFS