### PR TITLE
Reduce the log noise from auto-auth failures.

### DIFF
--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -101,10 +102,11 @@ func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) error {
 
 	sometimes.Do(func() {
 		cmd := exec.CommandContext(ctx, "chainctl", "auth", "token", "--audience", host)
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = io.Discard // Don't pollute logs when things fail
 		out, err := cmd.Output()
 		if err != nil {
-			log.Warnf("Error running `chainctl auth token`: %v", err)
+			// Document that automatic auth failed and how to reproduce.
+			log.Infof("Unable to automatically authenticate, run `chainctl auth token --audience %q` to diagnose", host)
 			return
 		}
 		tok = string(out)


### PR DESCRIPTION
Today virtually all of our elastic builds surface errors because of this, but it's just noise.

This changes things to hide the chainctl error, reduce the severity of the (current) warning, and document how a user can reproduce the auth failure, if this is why things are not working for them.