### PR TITLE
sbom: Deduplicate filesystem arguments.

### DIFF
--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -125,7 +125,7 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 	s.ImageInfo.Arch = arch
 
 	var sboms = make([]types.SBOM, 0)
-	generators := generator.Generators(bc.fs)
+	generators := generator.Generators()
 	for _, format := range s.Formats {
 		gen, ok := generators[format]
 		if !ok {
@@ -238,7 +238,7 @@ func GenerateIndexSBOM(ctx context.Context, o options.Options, ic types.ImageCon
 		return archs[i].String() < archs[j].String()
 	})
 
-	generators := generator.Generators(nil)
+	generators := generator.Generators()
 	var sboms = make([]types.SBOM, 0, len(generators))
 	for _, format := range s.Formats {
 		gen, ok := generators[format]

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -17,8 +17,6 @@ package generator
 import (
 	"context"
 
-	apkfs "chainguard.dev/apko/pkg/apk/fs"
-
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/apko/pkg/sbom/options"
 )
@@ -30,11 +28,11 @@ type Generator interface {
 	GenerateIndex(*options.Options, string) error
 }
 
-func Generators(fsys apkfs.FullFS) map[string]Generator {
+func Generators() map[string]Generator {
 	generators := map[string]Generator{}
 
-	sx := spdx.New(fsys)
-	generators[sx.Key()] = &sx
+	sx := spdx.New()
+	generators[sx.Key()] = sx
 
 	return generators
 }

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -46,11 +46,10 @@ const (
 )
 
 type SPDX struct {
-	fs apkfs.FullFS
 }
 
-func New(fs apkfs.FullFS) SPDX {
-	return SPDX{fs}
+func New() *SPDX {
+	return &SPDX{}
 }
 
 func (sx *SPDX) Key() string {
@@ -198,7 +197,7 @@ func locateApkSBOM(fsys apkfs.FullFS, ipkg *apk.InstalledPackage) (string, error
 
 func (sx *SPDX) ProcessInternalApkSBOM(opts *options.Options, doc *Document, ipkg *apk.InstalledPackage) error {
 	// Check if apk installed an SBOM
-	path, err := locateApkSBOM(sx.fs, ipkg)
+	path, err := locateApkSBOM(opts.FS, ipkg)
 	if err != nil {
 		return fmt.Errorf("inspecting FS for internal apk SBOM: %w", err)
 	}
@@ -333,7 +332,7 @@ func mergeLicensingInfos(sourceDoc, targetDoc *Document) error {
 // ParseInternalSBOM opens an SBOM inside apks and
 func (sx *SPDX) ParseInternalSBOM(opts *options.Options, path string) (*Document, error) {
 	internalSBOM := &Document{}
-	data, err := sx.fs.ReadFile(path)
+	data, err := opts.FS.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening sbom file %s: %w", path, err)
 	}

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -16,7 +16,6 @@ package options
 
 import (
 	"fmt"
-	"io/fs"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -28,6 +27,7 @@ import (
 	purl "github.com/package-url/packageurl-go"
 
 	"chainguard.dev/apko/pkg/apk/apk"
+	"chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build/types"
 )
 
@@ -37,7 +37,7 @@ type Options struct {
 	ImageInfo ImageInfo
 
 	// Working directory,inherited from build context
-	FS fs.FS
+	FS fs.FullFS
 
 	// The reference of the generated image. Used for naming and purls
 	ImageReference string


### PR DESCRIPTION
SBOM generators took in an SBOM at initialization, but also at Generate time. This meant there could be 2 different filesystems, but it was also unclear why we needed to have the filesystem at init time anyway, since it means that generators had to be tied 1:1 to their filesystems instead of reused for multiple files systems.

In practice, these were the same filesystem being plumbed at 2 different places. This simplifies this so that we only use the Generate-time FS which makes the most sense.

BREAKING CHANGE:

- SBOM Generators no longer take a filesystem at init time. The filesystem passed in through the SBOM options at generation time is used.