### PR TITLE
Don't separate cache by repos

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -478,22 +478,17 @@ func cacheDirForPackage(root string, pkg InstallablePackage) (string, error) {
 
 // cachePathFromURL given a URL, figure out what the cache path would be
 func cachePathFromURL(root string, u url.URL) (string, error) {
+	// We have a content-addressable cache "inside" of a package, thus we don't
+	// have to separate different index hosts when caching packages. This will
+	// allow cache hits even when using different index hosts, as long as the
+	// package is the same.
 	// the last two levels are what we append. For example https://example.com/foo/bar/x86_64/baz.apk
 	// means we want to append x86_64/baz.apk to our cache root
-	u2 := u
-	u2.ForceQuery = false
-	u2.RawFragment = ""
-	u2.RawQuery = ""
-	filename := filepath.Base(u2.Path)
-	archDir := filepath.Dir(u2.Path)
-	dir := filepath.Base(archDir)
-	repoDir := filepath.Dir(archDir)
-	// include the hostname
-	u2.Path = repoDir
+	filename := filepath.Base(u.Path)
+	archDir := filepath.Dir(u.Path)
+	arch := filepath.Base(archDir)
 
-	// url encode it so it can be a single directory
-	repoDir = url.QueryEscape(u2.String())
-	cacheFile := filepath.Join(root, repoDir, dir, filename)
+	cacheFile := filepath.Join(root, arch, filename)
 	// validate it is within root
 	cacheFile = filepath.Clean(cacheFile)
 	cleanroot := filepath.Clean(root)

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -619,11 +619,11 @@ func TestFetchPackage(t *testing.T) {
 		tmpDir := t.TempDir()
 		a := prepLayout(t, tmpDir)
 		// fill the cache
-		repoDir := filepath.Join(tmpDir, url.QueryEscape(testAlpineRepos), testArch)
-		err := os.MkdirAll(repoDir, 0o755)
+		dir := filepath.Join(tmpDir, testArch)
+		err := os.MkdirAll(dir, 0o755)
 		require.NoError(t, err, "unable to mkdir cache")
 
-		cacheApkFile := filepath.Join(repoDir, testPkgFilename)
+		cacheApkFile := filepath.Join(dir, testPkgFilename)
 		cacheApkDir := strings.TrimSuffix(cacheApkFile, ".apk")
 
 		a.SetClient(&http.Client{

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -22,7 +22,6 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -178,7 +177,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		tmpDir := t.TempDir()
 		a := prepLayout(t, tmpDir, []string{testAlpineRepos})
 		// fill the cache
-		repoDir := filepath.Join(tmpDir, url.QueryEscape(testAlpineRepos), testArch)
+		dir := filepath.Join(tmpDir, testArch)
 
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{
@@ -193,7 +192,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// check that the contents are the same
-		index1, err := os.ReadFile(filepath.Join(repoDir, "APKINDEX", base32.StdEncoding.EncodeToString([]byte("an-etag"))+".tar.gz"))
+		index1, err := os.ReadFile(filepath.Join(dir, "APKINDEX", base32.StdEncoding.EncodeToString([]byte("an-etag"))+".tar.gz"))
 		require.NoError(t, err, "unable to read cache index file")
 		index2, err := os.ReadFile(filepath.Join(testPrimaryPkgDir, indexFilename))
 		require.NoError(t, err, "unable to read previous index file")


### PR DESCRIPTION
Our cache is fully content-addressable in that each package is cached by the control- and datahashes respectively. As such, we don't have to separate the cache by different repos and can instead rely on that content-addressability to ensure packages that are actually different are not polluting each other. This raises cache-hit rates when working with multiple repositories that all have the same packages.