### PR TITLE
Add String functions to filesystem implementations

### DIFF
--- a/pkg/apk/fs/memfs.go
+++ b/pkg/apk/fs/memfs.go
@@ -54,6 +54,10 @@ func NewMemFS() FullFS {
 	}
 }
 
+func (m *memFS) String() string {
+	return "memfs"
+}
+
 // getNode returns the node for the given path. If the path is not found, it
 // returns an error.
 func (m *memFS) getNode(path string) (*node, error) {

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -207,6 +207,10 @@ type dirFS struct {
 	caseMapMutex sync.Mutex
 }
 
+func (f *dirFS) String() string {
+	return fmt.Sprintf("dirfs:%s", f.base)
+}
+
 func (f *dirFS) Readlink(name string) (string, error) {
 	// The underlying filesystem might not support symlinks, and it might be case-insensitive, so just
 	// use the one in memory.

--- a/pkg/apk/fs/sub.go
+++ b/pkg/apk/fs/sub.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"time"
@@ -10,6 +11,10 @@ import (
 type SubFS struct {
 	FS   FullFS
 	Root string
+}
+
+func (s *SubFS) String() string {
+	return fmt.Sprintf("%s:%s", s.FS, s.Root)
 }
 
 func (s *SubFS) Open(path string) (fs.File, error) {

--- a/pkg/tarfs/fs.go
+++ b/pkg/tarfs/fs.go
@@ -104,6 +104,10 @@ func checksumFromHeader(header *tar.Header) ([]byte, error) {
 	return checksum, nil
 }
 
+func (m *memFS) String() string {
+	return "tarfs"
+}
+
 func (m *memFS) WriteHeader(hdr tar.Header, tfs fs.FS, pkg *apk.Package) (bool, error) {
 	switch hdr.Typeflag {
 	case tar.TypeDir:


### PR DESCRIPTION
In error messages, filesystems are often printed (eg. https://github.com/chainguard-dev/apko/blob/db9be70c9b6128401a79ec6604d73c0f53a93504/pkg/apk/apk/repo.go#L129).

Without String function, this resulted in unreadable error messages:
```
Error: could not open repositories file in &{/ %!s(*fs.memFS=&{0xc000162000}) map[] {{} {%!s(int32=0) %!s(uint32=0)}}} at etc/apk/repositories: open /etc/apk/repositories: no such file or directory
```

This is the new error message:
```
Error: could not open repositories file in dirfs:/ at etc/apk/repositories: open /etc/apk/repositories: no such file or directory
```