### PR TITLE
DirFS: correct resetting of permissions

### DIFF
--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -236,8 +236,9 @@ func (f *dirFS) open(name string) (*fileImpl, error) {
 		file, err := os.Open(fullpath)
 		if err == nil {
 			return &fileImpl{
-				file: file,
-				name: baseName,
+				file:     file,
+				name:     baseName,
+				fullpath: fullpath,
 			}, nil
 		}
 		if !os.IsPermission(err) {
@@ -258,9 +259,10 @@ func (f *dirFS) open(name string) (*fileImpl, error) {
 		}
 		perms := fi.Mode()
 		return &fileImpl{
-			file:  file,
-			name:  baseName,
-			perms: &perms,
+			file:     file,
+			name:     baseName,
+			fullpath: fullpath,
+			perms:    &perms,
 		}, nil
 	}
 
@@ -618,8 +620,9 @@ func (f *dirFS) removeOnDisk(p string) (removeOnDisk bool) {
 type file File
 type fileImpl struct {
 	file
-	name  string
-	perms *os.FileMode
+	name     string
+	fullpath string
+	perms    *os.FileMode
 }
 
 func (f fileImpl) Close() error {
@@ -627,7 +630,8 @@ func (f fileImpl) Close() error {
 		return err
 	}
 	if f.perms != nil {
-		return os.Chmod(f.name, *f.perms)
+		// f.name is the basename of the path, use the f.file.name here
+		return os.Chmod(f.fullpath, *f.perms)
 	}
 	return nil
 }


### PR DESCRIPTION
The DirFS implementation of open() attempts to perform an os.Open() on the underlying file and if a permissions error is returned, attempts to work around this by changing the permissions on the file and then retrying the os.Open() call. If this succeeds, the original permssions are saved to be reset when the File object is Close()ed.

However, the Close() operation was performing the restorative chmod operation on the saved name of the file, which is the *basename* of the original file, which thus results in the chmod being performed on `$PWD/$(basename NAME)`.

This bug is triggered in melange's qemu runner due to Wolfi's base package permissions on `/etc/shadow` getting changed to mode 0000; when melange would attempt to build the cpio initrd for the qemu guest, apko's pkg/build/tarball.go would end up in this path, and after the initrd tarball was written, the close operation would perform chmod("shadow", 0000), and in the wolfi git repo, there is a shadow/ directory that would get its permissions changed, which would make git unhappy.

The targeted fix for this is to also stash the fullpath of the underlying file and on Close(), use that in the chmod() call. Also add a testcase to ensure the permissions get reset correctly.

To reproduce this issue in melange/wolfi (possibly only on filesystems that are case sensitive), do:
- cd wolfi-dev/os git repo
- rm kernel/ARCH/melange-cpio/melange-guest.initramfs.cpio (if it exists)
- ls -ld shadow and ensure it currently has accessible permissions
- make package/hello-wolfi
- ls -ld shadow again, it likely is mode 0000

To test the fix with melange/apko/wolfi, one will need to checkout this branch and add 
```
replace chainguard.dev/apko => /PATH/TO/YOUR/CLONE/OF/apko
```
to the `go.mod` file in melange, probably run go mod tidy, rebuild melange, then do a package build in wolfi with the MELANGE environment variable set to the location of your built binary if you didn't install it.