### PR TITLE
Pin test examples to alpine v3.22 due to ongoing usr-merge effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An apko file for building an Alpine base image looks like this:
 ```yaml
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
 

--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -12,7 +12,7 @@ This is easier to understand by looking at a simple example:
 ```yaml
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
 
@@ -42,7 +42,7 @@ The following example builds an nginx image and covers the full range of apko fe
 ```yaml
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-baselayout
     - nginx

--- a/examples/alpine-amd64.yaml
+++ b/examples/alpine-amd64.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
 

--- a/examples/alpine-base-rootless.yaml
+++ b/examples/alpine-base-rootless.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
 

--- a/examples/alpine-base.yaml
+++ b/examples/alpine-base.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
 

--- a/examples/alpine-python3.yaml
+++ b/examples/alpine-python3.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-base
     - python3

--- a/examples/alpine-slim.yaml
+++ b/examples/alpine-slim.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-baselayout-data
     - apk-tools

--- a/examples/apko-devenv.yaml
+++ b/examples/apko-devenv.yaml
@@ -20,8 +20,8 @@
 #
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
-    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/community
   packages:
     - alpine-base
     - go

--- a/examples/nginx-rootless.yaml
+++ b/examples/nginx-rootless.yaml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.22/main
   packages:
     - alpine-baselayout
     - nginx


### PR DESCRIPTION
Alpine is implementing usr-merge upstream and that is breaking assumptions in our current implementation. To avoid blocking on issues on edge s the implementation is going on upstream, this pins the respective examples that use `alpine-base` to v3.22.