### PR TITLE
Fix retry handling of the range retry transport

### DIFF
--- a/pkg/apk/apk/transport.go
+++ b/pkg/apk/apk/transport.go
@@ -72,6 +72,10 @@ func (r *rangeRetryReader) reset(oerr error) (*http.Response, error) {
 		return resp, nil
 	}
 
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+		// Redirects should be handed back as-is so the client can deal with them.
+		return resp, nil
+	}
 	if resp.StatusCode == http.StatusOK {
 		// If the upstream doesn't support Range requests for some reason and only returns 200,
 		// we need to discard anything we've already Read().


### PR DESCRIPTION
Before a recent refactor in 89f7c136729d533c74518b174099a1131d5092a9 the "transport" used an HTTP inside of it, which dealt with redirects inside of the transport itself. This is now subtly broken in that the default usage in apko passes a cache in, which in term uses a client as well. If this transport is used without a client though, redirects actually fail.

This makes it so that redirects are passed through as is so an external client can handle them accordingly.