### PR TITLE
ci - make verify workflow use golang 1.24 for compat with golangci-lint

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 'stable'
+          go-version: '1.24'
           check-latest: true
 
       - name: golangci-lint


### PR DESCRIPTION
golangci-lint does not yet support golang 1.25 (stable), so the verify workflow would fail with:

 > Running [/path/golangci-lint run] in [/home/runner/work/apko/apko] ...
 > panic: file requires newer Go version go1.25 (application built with go1.24) [recovered]
 >   panic: file requires newer Go version go1.25 (application built with go1.24)