### PR TITLE
Simplify the sorting of paths for apk db/installed file.

### DIFF
--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -410,105 +410,76 @@ func parseInstalledPerms(permString string) (uid, gid int, perms int64, err erro
 	return
 }
 
+// TODO: This function is needed to make the test pass in
+//
+//	TestSortTarHeaders/intermediate_dirs_in_the_tree_should_be_required_to_preserve_children
+//
+// The comment there indicates that we want to drop files that are orphaned rather than
+// keep them.
+func removeOrphanedEntries(headers []tar.Header) {
+	return
+}
+
 // sortTarHeaders sorts tar headers by name. It ensures that all file children
 // of a directory are listed immediately after the directory itself. This is to
 // support usr/lib/apk/db/installed, which lists full paths for directories, but
 // only the basename for the files, so the last directory entry before a file
 // must be the parent in which it sits.
 func sortTarHeaders(headers []tar.Header) []tar.Header {
-	var (
-		// Create a tree with everything in it, where keys are full directory paths,
-		// values are slice of full paths of children. (Every directory in the tree will
-		// have its own key in the map.)
-		directoryChildren = map[string][]string{}
-
-		all = map[string]tar.Header{}
-	)
-
-	for _, header := range headers {
-		// Use a cleaned name for map keys to ensure consistency with lookups later.
-		cleanedName := filepath.Clean(header.Name)
-
-		dir := filepath.Dir(cleanedName)
-		directoryChildren[dir] = append(directoryChildren[dir], cleanedName)
-		all[cleanedName] = header
-	}
-
-	// Map the directory entries (the keys in "directoryChildren") to a slice (and
-	// sort them for determinism).
-	var dirEntries = make([]string, 0, len(directoryChildren))
-	for dir := range directoryChildren {
-		dirEntries = append(dirEntries, dir)
-	}
-	sort.Strings(dirEntries)
-
-	// We'll start with top-level entries (including files and directories in root),
-	// and then descend into their children recursively.
-	var topLevelEntries = make([]string, 0, len(dirEntries))
-	for _, dir := range dirEntries {
-		if filepath.Dir(dir) == "." {
-			topLevelEntries = append(topLevelEntries, dir)
-		}
-	}
-
-	// Special case: if we have files in the root directory, include them
-	rootFiles := directoryChildren["."]
-	var hasRootFiles bool
-	for _, rootFile := range rootFiles {
-		header, ok := all[rootFile]
-		if ok && header.Typeflag != tar.TypeDir {
-			hasRootFiles = true
-			break
-		}
-	}
-
-	sort.Strings(topLevelEntries)
-
-	if hasRootFiles {
-		// If we have root files, use the children of "." as the starting point
-		sorted := sortChildrenTarHeaders(directoryChildren, all, rootFiles)
-		return sorted
-	} else {
-		// Otherwise use the original algorithm
-		sorted := sortChildrenTarHeaders(directoryChildren, all, topLevelEntries)
-		return sorted
-	}
+	hCopy := make([]tar.Header, len(headers))
+	copy(hCopy, headers)
+	tarHeadersSort(hCopy)
+	removeOrphanedEntries(hCopy)
+	return hCopy
 }
 
-func sortChildrenTarHeaders(directoryChildren map[string][]string, all map[string]tar.Header, children []string) []tar.Header {
-	sort.Strings(children)
+// compare two paths such that inside a directory
+// 1. all non-directories (files, symlink, ...) will sort before directories
+// 2. all non-directories and directories will be sorted within themselves.
+func pathCompare(a string, aIsDir bool, b string, bIsDir bool) int {
+	var n, result int
+	aClean := filepath.Clean(a)
+	bClean := filepath.Clean(b)
+	if aClean == bClean {
+		return 0
+	}
+	sep := fmt.Sprintf("%c", filepath.Separator)
+	aToks := strings.Split(aClean, sep)
+	bToks := strings.Split(bClean, sep)
 
-	// Non-directory type files need to be first.
-	var sorted = make([]tar.Header, 0, len(children))
-	for _, child := range children {
-		header, ok := all[child]
-		if !ok {
-			continue
-		}
-		if header.Typeflag != tar.TypeDir {
-			sorted = append(sorted, header)
+	for n = 0; n < len(aToks)-1 && n < len(bToks)-1; n++ {
+		result = strings.Compare(aToks[n], bToks[n])
+		if result != 0 {
+			return -1
 		}
 	}
 
-	// Then directories.
-	for _, child := range children {
-		header, ok := all[child]
-		if !ok {
-			continue
-		}
-		if header.Typeflag == tar.TypeDir {
-			sorted = append(sorted, header)
+	// n represents the component that should be compared.
+	// this token is a directory if
+	//  1. it is the last token and the header is a directory ('lib' in /usr/local/lib)
+	//  2. it is not the path's last token ('local' in /var/local/lib)
+	aTokIsDir := n+1 < len(aToks) || aIsDir
+	bTokIsDir := n+1 < len(bToks) || bIsDir
 
-			// And their children.
-			children, ok := directoryChildren[child]
-			if !ok || len(children) == 0 {
-				continue
-			}
-
-			sortedChildren := sortChildrenTarHeaders(directoryChildren, all, children)
-			sorted = append(sorted, sortedChildren...)
-		}
+	if aTokIsDir == bTokIsDir {
+		// both are directories or non-directories
+		return strings.Compare(aToks[n], bToks[n])
 	}
+	// if a is not a dir, it goes before b
+	if !aTokIsDir {
+		return -1
+	}
+	return 1
+}
 
-	return sorted
+// sort an array of tar.Header such that
+// non-directories within a directory come before directories and are sorted.
+// directories are sorted within themselves.
+func tarHeadersSort(headers []tar.Header) {
+	sort.SliceStable(headers,
+		func(i, j int) bool {
+			return pathCompare(
+				headers[i].Name, headers[i].Typeflag == tar.TypeDir,
+				headers[j].Name, headers[j].Typeflag == tar.TypeDir) < 0
+		})
 }


### PR DESCRIPTION
The change here allows us to just use sort.Slice on []tar.Headers. It also makes it much easier to test, as we can simply test the comparison of 2 different entries and assume that sort.Slice is correct.

The thing that is still TODO here is that my changes are not dropping intermediate paths. There is a test in TestSortTarHeaders named intermediate_dirs_in_the_tree_should_be_required_to_preserve_children that is failing now.

Other TODO is a less clunky tarHeadersSort