### PR TITLE
github: build samples offline too

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -90,6 +90,7 @@ jobs:
               ${build_script} ./apko
             else
               ./apko build ${cfg} ${name}:build /tmp/${name}.tar --arch amd64
+              ./apko build --offline ${cfg} ${name}:build /tmp/${name}.tar --arch amd64
             fi
           done
 


### PR DESCRIPTION
In the github workflow build samples twice, once online and once
offline. Ideally offline builds should kill the networking, but even
doing implied offline build will help shake out any offline
buildability bugs.
