### PR TITLE
`MergeInto` should favor the receiver value for `run-as`

### DIFF
--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -154,7 +154,7 @@ func (ic *ImageConfiguration) MergeInto(target *ImageConfiguration) error {
 }
 
 func (a *ImageAccounts) MergeInto(target *ImageAccounts) error {
-	if target.RunAs == "" {
+	if a.RunAs != "" {
 		target.RunAs = a.RunAs
 	}
 	target.Users = slices.Concat(a.Users, target.Users)

--- a/pkg/build/types/image_configuration_test.go
+++ b/pkg/build/types/image_configuration_test.go
@@ -208,7 +208,7 @@ func TestMergeInto(t *testing.T) {
 			StopSignal: "bar",
 			WorkDir:    "bar",
 			Accounts: types.ImageAccounts{
-				RunAs: "bar",
+				RunAs: "foo",
 				Users: []types.User{{
 					UserName: "foo",
 					UID:      1000,


### PR DESCRIPTION
Right now this is backwards, so custom assembly overlays wouldn't appropriately override the base configuration's setting.