### PR TITLE
Stop defensively cloning giant maps

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -212,8 +212,8 @@ type PkgResolver struct {
 func (p *PkgResolver) Clone() *PkgResolver {
 	return &PkgResolver{
 		indexes:      p.indexes,
-		nameMap:      maps.Clone(p.nameMap),
-		installIfMap: maps.Clone(p.installIfMap),
+		nameMap:      p.nameMap,
+		installIfMap: p.installIfMap,
 		selected:     map[string]*RepositoryPackage{},
 	}
 }


### PR DESCRIPTION
We don't actually ever modify these maps once they've been set, so we are wasting time and memory cloning them. This cuts down runtime of a couple resolver-heavy workloads that are important to me in half.