### PR TITLE
fix(fs): fix dirFS caching bug where ReadFile returns zeros

### DIFF
--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -423,21 +423,15 @@ func (f *dirFS) ReadFile(name string) ([]byte, error) {
 	return f.overrides.ReadFile(name)
 }
 func (f *dirFS) WriteFile(name string, b []byte, mode fs.FileMode) error {
-	var (
-		memContent []byte
-	)
 	if f.createOnDisk(name) {
 		if err := os.WriteFile(filepath.Join(f.base, name), b, mode); err != nil {
 			return err
 		}
-	} else {
-		memContent = b
 	}
 
-	// ensure file exists in memory
-	// if this is just a flag for what is on disk, make it with zero size
-	// if it is the actual file because of case sensitivity, then use the actual content
-	return f.overrides.WriteFile(name, memContent, mode)
+	// Always cache the actual content to ensure ReadFile returns correct data
+	// Previously cached empty buffer for disk files, causing ReadFile to return zeros
+	return f.overrides.WriteFile(name, b, mode)
 }
 
 func (f *dirFS) Readnod(name string) (dev int, err error) {


### PR DESCRIPTION
This fixes a bug in dirFS where WriteFile would cache an empty buffer in the memory overlay even though it wrote the correct data to disk. This caused subsequent ReadFile operations to return zeros instead of the actual file content.

Root cause:
- WriteFile used conditional logic where memContent was left empty when createOnDisk(name) returned true
- The empty buffer was then stored in the overlay via f.overrides.WriteFile(name, memContent, mode)
- ReadFile would return this cached empty buffer when caseSensitiveOnDisk returned false

Impact:
- Any code that wrote a file and then read it back through dirFS could receive zeros instead of actual data
- This particularly affected updateScriptsTar in pkg/apk/apk/installed.go which would corrupt scripts.tar files during package installation

Solution:
- Always cache the actual data in the memory overlay, not an empty buffer
- Simplified WriteFile by removing memContent variable and conditional
- Updated comment to clarify the new behavior

Added comprehensive unit tests to verify:
- Basic write/read cycles work correctly
- Multiple writes/reads maintain data integrity
- Stat calls don't affect caching behavior
- OpenFile/Write/Close patterns work correctly
- The exact updateScriptsTar pattern preserves data

🤖 Generated with [Claude Code](https://claude.com/claude-code)