### PR TITLE
sbom: Make sure sbom packages are connected to the document root.

### DIFF
--- a/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-aarch64.spdx.json
@@ -152,9 +152,19 @@
       "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout.melange.yaml-8e7230fc2d8afd47a5341ca0ba9b63f93bda5491"
     },
     {
+      "spdxElementId": "SPDXRef-Package-sha256-462b8caeb0369dd5ec14eb4f698cddd327f26ba65720561497217ffad2e96d6a",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
+    },
+    {
       "spdxElementId": "SPDXRef-Package-replayout-1.0.0-r0",
       "relationshipType": "DESCRIBED_BY",
       "relatedSpdxElement": "SPDXRef-Package-replayout.melange.yaml-8e7230fc2d8afd47a5341ca0ba9b63f93bda5491"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-sha256-462b8caeb0369dd5ec14eb4f698cddd327f26ba65720561497217ffad2e96d6a",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-replayout-1.0.0-r0"
     }
   ]
 }

--- a/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
+++ b/internal/cli/testdata/golden/sboms/sbom-x86_64.spdx.json
@@ -152,9 +152,19 @@
       "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout.melange.yaml-8e7230fc2d8afd47a5341ca0ba9b63f93bda5491"
     },
     {
+      "spdxElementId": "SPDXRef-Package-sha256-3fa87a64fb699f65953caad1adcba9f5d3f25134bfff43f92a1ed097712cd79a",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-pretend-baselayout-1.0.0-r0"
+    },
+    {
       "spdxElementId": "SPDXRef-Package-replayout-1.0.0-r0",
       "relationshipType": "DESCRIBED_BY",
       "relatedSpdxElement": "SPDXRef-Package-replayout.melange.yaml-8e7230fc2d8afd47a5341ca0ba9b63f93bda5491"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-sha256-3fa87a64fb699f65953caad1adcba9f5d3f25134bfff43f92a1ed097712cd79a",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-replayout-1.0.0-r0"
     }
   ]
 }

--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -264,6 +264,19 @@ func (sx *SPDX) ProcessInternalApkSBOM(opts *options.Options, doc *Document, ipk
 		return fmt.Errorf("merging LicensingInfos: %w", err)
 	}
 
+	// Add CONTAINS relationships from the document root package to all top-level elements from the internal SBOM.
+	// This ensures they are reachable from the document root for tools that traverse the SBOM graph.
+	if len(doc.DocumentDescribes) > 0 {
+		rootPkgID := doc.DocumentDescribes[0]
+		for elementID := range targetElementIDs {
+			doc.Relationships = append(doc.Relationships, Relationship{
+				Element: rootPkgID,
+				Type:    "CONTAINS",
+				Related: elementID,
+			})
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/both-describes-methods.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/both-describes-methods.spdx.json
@@ -101,6 +101,11 @@
       "spdxElementId": "SPDXRef-Package-test-pkg-both-1.0.0-r0",
       "relationshipType": "DEPENDS_ON",
       "relatedSpdxElement": "SPDXRef-Package-dep-from-relationship-2.0.0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-test-pkg-both-1.0.0-r0"
     }
   ]
 }

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/custom-license.spdx.json
@@ -62,7 +62,13 @@
       ]
     }
   ],
-  "relationships": [],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-font-ubuntu-0.869-r1"
+    }
+  ],
   "hasExtractedLicensingInfos": [
     {
       "licenseId": "LicenseRef-ubuntu-font",

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/describes-relationship.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/describes-relationship.spdx.json
@@ -124,6 +124,11 @@
       "spdxElementId": "SPDXRef-Package-test-pkg-describes-1.0.0-r0",
       "relationshipType": "DEPENDS_ON",
       "relatedSpdxElement": "SPDXRef-Package-npm-lodash"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-test-pkg-describes-1.0.0-r0"
     }
   ]
 }

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/no-supplier.spdx.json
@@ -62,5 +62,11 @@
       ]
     }
   ],
-  "relationships": []
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-libattr1-2.5.1-r2"
+    }
+  ]
 }

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/package-deduplicating.spdx.json
@@ -129,6 +129,11 @@
       "relatedSpdxElement": "SPDXRef-Package-github.com-elastic-logstash-v8.15.3-8364c8e89cfb113e38ec3f966df7eb1e9abe9d33-0"
     },
     {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-logstash-8-8.15.3-r4"
+    },
+    {
       "spdxElementId": "SPDXRef-Package-logstash-8-compat-8.15.3-r4",
       "relationshipType": "DESCRIBED_BY",
       "relatedSpdxElement": "SPDXRef-Package-logstash-8.yaml-c7d40faa38ddffa98700cfa4c2f9bde196acc504"
@@ -137,6 +142,11 @@
       "spdxElementId": "SPDXRef-Package-logstash-8-compat-8.15.3-r4",
       "relationshipType": "GENERATED_FROM",
       "relatedSpdxElement": "SPDXRef-Package-github.com-elastic-logstash-v8.15.3-8364c8e89cfb113e38ec3f966df7eb1e9abe9d33-0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-logstash-8-compat-8.15.3-r4"
     }
   ]
 }

--- a/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
+++ b/pkg/sbom/generator/spdx/testdata/expected_image_sboms/unbound-package-dedupe.spdx.json
@@ -148,6 +148,11 @@
       "relatedSpdxElement": "SPDXRef-Package-github.com-NLnetLabs-unbound-release-1.23.0-30c13d0351abd2edc3d6dc76365f576c87b9736e-0"
     },
     {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-unbound-libs-1.23.0-r0"
+    },
+    {
       "spdxElementId": "SPDXRef-Package-unbound-1.23.0-r0",
       "relationshipType": "DESCRIBED_BY",
       "relatedSpdxElement": "SPDXRef-Package-unbound.yaml-23e8ff8479b39f3f2e97fdca28d814f0c434c39b"
@@ -158,6 +163,11 @@
       "relatedSpdxElement": "SPDXRef-Package-github.com-NLnetLabs-unbound-release-1.23.0-30c13d0351abd2edc3d6dc76365f576c87b9736e-0"
     },
     {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-unbound-1.23.0-r0"
+    },
+    {
       "spdxElementId": "SPDXRef-Package-unbound-config-1.23.0-r0",
       "relationshipType": "DESCRIBED_BY",
       "relatedSpdxElement": "SPDXRef-Package-unbound.yaml-23e8ff8479b39f3f2e97fdca28d814f0c434c39b"
@@ -166,6 +176,11 @@
       "spdxElementId": "SPDXRef-Package-unbound-config-1.23.0-r0",
       "relationshipType": "GENERATED_FROM",
       "relatedSpdxElement": "SPDXRef-Package-github.com-NLnetLabs-unbound-release-1.23.0-30c13d0351abd2edc3d6dc76365f576c87b9736e-0"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Package-unbound-config-1.23.0-r0"
     }
   ]
 }


### PR DESCRIPTION
Currently we do not link the packages to the top level described document, so if you try to traverse the document graph you end up not reaching a lot of the nodes.

This adds a describe relationship to all packages, to create the edge.