### PR TITLE
Use in-memory control data everywhere

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -1213,7 +1213,7 @@ func (a *APK) cachedPackage(ctx context.Context, pkg InstallablePackage, cacheDi
 		exp.SignatureHash = signatureHash[:]
 	}
 
-	datahash, err := a.datahash(bytes.NewReader(control))
+	datahash, err := a.datahash(exp.ControlFS)
 	if err != nil {
 		return nil, fmt.Errorf("datahash for %s: %w", pkg, err)
 	}
@@ -1491,16 +1491,15 @@ func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expand
 	}
 
 	// update the triggers
-	controlTar.Reset(controlData)
-	if err := a.updateTriggers(pkg, controlTar); err != nil {
+	if err := a.updateTriggers(pkg, expanded.ControlFS); err != nil {
 		return nil, fmt.Errorf("unable to update triggers for pkg %s: %w", pkg.Name, err)
 	}
 
 	return installedFiles, nil
 }
 
-func (a *APK) datahash(controlTar io.Reader) (string, error) {
-	values, err := a.controlValue(controlTar, "datahash")
+func (a *APK) datahash(controlFS fs.FS) (string, error) {
+	values, err := a.controlValue(controlFS, "datahash")
 	if err != nil {
 		return "", fmt.Errorf("reading datahash from control: %w", err)
 	}

--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -190,8 +191,8 @@ func (a *APK) readScriptsTar() (io.ReadCloser, error) {
 }
 
 // TODO: We should probably parse control section on the first pass and reuse it.
-func (a *APK) controlValue(controlTar io.Reader, want string) ([]string, error) {
-	mapping, err := controlValue(controlTar, want)
+func (a *APK) controlValue(controlFs fs.FS, want string) ([]string, error) {
+	mapping, err := controlValue(controlFs, want)
 	if err != nil {
 		return nil, err
 	}
@@ -204,14 +205,14 @@ func (a *APK) controlValue(controlTar io.Reader, want string) ([]string, error) 
 }
 
 // updateTriggers insert the triggers into the triggers file
-func (a *APK) updateTriggers(pkg *Package, controlTar io.Reader) error {
+func (a *APK) updateTriggers(pkg *Package, controlFs fs.FS) error {
 	triggers, err := a.fs.OpenFile(triggersFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("unable to open triggers file %s: %w", triggersFilePath, err)
 	}
 	defer triggers.Close()
 
-	values, err := a.controlValue(controlTar, "triggers")
+	values, err := a.controlValue(controlFs, "triggers")
 	if err != nil {
 		return fmt.Errorf("updating triggers for %s: %w", pkg.Name, err)
 	}

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"chainguard.dev/apko/internal/tarfs"
 	"chainguard.dev/apko/pkg/apk/expandapk"
 )
 
@@ -461,7 +462,9 @@ func TestUpdateTriggers(t *testing.T) {
 
 	// pass the controltargz to updateScriptsTar
 	r := bytes.NewReader(buf.Bytes())
-	err = a.updateTriggers(pkg, r)
+	fs, err := tarfs.New(r, int64(buf.Len()))
+	require.NoError(t, err, "unable to create tarfs: %v", err)
+	err = a.updateTriggers(pkg, fs)
 	require.NoError(t, err, "unable to update triggers: %v", err)
 
 	// successfully wrote it; not check that it was written correctly


### PR DESCRIPTION
Currently, apko sometimes uses an in-memory version of the control file and sometimes reads the data from the control file itself. This makes all of those instances use the cached data.