### PR TITLE
Add limit readers for readers that consume data from external sources.

### DIFF
--- a/internal/cli/build-cpio.go
+++ b/internal/cli/build-cpio.go
@@ -28,6 +28,7 @@ import (
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/cpio"
+	"chainguard.dev/apko/pkg/options"
 )
 
 func buildCPIO() *cobra.Command {
@@ -38,6 +39,7 @@ func buildCPIO() *cobra.Command {
 	var extraBuildRepos []string
 	var extraRepos []string
 	var extraPackages []string
+	var sizeLimits options.SizeLimits
 
 	cmd := &cobra.Command{
 		Use:     "build-cpio",
@@ -56,6 +58,7 @@ func buildCPIO() *cobra.Command {
 				build.WithBuildDate(buildDate),
 				build.WithSBOM(sbomPath),
 				build.WithArch(types.ParseArchitecture(buildArch)),
+				build.WithSizeLimits(sizeLimits),
 			)
 		},
 	}
@@ -67,6 +70,7 @@ func buildCPIO() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
+	addClientLimitFlags(cmd, &sizeLimits)
 
 	return cmd
 }

--- a/internal/cli/build-minirootfs.go
+++ b/internal/cli/build-minirootfs.go
@@ -26,6 +26,7 @@ import (
 
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/tarfs"
 )
 
@@ -38,6 +39,7 @@ func buildMinirootFS() *cobra.Command {
 	var extraBuildRepos []string
 	var extraRepos []string
 	var extraPackages []string
+	var sizeLimits options.SizeLimits
 
 	cmd := &cobra.Command{
 		Use:     "build-minirootfs",
@@ -57,6 +59,7 @@ func buildMinirootFS() *cobra.Command {
 				build.WithSBOM(sbomPath),
 				build.WithArch(types.ParseArchitecture(buildArch)),
 				build.WithIgnoreSignatures(ignoreSignatures),
+				build.WithSizeLimits(sizeLimits),
 			)
 		},
 	}
@@ -69,6 +72,7 @@ func buildMinirootFS() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraBuildRepos, "build-repository-append", "b", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include")
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
+	addClientLimitFlags(cmd, &sizeLimits)
 
 	return cmd
 }

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -37,6 +37,7 @@ import (
 	"chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/oci"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/sbom/generator"
 	"chainguard.dev/apko/pkg/tarfs"
 )
@@ -58,6 +59,7 @@ func buildCmd() *cobra.Command {
 	var lockfile string
 	var includePaths []string
 	var ignoreSignatures bool
+	var sizeLimits options.SizeLimits
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -116,6 +118,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithTempDir(tmp),
 				build.WithIncludePaths(includePaths),
 				build.WithIgnoreSignatures(ignoreSignatures),
+				build.WithSizeLimits(sizeLimits),
 			)
 		},
 	}
@@ -136,6 +139,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringVar(&lockfile, "lockfile", "", "a path to .lock.json file (e.g. produced by apko lock) that constraints versions of packages to the listed ones (default '' means no additional constraints)")
 	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append.")
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
+	addClientLimitFlags(cmd, &sizeLimits)
 	return cmd
 }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,35 @@
+// Copyright 2022, 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"chainguard.dev/apko/pkg/options"
+)
+
+// addClientLimitFlags adds size limit flags for APK client operations (fetching indexes, expanding packages).
+func addClientLimitFlags(cmd *cobra.Command, limits *options.SizeLimits) {
+	defaults := options.DefaultSizeLimits()
+
+	cmd.Flags().Int64Var(&limits.APKIndexDecompressedMaxSize, "max-apkindex-decompressed-size", defaults.APKIndexDecompressedMaxSize,
+		"maximum decompressed size for APKINDEX archives in bytes, protects against gzip bombs (0=default, -1=no limit)")
+	cmd.Flags().Int64Var(&limits.APKControlMaxSize, "max-apk-control-size", defaults.APKControlMaxSize,
+		"maximum decompressed size for APK control sections in bytes (0=default, -1=no limit)")
+	cmd.Flags().Int64Var(&limits.APKDataMaxSize, "max-apk-data-size", defaults.APKDataMaxSize,
+		"maximum decompressed size for APK data sections in bytes, protects against gzip bombs (0=default, -1=no limit)")
+	cmd.Flags().Int64Var(&limits.HTTPResponseMaxSize, "max-http-response-size", defaults.HTTPResponseMaxSize,
+		"maximum size for HTTP responses in bytes (0=default, -1=no limit)")
+}

--- a/pkg/apk/apk/limited_transport.go
+++ b/pkg/apk/apk/limited_transport.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"io"
+	"net/http"
+
+	"chainguard.dev/apko/pkg/limitio"
+)
+
+// limitedResponseTransport wraps an http.RoundTripper and limits the size of response bodies.
+type limitedResponseTransport struct {
+	wrapped http.RoundTripper
+	maxSize int64
+}
+
+// newLimitedResponseTransport creates a new transport that limits HTTP response body sizes.
+// If maxSize is -1, responses are unlimited.
+// If maxSize is 0, the default DefaultHTTPResponseSize is used.
+func newLimitedResponseTransport(wrapped http.RoundTripper, maxSize int64) http.RoundTripper {
+	return &limitedResponseTransport{
+		wrapped: wrapped,
+		maxSize: maxSize,
+	}
+}
+
+func (t *limitedResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the response body with a limited reader
+	resp.Body = &limitedReadCloser{
+		ReadCloser: resp.Body,
+		limited:    limitio.NewLimitedReaderWithDefault(resp.Body, t.maxSize, DefaultHTTPResponseSize),
+	}
+
+	return resp, nil
+}
+
+// limitedReadCloser wraps a ReadCloser with size limiting.
+type limitedReadCloser struct {
+	io.ReadCloser
+	limited io.Reader
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	return l.limited.Read(p)
+}

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -38,6 +38,15 @@ type opts struct {
 	ignoreSignatures   bool
 	transport          http.RoundTripper
 	packageGetter      PackageGetter
+	sizeLimits         *SizeLimits
+}
+
+// SizeLimits configures maximum sizes for various APK operations.
+type SizeLimits struct {
+	APKIndexDecompressedMaxSize int64
+	APKControlMaxSize           int64
+	APKDataMaxSize              int64
+	HTTPResponseMaxSize         int64
 }
 
 type Option func(*opts) error
@@ -150,6 +159,14 @@ func WithTransport(t http.RoundTripper) Option {
 func WithPackageGetter(pg PackageGetter) Option {
 	return func(o *opts) error {
 		o.packageGetter = pg
+		return nil
+	}
+}
+
+// WithSizeLimits sets size limits for APK operations.
+func WithSizeLimits(limits *SizeLimits) Option {
+	return func(o *opts) error {
+		o.sizeLimits = limits
 		return nil
 	}
 }

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -182,10 +182,14 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	if a.cache != nil {
 		httpClient = a.cache.client(httpClient, true)
 	}
-	opts := []IndexOption{WithIgnoreSignatures(ignoreSignatures),
+	opts := []IndexOption{
+		WithIgnoreSignatures(ignoreSignatures),
 		WithIgnoreSignatureForIndexes(a.noSignatureIndexes...),
 		WithHTTPClient(httpClient),
 		WithIndexAuthenticator(a.auth),
+	}
+	if sz := a.apkIndexDecompressedMaxSize(); sz != 0 {
+		opts = append(opts, WithIndexDecompressedMaxSize(sz))
 	}
 	return GetRepositoryIndexes(ctx, repos, keys, arch, opts...)
 }

--- a/pkg/apk/expandapk/options.go
+++ b/pkg/apk/expandapk/options.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expandapk
+
+// DefaultMaxControlSize is the default maximum decompressed size for control sections (10 MB).
+const DefaultMaxControlSize int64 = 10 << 20
+
+// DefaultMaxDataSize is the default maximum decompressed size for data sections (4 GB).
+const DefaultMaxDataSize int64 = 4 << 30
+
+// Options configures the behavior of APK expansion operations.
+type Options struct {
+	// MaxControlSize is the maximum decompressed size for signature and control sections.
+	// Use -1 for unlimited.
+	MaxControlSize int64
+
+	// MaxDataSize is the maximum decompressed size for the data section.
+	// Use -1 for unlimited.
+	MaxDataSize int64
+}
+
+// Option is a functional option for configuring Options.
+type Option func(*Options) error
+
+// WithMaxControlSize sets the maximum decompressed size for signature and control sections.
+func WithMaxControlSize(size int64) Option {
+	return func(o *Options) error {
+		o.MaxControlSize = size
+		return nil
+	}
+}
+
+// WithMaxDataSize sets the maximum decompressed size for the data section.
+func WithMaxDataSize(size int64) Option {
+	return func(o *Options) error {
+		o.MaxDataSize = size
+		return nil
+	}
+}
+
+// DefaultOptions returns Options with default size limits.
+func DefaultOptions() *Options {
+	return &Options{
+		MaxControlSize: DefaultMaxControlSize,
+		MaxDataSize:    DefaultMaxDataSize,
+	}
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -282,6 +282,12 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		apk.WithAuthenticator(bc.o.Auth),
 		apk.WithTransport(bc.o.Transport),
 		apk.WithPackageGetter(bc.o.PackageGetter),
+		apk.WithSizeLimits(&apk.SizeLimits{
+			APKIndexDecompressedMaxSize: bc.o.SizeLimits.APKIndexDecompressedMaxSize,
+			APKControlMaxSize:           bc.o.SizeLimits.APKControlMaxSize,
+			APKDataMaxSize:              bc.o.SizeLimits.APKDataMaxSize,
+			HTTPResponseMaxSize:         bc.o.SizeLimits.HTTPResponseMaxSize,
+		}),
 	}
 	// only try to pass the cache dir if one of the following is true:
 	// - the user has explicitly set a cache dir

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -26,6 +26,7 @@ import (
 	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/sbom/generator"
 
 	"github.com/chainguard-dev/clog"
@@ -254,6 +255,14 @@ func WithTransport(t http.RoundTripper) Option {
 func WithPackageGetter(pg apk.PackageGetter) Option {
 	return func(bc *Context) error {
 		bc.o.PackageGetter = pg
+		return nil
+	}
+}
+
+// WithSizeLimits sets the size limits for various operations.
+func WithSizeLimits(limits options.SizeLimits) Option {
+	return func(bc *Context) error {
+		bc.o.SizeLimits = limits
 		return nil
 	}
 }

--- a/pkg/cpio/layer.go
+++ b/pkg/cpio/layer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/u-root/u-root/pkg/cpio"
 )
 
+// FromLayer converts a container layer to CPIO format.
 func FromLayer(layer v1.Layer, dest io.Writer) error {
 	// Open the filesystem layer to walk through the file.
 	u, err := layer.Uncompressed()
@@ -31,6 +32,7 @@ func FromLayer(layer v1.Layer, dest io.Writer) error {
 		return err
 	}
 	defer u.Close()
+
 	tarReader := tar.NewReader(u)
 
 	w := cpio.NewDedupWriter(cpio.Newc.Writer(dest))

--- a/pkg/limitio/limitio.go
+++ b/pkg/limitio/limitio.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package limitio provides size-limited I/O operations to prevent unbounded reads.
+package limitio
+
+import (
+	"fmt"
+	"io"
+)
+
+// SizeLimitExceededError is returned when a read exceeds its configured size limit.
+type SizeLimitExceededError struct {
+	Limit int64
+}
+
+func (e *SizeLimitExceededError) Error() string {
+	return fmt.Sprintf("size limit exceeded: limit is %d bytes", e.Limit)
+}
+
+// LimitedReader wraps io.LimitedReader and returns a SizeLimitExceededError when the
+// limit is exceeded. Unlike io.LimitedReader which returns EOF, this returns a
+// specific error to indicate the limit was exceeded.
+type LimitedReader struct {
+	lr       *io.LimitedReader
+	limit    int64 // original limit for error messages
+	exceeded bool  // true if we've determined the limit was exceeded
+}
+
+// NewLimitedReader creates a new LimitedReader that will return a SizeLimitExceededError
+// if more than limit bytes are read from r.
+//   - If limit == -1: returns the reader unwrapped (unlimited)
+func NewLimitedReader(r io.Reader, limit int64) io.Reader {
+	if limit == -1 {
+		return r
+	}
+	return &LimitedReader{
+		lr:    &io.LimitedReader{R: r, N: limit},
+		limit: limit,
+	}
+}
+
+// NewLimitedReaderWithDefault creates a LimitedReader with special handling for default values:
+//   - If limit == -1: returns the reader unwrapped (unlimited)
+//   - If limit == 0: uses defaultLimit
+//   - Otherwise: uses the provided limit
+func NewLimitedReaderWithDefault(r io.Reader, limit, defaultLimit int64) io.Reader {
+	if limit == 0 {
+		limit = defaultLimit
+	}
+	return NewLimitedReader(r, limit)
+}
+
+func (l *LimitedReader) Read(p []byte) (n int, err error) {
+	if l.exceeded {
+		return 0, &SizeLimitExceededError{Limit: l.limit}
+	}
+	n, err = l.lr.Read(p)
+	if err == io.EOF && l.lr.N <= 0 {
+		// LimitedReader returns EOF when limit is reached, but we need to check
+		// if there's more data available to determine if the limit was exceeded.
+		// Try to read one more byte from the underlying reader.
+		var buf [1]byte
+		if nn, _ := l.lr.R.Read(buf[:]); nn > 0 {
+			l.exceeded = true
+			return n, &SizeLimitExceededError{Limit: l.limit}
+		}
+	}
+	return n, err
+}


### PR DESCRIPTION
This adds a safety layer to tune resource usage for any reads of APKs, APK indexes, or other external data sources.

These are all optional flags, that default to a default value if not set.