### PR TITLE
Make resolve and dq caches local

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -145,7 +145,9 @@ type cache struct {
 	dir     string
 	offline bool
 
-	shared *Cache
+	shared          *Cache
+	resolverCache   *resolverCache
+	disqualifyCache *disqualifyCache
 }
 
 // client return an http.Client that knows how to read from and write to the cache

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -103,9 +103,11 @@ func WithCache(cacheDir string, offline bool, shared *Cache) Option {
 			}
 		}
 		o.cache = &cache{
-			dir:     cacheDir,
-			offline: offline,
-			shared:  shared,
+			dir:             cacheDir,
+			offline:         offline,
+			shared:          shared,
+			resolverCache:   &resolverCache{},
+			disqualifyCache: &disqualifyCache{},
 		}
 		return nil
 	}

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -221,10 +221,6 @@ func (p *PkgResolver) Clone() *PkgResolver {
 // NewPkgResolver creates a new pkgResolver from a list of indexes.
 // The indexes are anything that implements NamedIndex.
 func NewPkgResolver(ctx context.Context, indexes []NamedIndex) *PkgResolver {
-	return globalResolverCache.Get(ctx, indexes)
-}
-
-func newPkgResolver(ctx context.Context, indexes []NamedIndex) *PkgResolver {
 	_, span := otel.Tracer("go-apk").Start(ctx, "NewPkgResolver")
 	defer span.End()
 
@@ -485,12 +481,15 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 
 // GetPackagesWithDependencies get all of the dependencies for the given packages based on the
 // indexes. Does not filter for installed already or not.
-func (p *PkgResolver) GetPackagesWithDependencies(ctx context.Context, packages []string, allArchs map[string][]NamedIndex) (toInstall []*RepositoryPackage, conflicts []string, err error) {
+func (p *PkgResolver) GetPackagesWithDependencies(ctx context.Context, packages []string, dq map[*RepositoryPackage]string) (toInstall []*RepositoryPackage, conflicts []string, err error) {
 	_, span := otel.Tracer("go-apk").Start(ctx, "GetPackagesWithDependencies")
 	defer span.End()
 
-	// Tracks all the packages we have disqualified and the reason we disqualified them.
-	dq := globalDisqualifyCache.Get(ctx, allArchs)
+	if dq == nil {
+		// Make sure we have a map to avoid panics. The code below mutates this map, so we need
+		// it to not be nil in all cases.
+		dq = map[*RepositoryPackage]string{}
+	}
 
 	// We're going to mutate this as our set of input packages to install, so make a copy.
 	constraints := slices.Clone(packages)
@@ -1136,7 +1135,7 @@ func maybedqerror(pkgs []*repositoryPackage, dq map[*RepositoryPackage]string) e
 	return errors.New("not in indexes")
 }
 
-func disqualifyDifference(ctx context.Context, byArch map[string][]NamedIndex) map[*RepositoryPackage]string {
+func disqualifyDifference(ctx context.Context, byArch map[string][]NamedIndex, resolverCache *resolverCache) map[*RepositoryPackage]string {
 	dq := map[*RepositoryPackage]string{}
 
 	if len(byArch) == 1 {
@@ -1164,7 +1163,7 @@ func disqualifyDifference(ctx context.Context, byArch map[string][]NamedIndex) m
 	}
 
 	for arch := range allowablePackages {
-		p := globalResolverCache.Get(ctx, byArch[arch])
+		p := resolverCache.get(ctx, byArch[arch])
 		for otherArch, allowed := range allowablePackages {
 			if otherArch == arch {
 				continue

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -1026,8 +1026,9 @@ func TestDisqualifyingOtherArchitectures(t *testing.T) {
 		"x86_64":  testNamedRepositoryFromIndexes(index),
 		"aarch64": armIndex,
 	}
+	dq := disqualifyDifference(context.Background(), byArch, globalResolverCache)
 
 	resolver := NewPkgResolver(context.Background(), armIndex)
-	_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, byArch)
+	_, _, err := resolver.GetPackagesWithDependencies(context.Background(), names, dq)
 	require.ErrorContains(t, err, "package \"onlyinarm64-1.0.0.apk\" not available for arch \"x86_64\"")
 }

--- a/pkg/apk/apk/shameful_global_caches.go
+++ b/pkg/apk/apk/shameful_global_caches.go
@@ -68,7 +68,7 @@ func (r *resolverCache) fill(indexes []NamedIndex, pr *PkgResolver) {
 	child.fill(indexes[1:], pr)
 }
 
-func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResolver {
+func (r *resolverCache) get(ctx context.Context, indexes []NamedIndex) *PkgResolver {
 	r.Lock()
 	defer r.Unlock()
 
@@ -76,7 +76,7 @@ func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResol
 		return pr.Clone()
 	}
 
-	pr := newPkgResolver(ctx, indexes)
+	pr := NewPkgResolver(ctx, indexes)
 	r.fill(indexes, pr)
 
 	return pr.Clone()
@@ -130,7 +130,7 @@ func (r *disqualifyCache) fill(indexes []NamedIndex, dq map[*RepositoryPackage]s
 
 // It is expensive to compute the difference between every architecture.
 // This caches that difference based on the input []NamedIndex for every architecture.
-func (r *disqualifyCache) Get(ctx context.Context, byArch map[string][]NamedIndex) map[*RepositoryPackage]string {
+func (r *disqualifyCache) get(ctx context.Context, byArch map[string][]NamedIndex, resolverCache *resolverCache) map[*RepositoryPackage]string {
 	r.Lock()
 	defer r.Unlock()
 
@@ -142,7 +142,7 @@ func (r *disqualifyCache) Get(ctx context.Context, byArch map[string][]NamedInde
 		return maps.Clone(dq)
 	}
 
-	dq := disqualifyDifference(ctx, byArch)
+	dq := disqualifyDifference(ctx, byArch, resolverCache)
 	r.fill(indexes, dq)
 
 	return maps.Clone(dq)


### PR DESCRIPTION
This makes the shamefully global caches no longer shamefully global if a cache is configured. This allows for better scoping of the respective caches when apko is used as a library.