### PR TITLE
sbom: Include predicate type as the output SBOM.

### DIFF
--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -129,10 +129,11 @@ func (bc *Context) GenerateImageSBOM(ctx context.Context, arch types.Architectur
 			return nil, fmt.Errorf("generating %s sbom: %w", gen.Key(), err)
 		}
 		sboms = append(sboms, types.SBOM{
-			Path:   filename,
-			Format: gen.Key(),
-			Arch:   arch.String(),
-			Digest: h,
+			Path:          filename,
+			Format:        gen.Key(),
+			PredicateType: gen.PredicateType(),
+			Arch:          arch.String(),
+			Digest:        h,
 		})
 	}
 	return sboms, nil
@@ -259,9 +260,10 @@ func GenerateIndexSBOM(ctx context.Context, o options.Options, ic types.ImageCon
 			return nil, fmt.Errorf("generating %s sbom: %w", gen.Key(), err)
 		}
 		sboms = append(sboms, types.SBOM{
-			Path:   filename,
-			Format: gen.Key(),
-			Digest: h,
+			Path:          filename,
+			Format:        gen.Key(),
+			PredicateType: gen.PredicateType(),
+			Digest:        h,
 		})
 	}
 

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -429,10 +429,11 @@ func ParseArchitectures(in []string) []Architecture {
 }
 
 type SBOM struct {
-	Arch   string
-	Path   string
-	Format string
-	Digest v1.Hash
+	Arch          string
+	Path          string
+	Format        string
+	PredicateType string
+	Digest        v1.Hash
 }
 
 type Layering struct {

--- a/pkg/sbom/generator/generator.go
+++ b/pkg/sbom/generator/generator.go
@@ -25,6 +25,7 @@ import (
 type Generator interface {
 	Key() string
 	Ext() string
+	PredicateType() string
 	Generate(context.Context, *options.Options, string) error
 	GenerateIndex(*options.Options, string) error
 }

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -66,6 +66,10 @@ func (sx *SPDX) Ext() string {
 	return "spdx.json"
 }
 
+func (sx *SPDX) PredicateType() string {
+	return "https://spdx.dev/Document"
+}
+
 func stringToIdentifier(in string) (out string) {
 	in = strings.ReplaceAll(in, ":", "-")
 	return validIDCharsRe.ReplaceAllStringFunc(in, func(s string) string {


### PR DESCRIPTION
Currently we use the generator key as the format in the generated SBOM (e.g. "spdx"). It's more useful if we can get the predicate type in the output so we can know how to handle and parse it.