### PR TITLE
Refactor and export range retry transport

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -1384,7 +1384,7 @@ func (a *APK) FetchPackage(ctx context.Context, pkg FetchablePackage) (io.ReadCl
 		}
 
 		// This will return a body that retries requests using Range requests if Read() hits an error.
-		rrt := newRangeRetryTransport(ctx, client)
+		rrt := NewRangeRetryTransport(client.Transport)
 		res, err := rrt.RoundTrip(req)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get package apk at %s: %w", u, err)

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -321,7 +321,7 @@ func fetchRepositoryIndex(ctx context.Context, u string, etag string, opts *inde
 	}
 
 	// This will return a body that retries requests using Range requests if Read() hits an error.
-	rrt := newRangeRetryTransport(ctx, client)
+	rrt := NewRangeRetryTransport(client.Transport)
 	res, err := rrt.RoundTrip(req)
 	if err != nil {
 		return nil, err

--- a/pkg/apk/apk/transport_test.go
+++ b/pkg/apk/apk/transport_test.go
@@ -16,7 +16,6 @@ package apk
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -166,7 +165,7 @@ func TestTransport(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
-			rt := newRangeRetryTransport(context.Background(), &http.Client{Transport: tt})
+			rt := NewRangeRetryTransport(tt)
 
 			req := &http.Request{
 				URL:    &url.URL{},


### PR DESCRIPTION
This transport had some weirdness about it in terms of using an HTTP client internally instead of the "usual" transport layering. This fixes that and also avoids storing a context unnecessarily. That makes the transport itself stateless and statically usable for clients as well.

Fixes a couple of other nits around the transport as well.