### PR TITLE
Use cached resolvers to compute disqualifications

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -1164,7 +1164,7 @@ func disqualifyDifference(ctx context.Context, byArch map[string][]NamedIndex) m
 	}
 
 	for arch := range allowablePackages {
-		p := newPkgResolver(ctx, byArch[arch])
+		p := globalResolverCache.Get(ctx, byArch[arch])
 		for otherArch, allowed := range allowablePackages {
 			if otherArch == arch {
 				continue


### PR DESCRIPTION
Currently, we build a fresh resolver everytime we compute disqualifications even though, we might have that resolver cached already.