### PR TITLE
Revert "Add support for runtime-only repositories"

### DIFF
--- a/internal/cli/build-cpio.go
+++ b/internal/cli/build-cpio.go
@@ -36,7 +36,7 @@ func buildCPIO() *cobra.Command {
 	var sbomPath string
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 
 	cmd := &cobra.Command{
@@ -51,7 +51,7 @@ func buildCPIO() *cobra.Command {
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithExtraPackages(extraPackages),
 				build.WithBuildDate(buildDate),
 				build.WithSBOM(sbomPath),
@@ -65,7 +65,7 @@ func buildCPIO() *cobra.Command {
 	cmd.Flags().StringVar(&sbomPath, "sbom-path", "", "generate an SBOM")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 
 	return cmd

--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -36,7 +36,7 @@ func buildMinirootFS() *cobra.Command {
 	var ignoreSignatures bool
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 
 	cmd := &cobra.Command{
@@ -50,7 +50,7 @@ func buildMinirootFS() *cobra.Command {
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithExtraPackages(extraPackages),
 				build.WithTarball(args[1]),
 				build.WithBuildDate(buildDate),
@@ -67,7 +67,7 @@ func buildMinirootFS() *cobra.Command {
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 
 	return cmd

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -50,7 +50,7 @@ func buildCmd() *cobra.Command {
 	var sbomFormats []string
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 	var rawAnnotations []string
 	var cacheDir string
@@ -105,7 +105,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithSBOMFormats(sbomFormats),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithExtraPackages(extraPackages),
 				build.WithTags(args[1]),
 				build.WithVCS(withVCS),
@@ -127,7 +127,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -43,7 +43,7 @@ import (
 func dotcmd() *cobra.Command {
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var archstrs []string
 	var web, span bool
 	var cacheDir string
@@ -71,7 +71,7 @@ apko dot --web -S example.yaml
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
@@ -79,7 +79,7 @@ apko dot --web -S example.yaml
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().BoolVarP(&span, "spanning-tree", "S", false, "does something like a spanning tree to avoid a huge number of edges")
 	cmd.Flags().BoolVar(&web, "web", false, "launch a browser")

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -64,7 +64,7 @@ func RemoveLabel(s string) (string, error) {
 func lockInternal(cmdName string, extension string, deprecated string) *cobra.Command {
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var archstrs []string
 	var output string
 	var includePaths []string
@@ -93,7 +93,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 					build.WithConfig(args[0], includePaths),
 					build.WithExtraKeys(extraKeys),
 					build.WithExtraBuildRepos(extraBuildRepos),
-					build.WithExtraRepos(extraRepos),
+					build.WithExtraRuntimeRepos(extraRuntimeRepos),
 					build.WithIncludePaths(includePaths),
 					build.WithIgnoreSignatures(ignoreSignatures),
 					build.WithCache(cacheDir, false, apk.NewCache(true)),
@@ -104,7 +104,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringVar(&output, "output", "", "path to file where lock file will be written")
 	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append")
@@ -157,7 +157,6 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 			Packages:            make([]pkglock.LockPkg, 0, len(ic.Contents.Packages)),
 			BuildRepositories:   make([]pkglock.LockRepo, 0, len(ic.Contents.BuildRepositories)),
 			RuntimeRepositories: make([]pkglock.LockRepo, 0, len(ic.Contents.RuntimeRepositories)),
-			Repositories:        make([]pkglock.LockRepo, 0, len(ic.Contents.Repositories)),
 			Keyrings:            make([]pkglock.LockKeyring, 0, len(ic.Contents.Keyring)),
 		},
 	}
@@ -217,45 +216,39 @@ func LockCmd(ctx context.Context, output string, archs []types.Architecture, opt
 			lock.Contents.Packages = append(lock.Contents.Packages, lockPkg)
 		}
 		for _, repositoryURI := range ic.Contents.BuildRepositories {
-			repoLock, err := repoLock(repositoryURI, arch)
+			repo := apk.Repository{URI: fmt.Sprintf("%s/%s", repositoryURI, arch.ToAPK())}
+			name, err := RemoveLabel(stripURLScheme(repo.URI))
 			if err != nil {
-				return fmt.Errorf("locking build repositories: %w", err)
+				return fmt.Errorf("failed to remove label from repository URI: %w", err)
 			}
-			lock.Contents.BuildRepositories = append(lock.Contents.BuildRepositories, repoLock)
+			url, err := RemoveLabel(repo.IndexURI())
+			if err != nil {
+				return fmt.Errorf("failed to remove label from repository index URI: %w", err)
+			}
+			lock.Contents.BuildRepositories = append(lock.Contents.BuildRepositories, pkglock.LockRepo{
+				Name:         name,
+				URL:          url,
+				Architecture: arch.ToAPK(),
+			})
 		}
 		for _, repositoryURI := range ic.Contents.RuntimeRepositories {
-			repoLock, err := repoLock(repositoryURI, arch)
+			repo := apk.Repository{URI: fmt.Sprintf("%s/%s", repositoryURI, arch.ToAPK())}
+			name, err := RemoveLabel(stripURLScheme(repo.URI))
 			if err != nil {
-				return fmt.Errorf("locking runtime repositories: %w", err)
+				return fmt.Errorf("failed to remove label from repository URI: %w", err)
 			}
-			lock.Contents.RuntimeRepositories = append(lock.Contents.RuntimeRepositories, repoLock)
-		}
-		for _, repositoryURI := range ic.Contents.Repositories {
-			repoLock, err := repoLock(repositoryURI, arch)
+			url, err := RemoveLabel(repo.IndexURI())
 			if err != nil {
-				return fmt.Errorf("locking repositories: %w", err)
+				return fmt.Errorf("failed to remove label from repository index URI: %w", err)
 			}
-			lock.Contents.Repositories = append(lock.Contents.Repositories, repoLock)
+			lock.Contents.RuntimeRepositories = append(lock.Contents.RuntimeRepositories, pkglock.LockRepo{
+				Name:         name,
+				URL:          url,
+				Architecture: arch.ToAPK(),
+			})
 		}
 	}
 	return lock.SaveToFile(output)
-}
-
-func repoLock(repositoryURI string, arch types.Architecture) (pkglock.LockRepo, error) {
-	repo := apk.Repository{URI: fmt.Sprintf("%s/%s", repositoryURI, arch.ToAPK())}
-	name, err := RemoveLabel(stripURLScheme(repo.URI))
-	if err != nil {
-		return pkglock.LockRepo{}, fmt.Errorf("failed to remove label from repository URI: %w", err)
-	}
-	url, err := RemoveLabel(repo.IndexURI())
-	if err != nil {
-		return pkglock.LockRepo{}, fmt.Errorf("failed to remove label from repository index URI: %w", err)
-	}
-	return pkglock.LockRepo{
-		Name:         name,
-		URL:          url,
-		Architecture: arch.ToAPK(),
-	}, nil
 }
 
 func stripURLScheme(url string) string {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -46,7 +46,7 @@ func publish() *cobra.Command {
 	var archstrs []string
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var extraPackages []string
 	var rawAnnotations []string
 	var withVCS bool
@@ -112,7 +112,7 @@ in a keychain.`,
 					build.WithSBOMFormats(sbomFormats),
 					build.WithExtraKeys(extraKeys),
 					build.WithExtraBuildRepos(extraBuildRepos),
-					build.WithExtraRepos(extraRepos),
+					build.WithExtraRuntimeRepos(extraRuntimeRepos),
 					build.WithExtraPackages(extraPackages),
 					build.WithTags(args[1:]...),
 					build.WithVCS(withVCS),
@@ -142,7 +142,7 @@ in a keychain.`,
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVar(&sbomFormats, "sbom-formats", sbom.DefaultOptions.Formats, "SBOM formats to output")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -167,7 +167,7 @@ func TestPublishLayering(t *testing.T) {
 
 	// This test will fail if we ever make a change in apko that changes the image.
 	// Sometimes, this is intentional, and we need to change this and bump the version.
-	want := "sha256:d930d3cea6e6b1e53f388302a0bbe6ddff31db9952a667ed2ab6b93c1eeade6c"
+	want := "sha256:66dc21761826860d1152e8a6defa7919ad3f65af5d56fd75164c4c36ba85c648"
 	require.Equal(t, want, digest.String())
 
 	im, err := idx.IndexManifest()
@@ -195,9 +195,6 @@ func TestPublishLayering(t *testing.T) {
 
 		if strings.Contains(string(b), "./packages") {
 			t.Errorf("etc/apk/repositories contains build_repositories entry %q", "./packages")
-		}
-		if !strings.Contains(string(b), "apk.cgr.dev/runtime-only-repo") {
-			t.Errorf("etc/apk/repositories does not contain expected runtime_repositories entry %q", "apk.cgr.dev/runtime-only-repo")
 		}
 	}
 }

--- a/internal/cli/show-config.go
+++ b/internal/cli/show-config.go
@@ -31,7 +31,7 @@ import (
 func showConfig() *cobra.Command {
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var cacheDir string
 	var offline bool
 
@@ -49,7 +49,7 @@ The derived configuration is rendered in YAML.
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
@@ -57,7 +57,7 @@ The derived configuration is rendered in YAML.
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
 	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 

--- a/internal/cli/show-packages.go
+++ b/internal/cli/show-packages.go
@@ -63,7 +63,7 @@ type pkgInfo struct {
 func showPackages() *cobra.Command {
 	var extraKeys []string
 	var extraBuildRepos []string
-	var extraRepos []string
+	var extraRuntimeRepos []string
 	var archstrs []string
 	var format string
 	var tmpl string
@@ -108,7 +108,7 @@ packagelock and packagelock-source are particularly useful for inserting back in
 				build.WithConfig(args[0], []string{}),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraBuildRepos(extraBuildRepos),
-				build.WithExtraRepos(extraRepos),
+				build.WithExtraRuntimeRepos(extraRuntimeRepos),
 				build.WithCache(cacheDir, offline, apk.NewCache(true)),
 			)
 		},
@@ -116,7 +116,7 @@ packagelock and packagelock-source are particularly useful for inserting back in
 
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the keyring")
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
+	cmd.Flags().StringSliceVarP(&extraRuntimeRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config. Can also use 'host' to indicate arch of host this is running on")
 	cmd.Flags().StringVar(&format, "format", showPkgsFormatDefault, "format for showing packages; if pre-defined from list, will use that, else go template. See https://pkg.go.dev/text/template for more information. Available vars are `.Name`, `.Version`, `.Source`")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")

--- a/internal/cli/testdata/apko.lock.json
+++ b/internal/cli/testdata/apko.lock.json
@@ -12,7 +12,6 @@
       }
     ],
     "build_repositories": [],
-    "runtime_repositories": [],
     "repositories": [
       {
         "name": "./testdata/packages/x86_64",

--- a/internal/cli/testdata/image_on_top.apko.lock.json
+++ b/internal/cli/testdata/image_on_top.apko.lock.json
@@ -12,7 +12,6 @@
       }
     ],
     "build_repositories": [],
-    "runtime_repositories": [],
     "repositories": [
       {
         "name": "./testdata/packages/x86_64",

--- a/internal/cli/testdata/layering.yaml
+++ b/internal/cli/testdata/layering.yaml
@@ -3,8 +3,6 @@ contents:
     - ./testdata/melange.rsa.pub
   build_repositories:
     - ./packages
-  runtime_repositories:
-    - apk.cgr.dev/runtime-only-repo
   repositories:
     - ./testdata/packages
   packages:

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -30,10 +30,7 @@ func (bc *Context) postBuildSetApk(ctx context.Context) error {
 	//
 	// We do not include the build-time repositories here, because this is
 	// what defines the /etc/apk/repositories file in the final image.
-	runtimeRepos := sets.List(
-		sets.New(bc.ic.Contents.Repositories...).
-			Insert(bc.ic.Contents.RuntimeRepositories...).
-			Insert(bc.o.ExtraRepos...))
+	runtimeRepos := sets.List(sets.New(bc.ic.Contents.RuntimeRepositories...).Insert(bc.o.ExtraRuntimeRepos...))
 	if err := bc.apk.SetRepositories(ctx, runtimeRepos); err != nil {
 		return fmt.Errorf("failed to set apk repositories: %w", err)
 	}
@@ -48,14 +45,11 @@ func (bc *Context) initializeApk(ctx context.Context) error {
 	// We set the repositories file to be the union of all of the
 	// repositories when we initialize things, and we overwrite it
 	// with just the runtime repositories when we are done.
-	//
-	// We do not include the runtime-only repositories here, because those repos
-	// should not be used at build time.
 	buildRepos := sets.List(
 		sets.New(bc.ic.Contents.BuildRepositories...).
-			Insert(bc.ic.Contents.Repositories...).
+			Insert(bc.ic.Contents.RuntimeRepositories...).
 			Insert(bc.o.ExtraBuildRepos...).
-			Insert(bc.o.ExtraRepos...),
+			Insert(bc.o.ExtraRuntimeRepos...),
 	)
 	if err := bc.apk.InitDB(ctx, buildRepos...); err != nil {
 		return fmt.Errorf("failed to initialize apk database: %w", err)

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -195,9 +195,9 @@ func TestAuth_good(t *testing.T) {
 	bc, err := build.New(ctx, fs.NewMemFS(),
 		build.WithImageConfiguration(types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Repositories: []string{s.URL},
-				Keyring:      []string{s.URL + "/melange.rsa.pub"},
-				Packages:     []string{"pretend-baselayout"},
+				RuntimeRepositories: []string{s.URL},
+				Keyring:             []string{s.URL + "/melange.rsa.pub"},
+				Packages:            []string{"pretend-baselayout"},
 			},
 			Archs: types.ParseArchitectures([]string{"amd64", "arm64"}),
 		}),

--- a/pkg/build/lock.go
+++ b/pkg/build/lock.go
@@ -41,7 +41,7 @@ func LockImageConfiguration(ctx context.Context, ic types.ImageConfiguration, op
 	}
 
 	input.Contents.BuildRepositories = sets.List(sets.New(input.Contents.BuildRepositories...).Insert(o.ExtraBuildRepos...))
-	input.Contents.Repositories = sets.List(sets.New(input.Contents.Repositories...).Insert(o.ExtraRepos...))
+	input.Contents.RuntimeRepositories = sets.List(sets.New(input.Contents.RuntimeRepositories...).Insert(o.ExtraRuntimeRepos...))
 	input.Contents.Keyring = sets.List(sets.New(input.Contents.Keyring...).Insert(o.ExtraKeyFiles...))
 
 	mc, err := NewMultiArch(ctx, input.Archs, append(opts, WithImageConfiguration(*input))...)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -131,18 +131,9 @@ func WithExtraBuildRepos(repos []string) Option {
 	}
 }
 
-// WithExtraRuntimeRepos adds repos to be used at both image build-time and image run-time.
-// A future version of apko will only add these repos to the list of runtime repos, as the name suggests.
 func WithExtraRuntimeRepos(repos []string) Option {
 	return func(bc *Context) error {
-		bc.o.ExtraRepos = repos
-		return nil
-	}
-}
-
-func WithExtraRepos(repos []string) Option {
-	return func(bc *Context) error {
-		bc.o.ExtraRepos = repos
+		bc.o.ExtraRuntimeRepos = repos
 		return nil
 	}
 }

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -73,9 +73,19 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, incl
 		}
 	}
 
-	ic.Contents.BuildRepositories = trimRepos(ic.Contents.BuildRepositories)
-	ic.Contents.RuntimeRepositories = trimRepos(ic.Contents.RuntimeRepositories)
-	ic.Contents.Repositories = trimRepos(ic.Contents.Repositories)
+	runtimeRepos := make([]string, 0, len(ic.Contents.RuntimeRepositories))
+	for _, repo := range ic.Contents.RuntimeRepositories {
+		repo = strings.TrimRight(repo, "/")
+		runtimeRepos = append(runtimeRepos, repo)
+	}
+	ic.Contents.RuntimeRepositories = runtimeRepos
+
+	buildRepos := make([]string, 0, len(ic.Contents.BuildRepositories))
+	for _, repo := range ic.Contents.BuildRepositories {
+		repo = strings.TrimRight(repo, "/")
+		buildRepos = append(buildRepos, repo)
+	}
+	ic.Contents.BuildRepositories = buildRepos
 
 	// The top level components restriction is on the conservative side. Some of them would probably work out of the box.
 	// If someone needs any of them, it should be a matter of testing and hopefully doing minor changes.
@@ -93,15 +103,6 @@ func (ic *ImageConfiguration) parse(ctx context.Context, configData []byte, incl
 	}
 
 	return nil
-}
-
-func trimRepos(repos []string) []string {
-	result := make([]string, 0, len(repos))
-	for _, repo := range repos {
-		repo = strings.TrimRight(repo, "/")
-		result = append(result, repo)
-	}
-	return result
 }
 
 // Merge this configuration into the target, with the target taking precedence.
@@ -166,7 +167,6 @@ func (i *ImageContents) MergeInto(target *ImageContents) error {
 	target.Keyring = slices.Concat(i.Keyring, target.Keyring)
 	target.BuildRepositories = slices.Concat(i.BuildRepositories, target.BuildRepositories)
 	target.RuntimeRepositories = slices.Concat(i.RuntimeRepositories, target.RuntimeRepositories)
-	target.Repositories = slices.Concat(i.Repositories, target.Repositories)
 	target.Packages = slices.Concat(i.Packages, target.Packages)
 	if target.BaseImage == nil {
 		target.BaseImage = i.BaseImage
@@ -245,7 +245,6 @@ func (ic *ImageConfiguration) Summarize(ctx context.Context) {
 	log.Infof("  contents:")
 	log.Infof("    build repositories: %v", ic.Contents.BuildRepositories)
 	log.Infof("    runtime repositories: %v", ic.Contents.RuntimeRepositories)
-	log.Infof("    repositories: %v", ic.Contents.Repositories)
 	log.Infof("    keyring:      %v", ic.Contents.Keyring)
 	log.Infof("    packages:     %v", ic.Contents.Packages)
 	if ic.Entrypoint.Type != "" || ic.Entrypoint.Command != "" || len(ic.Entrypoint.Services) != 0 {

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -27,8 +27,7 @@ func TestOverlayWithEmptyContents(t *testing.T) {
 
 	require.NoError(t, ic.Load(ctx, configPath, []string{"testdata"}, hasher))
 	require.ElementsMatch(t, ic.Contents.BuildRepositories, []string{"secret repository"})
-	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"runtime repository"})
-	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package"})
 }
@@ -42,8 +41,7 @@ func TestOverlayWithAdditionalPackages(t *testing.T) {
 
 	require.NoError(t, ic.Load(ctx, configPath, []string{}, hasher))
 	require.ElementsMatch(t, ic.Contents.BuildRepositories, []string{"secret repository", "other_secret repository"})
-	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"runtime repository", "other runtime repository"})
-	require.ElementsMatch(t, ic.Contents.Repositories, []string{"repository"})
+	require.ElementsMatch(t, ic.Contents.RuntimeRepositories, []string{"repository"})
 	require.ElementsMatch(t, ic.Contents.Keyring, []string{"key"})
 	require.ElementsMatch(t, ic.Contents.Packages, []string{"package", "other_package"})
 }
@@ -77,10 +75,10 @@ func TestMergeInto(t *testing.T) {
 		name: "simple blend of contents",
 		source: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo"},
-				BuildRepositories: []string{"foo"},
-				Repositories:      []string{"foo"},
-				Packages:          []string{"foo"},
+				Keyring:             []string{"foo"},
+				BuildRepositories:   []string{"foo"},
+				RuntimeRepositories: []string{"foo"},
+				Packages:            []string{"foo"},
 			},
 			Environment: map[string]string{
 				"EXTRA": "foo",
@@ -96,18 +94,18 @@ func TestMergeInto(t *testing.T) {
 		},
 		target: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"bar"},
-				BuildRepositories: []string{"bar"},
-				Repositories:      []string{"bar"},
-				Packages:          []string{"bar"},
+				Keyring:             []string{"bar"},
+				BuildRepositories:   []string{"bar"},
+				RuntimeRepositories: []string{"bar"},
+				Packages:            []string{"bar"},
 			},
 		},
 		expected: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo", "bar"},
-				BuildRepositories: []string{"foo", "bar"},
-				Repositories:      []string{"foo", "bar"},
-				Packages:          []string{"foo", "bar"},
+				Keyring:             []string{"foo", "bar"},
+				BuildRepositories:   []string{"foo", "bar"},
+				RuntimeRepositories: []string{"foo", "bar"},
+				Packages:            []string{"foo", "bar"},
 			},
 			Environment: map[string]string{
 				"EXTRA": "foo",
@@ -125,36 +123,36 @@ func TestMergeInto(t *testing.T) {
 		name: "simple blend of contents",
 		source: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo"},
-				BuildRepositories: []string{"foo"},
-				Repositories:      []string{"foo"},
-				Packages:          []string{"foo"},
+				Keyring:             []string{"foo"},
+				BuildRepositories:   []string{"foo"},
+				RuntimeRepositories: []string{"foo"},
+				Packages:            []string{"foo"},
 			},
 		},
 		target: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"bar"},
-				BuildRepositories: []string{"bar"},
-				Repositories:      []string{"bar"},
-				Packages:          []string{"bar"},
+				Keyring:             []string{"bar"},
+				BuildRepositories:   []string{"bar"},
+				RuntimeRepositories: []string{"bar"},
+				Packages:            []string{"bar"},
 			},
 		},
 		expected: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo", "bar"},
-				BuildRepositories: []string{"foo", "bar"},
-				Repositories:      []string{"foo", "bar"},
-				Packages:          []string{"foo", "bar"},
+				Keyring:             []string{"foo", "bar"},
+				BuildRepositories:   []string{"foo", "bar"},
+				RuntimeRepositories: []string{"foo", "bar"},
+				Packages:            []string{"foo", "bar"},
 			},
 		},
 	}, {
 		name: "conflict resolution",
 		source: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo"},
-				BuildRepositories: []string{"foo"},
-				Repositories:      []string{"foo"},
-				Packages:          []string{"foo"},
+				Keyring:             []string{"foo"},
+				BuildRepositories:   []string{"foo"},
+				RuntimeRepositories: []string{"foo"},
+				Packages:            []string{"foo"},
 			},
 			Cmd:        "foo",
 			StopSignal: "foo",
@@ -199,10 +197,10 @@ func TestMergeInto(t *testing.T) {
 		},
 		expected: types.ImageConfiguration{
 			Contents: types.ImageContents{
-				Keyring:           []string{"foo"},
-				BuildRepositories: []string{"foo"},
-				Repositories:      []string{"foo"},
-				Packages:          []string{"foo"},
+				Keyring:             []string{"foo"},
+				BuildRepositories:   []string{"foo"},
+				RuntimeRepositories: []string{"foo"},
+				Packages:            []string{"foo"},
 			},
 			Cmd:        "bar",
 			StopSignal: "bar",

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -148,13 +148,6 @@
           "type": "array",
           "description": "A list of apk repositories to use for pulling packages at build time,\nwhich are not installed into /etc/apk/repositories in the image (to\ninstall packages at runtime)"
         },
-        "runtime_repositories": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "A list of apk repositories that are installed into /etc/apk/repositories in the image but not used\nat build time"
-        },
         "repositories": {
           "items": {
             "type": "string"

--- a/pkg/build/types/testdata/overlay/base.apko.yaml
+++ b/pkg/build/types/testdata/overlay/base.apko.yaml
@@ -1,8 +1,6 @@
 contents:
   build_repositories:
     - "secret repository"
-  runtime_repositories:
-    - "runtime repository"
   repositories:
     - "repository"
   keyring:

--- a/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
+++ b/pkg/build/types/testdata/overlay/overlay_with_package.apko.yaml
@@ -3,7 +3,5 @@ include: testdata/overlay/overlay.apko.yaml
 contents:
   build_repositories:
     - "other_secret repository"
-  runtime_repositories:
-    - "other runtime repository"
   packages:
     - "other_package"

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -79,13 +79,10 @@ type ImageContents struct {
 	// which are not installed into /etc/apk/repositories in the image (to
 	// install packages at runtime)
 	BuildRepositories []string `json:"build_repositories,omitempty" yaml:"build_repositories,omitempty"`
-	// A list of apk repositories that are installed into /etc/apk/repositories in the image but not used
-	// at build time
-	RuntimeRepositories []string `json:"runtime_repositories,omitempty" yaml:"runtime_repositories,omitempty"`
 	// A list of apk repositories to use for pulling packages during both the
 	// initial construction of the image, and also at runtime by seeding them
 	// into /etc/apk/repositories in the resulting image.
-	Repositories []string `json:"repositories,omitempty" yaml:"repositories,omitempty"`
+	RuntimeRepositories []string `json:"repositories,omitempty" yaml:"repositories,omitempty"`
 	// A list of public keys used to verify the desired repositories
 	Keyring []string `json:"keyring,omitempty" yaml:"keyring,omitempty"`
 	// A list of packages to include in the image
@@ -109,13 +106,13 @@ func (i ImageContents) MarshalYAML() (interface{}, error) {
 		ri.BuildRepositories[idx] = parsed.Redacted()
 	}
 
-	for idx, repo := range ri.Repositories {
+	for idx, repo := range ri.RuntimeRepositories {
 		rawURL := repo
 		parsed, err := url.Parse(rawURL)
 		if err != nil {
 			return nil, fmt.Errorf("parsing repository URL: %w", err)
 		}
-		ri.Repositories[idx] = parsed.Redacted()
+		ri.RuntimeRepositories[idx] = parsed.Redacted()
 	}
 
 	for idx, key := range ri.Keyring {

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -26,8 +26,7 @@ type Config struct {
 type LockContents struct {
 	Keyrings            []LockKeyring `json:"keyring"`
 	BuildRepositories   []LockRepo    `json:"build_repositories"`
-	RuntimeRepositories []LockRepo    `json:"runtime_repositories"`
-	Repositories        []LockRepo    `json:"repositories"`
+	RuntimeRepositories []LockRepo    `json:"repositories"`
 	// Packages in order of installation -> for a single architecture.
 	Packages []LockPkg `json:"packages"`
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -40,7 +40,7 @@ type Options struct {
 	SBOMFormats             []string           `json:"sbomFormats,omitempty"`
 	ExtraKeyFiles           []string           `json:"extraKeyFiles,omitempty"`
 	ExtraBuildRepos         []string           `json:"extraBuildRepos,omitempty"`
-	ExtraRepos              []string           `json:"extraRepos,omitempty"`
+	ExtraRuntimeRepos       []string           `json:"extraRepos,omitempty"`
 	ExtraPackages           []string           `json:"extraPackages,omitempty"`
 	Arch                    types.Architecture `json:"arch,omitempty"`
 	TempDirPath             string             `json:"tempDirPath,omitempty"`


### PR DESCRIPTION
Reverts chainguard-dev/apko#1786

This change is backwards incompatible with external usage of the ImageContents struct. We'll attempt that change again with less breakage, but will revert for now.