### PR TITLE
Revert "fix: include root-level files in the installed apk database. …

### DIFF
--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -442,37 +442,19 @@ func sortTarHeaders(headers []tar.Header) []tar.Header {
 	}
 	sort.Strings(dirEntries)
 
-	// We'll start with top-level entries (including files and directories in root),
-	// and then descend into their children recursively.
-	var topLevelEntries = make([]string, 0, len(dirEntries))
+	// We'll start with top-level directories, and then descend into their children
+	// recursively.
+	var topLevelDirs = make([]string, 0, len(dirEntries))
 	for _, dir := range dirEntries {
 		if filepath.Dir(dir) == "." {
-			topLevelEntries = append(topLevelEntries, dir)
+			topLevelDirs = append(topLevelDirs, dir)
 		}
 	}
 
-	// Special case: if we have files in the root directory, include them
-	rootFiles := directoryChildren["."]
-	var hasRootFiles bool
-	for _, rootFile := range rootFiles {
-		header, ok := all[rootFile]
-		if ok && header.Typeflag != tar.TypeDir {
-			hasRootFiles = true
-			break
-		}
-	}
+	sort.Strings(topLevelDirs)
 
-	sort.Strings(topLevelEntries)
-
-	if hasRootFiles {
-		// If we have root files, use the children of "." as the starting point
-		sorted := sortChildrenTarHeaders(directoryChildren, all, rootFiles)
-		return sorted
-	} else {
-		// Otherwise use the original algorithm
-		sorted := sortChildrenTarHeaders(directoryChildren, all, topLevelEntries)
-		return sorted
-	}
+	sorted := sortChildrenTarHeaders(directoryChildren, all, topLevelDirs)
+	return sorted
 }
 
 func sortChildrenTarHeaders(directoryChildren map[string][]string, all map[string]tar.Header, children []string) []tar.Header {

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -77,8 +77,6 @@ func TestAddInstalledPackage(t *testing.T) {
 		BuildTime: time.Now(),
 	}
 	newFiles := []tar.Header{
-		{Name: "slashfile", Typeflag: tar.TypeReg, Size: 24, Mode: 0o644}, // file in /
-		{Name: "slashLink", Typeflag: tar.TypeSymlink, Linkname: "usr/foo/testfile"},
 		{Name: "usr", Typeflag: tar.TypeDir, Mode: 0o755},                          // standard perms should not generate extra perms line
 		{Name: "usr/foo", Typeflag: tar.TypeDir, Mode: 0o700},                      // should generate extra M: perms line
 		{Name: "usr/foo/testfile", Typeflag: tar.TypeReg, Size: 1234, Mode: 0o644}, // standard perms should not generate extra perms line
@@ -105,11 +103,8 @@ func TestAddInstalledPackage(t *testing.T) {
 
 	// The same random checksum from before, converted to what we expect.
 	want := "Z:Q1kavxlyJ9L+cdAW9My2ixbJybJ2g="
-	lines := strings.Split(string(installedFile), "\n")
-	require.Contains(t, lines, want)
-	require.Contains(t, lines, "R:testfile")
-	require.Contains(t, lines, "R:slashfile")
-	require.Contains(t, lines, "R:slashLink")
+	str := string(installedFile)
+	require.Contains(t, str, want)
 }
 
 func TestIsInstalledPackage(t *testing.T) {


### PR DESCRIPTION
…(#1801)"

This reverts commit 37187b1a56a69b50af35c52d822b017d7fece984.

The generated /lib/dpk/db/installed files were not readable by apk. apk would fail with messages like this:

    / # apk info -L
    ERROR: FDB format error (line 16, entry 'R')
    ERROR: Unable to read database state: database file format error
    ERROR: Failed to open apk database: database file format error

The problem is that apk requires 'R:' entries to have a preceeding 'F' (directory) entry.  If the only entries in / are directories, then this is not a problem.  In order to put an 'R:' entry in /, it must be preceeded by a 'F:' (a directory entry with "" as value).