### PR TITLE
apk: fix offline cached builds with alpine key discovery

### DIFF
--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -323,16 +323,24 @@ func (t *cacheTransport) fetchOffline(cacheFile string) (*http.Response, error) 
 		return nil, fmt.Errorf("listing %q for offline cache: %w", cacheDir, err)
 	}
 
-	if len(des) == 0 {
+	// Filter out directories, only consider files
+	var files []os.DirEntry
+	for _, de := range des {
+		if !de.IsDir() {
+			files = append(files, de)
+		}
+	}
+
+	if len(files) == 0 {
 		return nil, fmt.Errorf("no offline cached entries for %s", cacheDir)
 	}
 
-	newest, err := des[0].Info()
+	newest, err := files[0].Info()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, de := range des[1:] {
+	for _, de := range files[1:] {
 		fi, err := de.Info()
 		if err != nil {
 			return nil, err

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -323,11 +323,9 @@ func (a *APK) InitDB(ctx context.Context, buildRepos ...string) error {
 	for _, repo := range buildRepos {
 		if ver, ok := parseAlpineVersion(repo); ok {
 			if err := a.fetchAlpineKeys(ctx, ver); err != nil {
-				if a.cache != nil && !a.cache.offline {
-					var nokeysErr *NoKeysFoundError
-					if !errors.As(err, &nokeysErr) {
-						return fmt.Errorf("failed to fetch alpine-keys: %w", err)
-					}
+				var nokeysErr *NoKeysFoundError
+				if !errors.As(err, &nokeysErr) {
+					return fmt.Errorf("failed to fetch alpine-keys: %w", err)
 				}
 				log.Debugf("ignoring missing keys: %v", err)
 			}
@@ -882,8 +880,6 @@ func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions ...string) err
 
 	u := alpineReleasesURL
 	client := a.client
-	// NB: Does not seem to work, but at least offline builds are
-	// not getting stuck here anymore
 	if a.cache != nil {
 		client = a.cache.client(client, true)
 	}


### PR DESCRIPTION
Even in offline case, calls to releases.json were performed without
caching. And caching them, appears to not work (possibly bug in
cachePathFromURL() as there are not enough sub-directories).

Offline cache is needed to avoid looping trying to download releases.json when one doesn't have
internet and is building with --offline flag.

Then cache discovery needed to be fixed up, as for the first time there is a possibility of a subdirectory in the cached dir. (thanks to @javacruft)

Also downgrade all Warnings around not able to fetch keys to Debug
level, as most of the time they are red-herring (alpine URLs do not have Chainguard key discovery, and most artifactory urls do not have Chainguard key discovery either potentially).