### PR TITLE
chore(zizmor): trigger zizmor on updates to dependabot config [PSEC-871]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
   schedule:
     interval: "daily"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+rules:
+  # adjust the default cooldown for non-security dependabot updates
+  # to 3 days, down from 7.
+  dependabot-cooldown:
+    config:
+      days: 3


### PR DESCRIPTION
Since zizmor flags on lack of a cooldown config in the dependabot configuration, update the zizmor workflow config to trigger on updates to that configuration as well. Similarly trigger for changes to the zizmor configuration.

v2: add a 3-day cooldown to the dependabot config, as well as a zizmor config file set to allow cooldowns less than the default 7 days.