### PR TITLE
bug-fix: handles usrmerge base image correctly

### DIFF
--- a/.github/workflows/examples-test.yaml
+++ b/.github/workflows/examples-test.yaml
@@ -1,0 +1,108 @@
+name: Test Examples
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-on-top-of-base:
+    name: Test on_top_of_base example (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Build apko
+        run: make apko
+
+      - name: Test on_top_of_base example - usr-merge base image handling
+        run: |
+          set -euxo pipefail
+
+          # Test with busybox base image (has usr-merge layout with /lib -> /usr/lib symlink)
+          # This verifies that apko correctly handles building on top of base images with usr-merge layout
+          BASE_IMAGE="cgr.dev/chainguard/busybox:latest"
+          OUTPUT_TAR="test-output-${{ matrix.arch }}.tar"
+
+          echo "Testing on_top_of_base example with ${{ matrix.arch }} architecture..."
+
+          # Build image on top of base using the parameterized build.sh script
+          ./examples/on_top_of_base/build.sh \
+            ./apko \
+            "$BASE_IMAGE" \
+            "$OUTPUT_TAR" \
+            "${{ matrix.arch }}"
+
+          # Load the built image
+          docker load -i "$OUTPUT_TAR"
+
+          # Determine the correct image tag based on architecture
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+            IMAGE_TAG="base_image:latest-amd64"
+          else
+            IMAGE_TAG="base_image:latest-arm64"
+          fi
+
+          # Test that shell works (verifies /lib symlink is preserved correctly)
+          echo "Testing shell execution on ${{ matrix.arch }}..."
+          if docker run --rm --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+             --entrypoint /bin/sh "$IMAGE_TAG" \
+             -c "echo 'Shell works on ${{ matrix.arch }}'" | grep -q "Shell works"; then
+            echo "Shell executes correctly on ${{ matrix.arch }}"
+          else
+            echo "FAILED: Shell failed to execute on ${{ matrix.arch }} (indicates broken /lib symlink)"
+            exit 1
+          fi
+
+          # Test another binary to be thorough
+          echo "Testing busybox execution on ${{ matrix.arch }}..."
+          if docker run --rm --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+             --entrypoint /bin/busybox "$IMAGE_TAG" echo "Busybox works" | grep -q "Busybox works"; then
+            echo "Busybox executes correctly on ${{ matrix.arch }}"
+          else
+            echo "FAILED: Busybox failed to execute on ${{ matrix.arch }}"
+            exit 1
+          fi
+
+          echo "PASSED: on_top_of_base example test for ${{ matrix.arch }}"
+
+      - name: Clean up
+        if: always()
+        run: |
+          # Clean up docker images
+          docker rmi base_image:latest-amd64 2>/dev/null || true
+          docker rmi base_image:latest-arm64 2>/dev/null || true
+          # Clean up build artifacts
+          rm -rf ./examples/on_top_of_base/{base_image,apkindexes,fs_dump,top_image,*.lock.json,*.tar}
+

--- a/examples/on_top_of_base/build.sh
+++ b/examples/on_top_of_base/build.sh
@@ -3,9 +3,11 @@
 # Script for building image on top of base with apko. Must be run from the root of github repository.
 
 apko_binary="${1:-apko}"
+BASE_IMAGE="${2:-cgr.dev/chainguard/wolfi-base:latest}"
+OUTPUT_TAR="${3:-}"
+ARCH="${4:-x86_64}"
 
 EXAMPLE_DIR=./examples/on_top_of_base
-BASE_IMAGE=cgr.dev/chainguard/wolfi-base:latest
 BASE_IMAGE_DIR="$EXAMPLE_DIR/base_image"
 APKINDEX_DIR="$EXAMPLE_DIR/apkindexes"
 FS_DUMP_DIR="$EXAMPLE_DIR/fs_dump"
@@ -16,11 +18,16 @@ crane pull "$BASE_IMAGE" "$BASE_IMAGE_DIR" --format=oci
 mkdir -p "$FS_DUMP_DIR"
 crane export "$BASE_IMAGE" "$FS_DUMP_DIR/fs.tar"
 tar -C "$FS_DUMP_DIR" -xf "$FS_DUMP_DIR/fs.tar"
-mkdir -p "$APKINDEX_DIR/x86_64/"
-cp "$FS_DUMP_DIR/lib/apk/db/installed" "$APKINDEX_DIR/x86_64/APKINDEX"
+mkdir -p "$APKINDEX_DIR/$ARCH/"
+cp "$FS_DUMP_DIR/lib/apk/db/installed" "$APKINDEX_DIR/$ARCH/APKINDEX"
 
-"$apko_binary" lock "$EXAMPLE_DIR/base_image.yaml"
+"$apko_binary" lock "$EXAMPLE_DIR/base_image.yaml" --arch="$ARCH"
 
-mkdir -p "$EXAMPLE_DIR/top_image"
-
-"$apko_binary" build "$EXAMPLE_DIR/base_image.yaml" base_image:latest "$EXAMPLE_DIR/top_image/" --lockfile="$EXAMPLE_DIR/base_image.lock.json" --sbom=False
+if [ -n "$OUTPUT_TAR" ]; then
+    # Output to tar file
+    "$apko_binary" build --arch="$ARCH" "$EXAMPLE_DIR/base_image.yaml" base_image:latest "$OUTPUT_TAR" --lockfile="$EXAMPLE_DIR/base_image.lock.json" --sbom=False
+else
+    # Output to directory (original behavior)
+    mkdir -p "$EXAMPLE_DIR/top_image"
+    "$apko_binary" build --arch="$ARCH" "$EXAMPLE_DIR/base_image.yaml" base_image:latest "$EXAMPLE_DIR/top_image/" --lockfile="$EXAMPLE_DIR/base_image.lock.json" --sbom=False
+fi


### PR DESCRIPTION
When building on a base image with usrmerge layout, we should not try to create the `lib` directory, because the provided packages already has it.

To avoid making this decision based on actually looking at the base image's file system, we will just look at the install packages to see if it was one that provides a usrmerge layout. 

Also add a "examples test" to run the sample's shell script to confirm fix.