### PR TITLE
Fixes local tag publishing

### DIFF
--- a/pkg/build/oci/publish.go
+++ b/pkg/build/oci/publish.go
@@ -53,7 +53,7 @@ func LoadImage(ctx context.Context, image v1.Image, tags []string) (name.Referen
 		if err != nil {
 			return name.Digest{}, err
 		}
-		if !strings.HasPrefix(localSrcTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
+		if !strings.HasPrefix(localDstTag.Name(), fmt.Sprintf("%s/", LocalDomain)) {
 			log.Infof("tagging local image %s as %s", localSrcTag.Name(), localDstTag.Name())
 			if err := daemon.Tag(localSrcTag, localDstTag, daemon.WithContext(ctx)); err != nil {
 				return name.Digest{}, err


### PR DESCRIPTION
When you run `apko publish --local` right now - it ignores all tags except the default apko.local/cache tag

eg:
<img width="1274" height="556" alt="image" src="https://github.com/user-attachments/assets/b143abf8-520d-45d2-9929-87973464d531" />

This looks like it might have been the result of a typo. The tagging logic checks to see whether our "source" tag (the apko.local one) starts with apko.local, and if so, skips it. Instead, I believe this check was meant to use `localDstTag` so we can check that any additional tags can't fall under the `apko.cache` domain.

Evidence of fix:
<img width="1274" height="620" alt="image" src="https://github.com/user-attachments/assets/847cac2f-a4b1-4a16-8a5f-b817db0da751" />
