### PR TITLE
Align go version when linting code with all other actions

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: '1.24'
+          go-version-file: './go.mod'
           check-latest: true
 
       - name: golangci-lint


### PR DESCRIPTION
This is the only place we're still hardcoding the Golang version instead of inferring it from the go.mod file and it breaks PRs that update us to 1.25, so this fixes that.