### PR TITLE
Add support for SPDX SBOMs without shortcut fields.

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -215,9 +215,20 @@ func (sx *SPDX) ProcessInternalApkSBOM(opts *options.Options, doc *Document, ipk
 	}
 
 	// Cycle the top level elements...
+	// Find elements described by the document - check both documentDescribes array
+	// and DESCRIBES relationships (from SPDXRef-DOCUMENT)
 	idsDescribedByAPKSBOM := map[string]struct{}{}
+
+	// First check documentDescribes array
 	for _, elementID := range apkSBOMDoc.DocumentDescribes {
 		idsDescribedByAPKSBOM[elementID] = struct{}{}
+	}
+
+	// Also check for DESCRIBES relationships from SPDXRef-DOCUMENT
+	for _, rel := range apkSBOMDoc.Relationships {
+		if rel.Element == "SPDXRef-DOCUMENT" && rel.Type == "DESCRIBES" {
+			idsDescribedByAPKSBOM[rel.Related] = struct{}{}
+		}
 	}
 
 	// ... searching for a 1st level package

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -185,6 +185,50 @@ func TestSPDX_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "describes-relationship",
+			opts: &options.Options{
+				ImageInfo: options.ImageInfo{
+					Layers: []v1.Descriptor{{}},
+				},
+				OS: options.OSInfo{
+					Name:    "unknown",
+					ID:      "unknown",
+					Version: "3.0",
+				},
+				FileName: "sbom",
+				Packages: []*apk.InstalledPackage{
+					{
+						Package: apk.Package{
+							Name:    "test-pkg-describes",
+							Version: "1.0.0-r0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "both-describes-methods",
+			opts: &options.Options{
+				ImageInfo: options.ImageInfo{
+					Layers: []v1.Descriptor{{}},
+				},
+				OS: options.OSInfo{
+					Name:    "unknown",
+					ID:      "unknown",
+					Version: "3.0",
+				},
+				FileName: "sbom",
+				Packages: []*apk.InstalledPackage{
+					{
+						Package: apk.Package{
+							Name:    "test-pkg-both",
+							Version: "1.0.0-r0",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sbom/generator/spdx/testdata/apk_sboms/test-pkg-both-1.0.0-r0.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/apk_sboms/test-pkg-both-1.0.0-r0.spdx.json
@@ -1,0 +1,83 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "apk-test-pkg-both-1.0.0-r0",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2025-12-17T00:00:00Z",
+    "creators": [
+      "Tool: melange (test)",
+      "Organization: Chainguard, Inc"
+    ],
+    "licenseListVersion": "3.22"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/test",
+  "documentDescribes": [
+    "SPDXRef-Package-test-pkg-both-1.0.0-r0"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "name": "test-pkg-both",
+      "versionInfo": "1.0.0-r0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:apk/wolfi/test-pkg-both@1.0.0-r0?arch=x86_64&distro=wolfi",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dep-from-array-1.0.0",
+      "name": "dep-from-array",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "https://example.com/dep-from-array-1.0.0.tar.gz",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dep-from-relationship-2.0.0",
+      "name": "dep-from-relationship",
+      "versionInfo": "2.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "BSD-3-Clause",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/example/dep-from-relationship@v2.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-test-pkg-both-1.0.0-r0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-dep-from-array-1.0.0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-dep-from-relationship-2.0.0"
+    }
+  ]
+}

--- a/pkg/sbom/generator/spdx/testdata/apk_sboms/test-pkg-describes-1.0.0-r0.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/apk_sboms/test-pkg-describes-1.0.0-r0.spdx.json
@@ -1,0 +1,101 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "apk-test-pkg-describes-1.0.0-r0",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2025-12-17T00:00:00Z",
+    "creators": [
+      "Tool: melange (test)",
+      "Organization: Chainguard, Inc"
+    ],
+    "licenseListVersion": "3.22"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/test",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "name": "test-pkg-describes",
+      "versionInfo": "1.0.0-r0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:apk/wolfi/test-pkg-describes@1.0.0-r0?arch=x86_64&distro=wolfi",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-test-dependency-1.0.0",
+      "name": "test-dependency",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "https://example.com/test-dependency-1.0.0.tar.gz",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-golang-github.com-example-module",
+      "name": "github.com/example/module",
+      "versionInfo": "v1.2.3",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/example/module@v1.2.3",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-npm-lodash",
+      "name": "lodash",
+      "versionInfo": "4.17.21",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:npm/lodash@4.17.21",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-test-pkg-describes-1.0.0-r0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-test-dependency-1.0.0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-golang-github.com-example-module"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-npm-lodash"
+    }
+  ]
+}

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/both-describes-methods.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/both-describes-methods.spdx.json
@@ -1,0 +1,106 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "sbom",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "0001-01-01T00:00:00Z",
+    "creators": [
+      "Tool: apko (devel)",
+      "Organization: Chainguard, Inc"
+    ],
+    "licenseListVersion": "3.16"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/apko/",
+  "documentDescribes": [
+    "SPDXRef-Package-"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-",
+      "name": "",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "apko operating system layer",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:oci/image?mediaType=\u0026os=linux",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-OperatingSystem-unknown",
+      "name": "unknown",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "name": "test-pkg-both",
+      "versionInfo": "1.0.0-r0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:apk/wolfi/test-pkg-both@1.0.0-r0?arch=x86_64\u0026distro=wolfi",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dep-from-array-1.0.0",
+      "name": "dep-from-array",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "https://example.com/dep-from-array-1.0.0.tar.gz",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dep-from-relationship-2.0.0",
+      "name": "dep-from-relationship",
+      "versionInfo": "2.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "BSD-3-Clause",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: unknown",
+      "supplier": "Organization: unknown",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/example/dep-from-relationship@v2.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-dep-from-array-1.0.0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-dep-from-relationship-2.0.0"
+    }
+  ]
+}

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/describes-relationship.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/describes-relationship.spdx.json
@@ -1,0 +1,129 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "sbom",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "0001-01-01T00:00:00Z",
+    "creators": [
+      "Tool: apko (devel)",
+      "Organization: Chainguard, Inc"
+    ],
+    "licenseListVersion": "3.16"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/apko/",
+  "documentDescribes": [
+    "SPDXRef-Package-"
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-",
+      "name": "",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "apko operating system layer",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:oci/image?mediaType=\u0026os=linux",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-OperatingSystem-unknown",
+      "name": "unknown",
+      "versionInfo": "3.0",
+      "filesAnalyzed": false,
+      "description": "Operating System",
+      "downloadLocation": "NOASSERTION",
+      "supplier": "Organization: unknown",
+      "primaryPackagePurpose": "OPERATING_SYSTEM"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "name": "test-pkg-describes",
+      "versionInfo": "1.0.0-r0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:apk/wolfi/test-pkg-describes@1.0.0-r0?arch=x86_64\u0026distro=wolfi",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-test-dependency-1.0.0",
+      "name": "test-dependency",
+      "versionInfo": "1.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "https://example.com/test-dependency-1.0.0.tar.gz",
+      "originator": "Organization: Test",
+      "supplier": "Organization: Test"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-golang-github.com-example-module",
+      "name": "github.com/example/module",
+      "versionInfo": "v1.2.3",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: unknown",
+      "supplier": "Organization: unknown",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:golang/github.com/example/module@v1.2.3",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-npm-lodash",
+      "name": "lodash",
+      "versionInfo": "4.17.21",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "downloadLocation": "NOASSERTION",
+      "originator": "Organization: unknown",
+      "supplier": "Organization: unknown",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:npm/lodash@4.17.21",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-test-dependency-1.0.0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-golang-github.com-example-module"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-npm-lodash"
+    }
+  ]
+}


### PR DESCRIPTION
SPDX considers documentDescribes as a shortcut field - it is not present in SPDX Go types (even though it will unmarshal them correctly). However, if apko is presented an SBOM without a shortcut field, it will fail to extract out the package details, even though the SBOM is considered valid by SPDX standards.

This adds support to look for the equivalent details in the DESCRIBES relationship.

See https://github.com/spdx/tools-golang/pull/201 for more context.