### PR TITLE
fs: strip special mode bits in OpenFile/WriteFile

### DIFF
--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"slices"
 	"strings"
@@ -55,16 +56,27 @@ func (a *APK) writeOneFile(header *tar.Header, r io.Reader, allowOverwrite bool)
 			return fmt.Errorf("unable to remove existing file %s: %w", header.Name, err)
 		}
 	}
-	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, header.FileInfo().Mode())
+	mode := header.FileInfo().Mode()
+	// a.fs silently strips setuid/setgid/sticky from OpenFile; we re-apply
+	// them with Chmod after Close so the kernel's file_remove_privs() (Linux,
+	// non-privileged writer) doesn't clear them during the write below.
+	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", header.Name, err)
 	}
-	defer f.Close()
 
 	if _, err := io.CopyN(f, r, header.Size); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("unable to write content for %s: %w", header.Name, err)
 	}
-	// override one of the
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to close %s: %w", header.Name, err)
+	}
+	if mode&(fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky) != 0 {
+		if err := a.fs.Chmod(header.Name, mode); err != nil {
+			return fmt.Errorf("unable to apply special mode bits to %s: %w", header.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"slices"
 	"strings"
@@ -56,27 +55,16 @@ func (a *APK) writeOneFile(header *tar.Header, r io.Reader, allowOverwrite bool)
 			return fmt.Errorf("unable to remove existing file %s: %w", header.Name, err)
 		}
 	}
-	mode := header.FileInfo().Mode()
-	// a.fs silently strips setuid/setgid/sticky from OpenFile; we re-apply
-	// them with Chmod after Close so the kernel's file_remove_privs() (Linux,
-	// non-privileged writer) doesn't clear them during the write below.
-	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	f, err := a.fs.OpenFile(header.Name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, header.FileInfo().Mode())
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", header.Name, err)
 	}
+	defer f.Close()
 
 	if _, err := io.CopyN(f, r, header.Size); err != nil {
-		_ = f.Close()
 		return fmt.Errorf("unable to write content for %s: %w", header.Name, err)
 	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("unable to close %s: %w", header.Name, err)
-	}
-	if mode&(fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky) != 0 {
-		if err := a.fs.Chmod(header.Name, mode); err != nil {
-			return fmt.Errorf("unable to apply special mode bits to %s: %w", header.Name, err)
-		}
-	}
+	// override one of the
 	return nil
 }
 

--- a/pkg/apk/apk/path_traversal_test.go
+++ b/pkg/apk/apk/path_traversal_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
@@ -238,6 +239,90 @@ func TestSymlinkEscape_HardlinkThroughSymlink(t *testing.T) {
 	if _, statErr := os.Lstat(outsideLinked); statErr == nil {
 		t.Fatalf("expected %s to not exist after fix", outsideLinked)
 	}
+}
+
+// TestInstallSetuidBinary exercises the end-to-end install of a setuid regular
+// file — the mount binary shape that triggered "unsupported file mode" on
+// melange qemu runners. dirFS.OpenFile silently strips non-perm mode bits;
+// installRegularFile must re-apply them with Chmod after Close so the setuid
+// bit survives the kernel's file_remove_privs() during the write.
+func TestInstallSetuidBinary(t *testing.T) {
+	ctx := t.Context()
+
+	sandbox := t.TempDir()
+	base := filepath.Join(sandbox, "base")
+	fsys := apkfs.DirFS(ctx, base, apkfs.WithCreateDir())
+	if fsys == nil {
+		t.Fatalf("failed to create dirfs for base %s", base)
+	}
+
+	a, err := New(ctx, WithFS(fsys))
+	if err != nil {
+		t.Fatalf("apk.New: %v", err)
+	}
+
+	content := []byte("setuid binary payload")
+	// 0o4755 = S_ISUID | rwxr-xr-x — the shape in the mount APK's tar header.
+	r, err := makeTestTarWithRegFile("usr/bin/mount", content, 0o4755)
+	if err != nil {
+		t.Fatalf("makeTestTarWithRegFile: %v", err)
+	}
+
+	if _, err := a.installAPKFiles(ctx, r, &Package{}); err != nil {
+		t.Fatalf("installAPKFiles failed: %v", err)
+	}
+
+	installed := filepath.Join(base, "usr/bin/mount")
+	fi, err := os.Stat(installed)
+	if err != nil {
+		t.Fatalf("installed file missing: %v", err)
+	}
+	if fi.Mode()&os.ModeSetuid == 0 {
+		t.Fatalf("expected setuid bit on %s, got mode %s", installed, fi.Mode())
+	}
+	if fi.Mode().Perm() != 0o755 {
+		t.Fatalf("expected perm 0o755 on %s, got %o", installed, fi.Mode().Perm())
+	}
+
+	got, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatalf("reading installed file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func makeTestTarWithRegFile(name string, content []byte, mode int64) (*bytes.Reader, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	// Emit a TypeDir entry for each parent so installAPKFiles can MkdirAll
+	// before the regular-file entry lands.
+	parts := strings.Split(filepath.ToSlash(name), "/")
+	for i := 1; i < len(parts); i++ {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     strings.Join(parts[:i], "/") + "/",
+			Typeflag: tar.TypeDir,
+			Mode:     0o755,
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Mode:     mode,
+		Size:     int64(len(content)),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(content); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(buf.Bytes()), nil
 }
 
 func makeSymlinkThenFileTar(symlinkName, symlinkTarget, fileName string, content []byte) (*bytes.Reader, error) {

--- a/pkg/apk/apk/path_traversal_test.go
+++ b/pkg/apk/apk/path_traversal_test.go
@@ -242,10 +242,11 @@ func TestSymlinkEscape_HardlinkThroughSymlink(t *testing.T) {
 }
 
 // TestInstallSetuidBinary exercises the end-to-end install of a setuid regular
-// file — the mount binary shape that triggered "unsupported file mode" on
-// melange qemu runners. dirFS.OpenFile silently strips non-perm mode bits;
-// installRegularFile must re-apply them with Chmod after Close so the setuid
-// bit survives the kernel's file_remove_privs() during the write.
+// file — the mount-binary shape that triggered "unsupported file mode" on
+// melange qemu runners. *os.Root rejects non-permission bits in OpenFile, so
+// dirFS.OpenFile silently strips them; the full mode survives via the memFS
+// overlay and is what downstream layer/tar/cpio emitters consume through
+// dirFS.Stat().Mode() and DirEntry.Info().Mode().
 func TestInstallSetuidBinary(t *testing.T) {
 	ctx := t.Context()
 
@@ -272,24 +273,24 @@ func TestInstallSetuidBinary(t *testing.T) {
 		t.Fatalf("installAPKFiles failed: %v", err)
 	}
 
-	installed := filepath.Join(base, "usr/bin/mount")
-	fi, err := os.Stat(installed)
+	// fsys.Stat is the authoritative mode for downstream emission.
+	fi, err := fsys.Stat("usr/bin/mount")
 	if err != nil {
-		t.Fatalf("installed file missing: %v", err)
+		t.Fatalf("fsys.Stat: %v", err)
 	}
 	if fi.Mode()&os.ModeSetuid == 0 {
-		t.Fatalf("expected setuid bit on %s, got mode %s", installed, fi.Mode())
+		t.Fatalf("expected setuid bit via fsys.Stat, got %s", fi.Mode())
 	}
 	if fi.Mode().Perm() != 0o755 {
-		t.Fatalf("expected perm 0o755 on %s, got %o", installed, fi.Mode().Perm())
+		t.Fatalf("expected perm 0o755, got %o", fi.Mode().Perm())
 	}
 
-	got, err := os.ReadFile(installed)
+	got, err := os.ReadFile(filepath.Join(base, "usr/bin/mount"))
 	if err != nil {
 		t.Fatalf("reading installed file: %v", err)
 	}
 	if string(got) != string(content) {
-		t.Fatalf("content mismatch: got %q, want %q", got, content)
+		t.Fatalf("content mismatch")
 	}
 }
 

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -311,11 +311,13 @@ func (f *dirFS) open(name string) (*fileImpl, error) {
 	return &fileImpl{file: file, name: baseName}, nil
 }
 
-// Open open a file for reading. Returns fs.File.
-// If the file has the wrong permissions for reading, it tries to
-// change them, and then change them back when closing.
-// This only works if the user reading the file actually has
-// permissions to change the file permissions.
+// OpenFile opens a file, returning a File.
+//
+// Non-permission bits in perm (setuid/setgid/sticky) are silently stripped —
+// *os.Root refuses them in OpenFile, and applying them eagerly would be
+// cleared again by the kernel's file_remove_privs() on the caller's next
+// write (on Linux, for non-privileged processes). Callers that need those
+// bits on disk must Chmod after the final close.
 func (f *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
 	var (
 		file File
@@ -329,14 +331,14 @@ func (f *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) 
 		// do we create it on disk?
 		if f.createOnDisk(name) {
 			_ = file.Close()
-			file, err = f.root.OpenFile(f.relPath(name), flag, perm)
+			file, err = f.root.OpenFile(f.relPath(name), flag, perm.Perm())
 			if err != nil {
 				return nil, err
 			}
 		}
 	} else {
 		if f.caseSensitiveOnDisk(name) {
-			file, err = f.root.OpenFile(f.relPath(name), flag, perm)
+			file, err = f.root.OpenFile(f.relPath(name), flag, perm.Perm())
 		} else {
 			file, err = f.overrides.OpenFile(name, flag, perm)
 		}
@@ -467,9 +469,12 @@ func (f *dirFS) ReadFile(name string) ([]byte, error) {
 	}
 	return f.overrides.ReadFile(name)
 }
+// WriteFile writes data to the named file. Non-permission bits in mode
+// (setuid/setgid/sticky) are silently stripped for the disk write — *os.Root
+// refuses them. Callers that need those bits on disk must Chmod after.
 func (f *dirFS) WriteFile(name string, b []byte, mode fs.FileMode) error {
 	if f.createOnDisk(name) {
-		if err := f.root.WriteFile(f.relPath(name), b, mode); err != nil {
+		if err := f.root.WriteFile(f.relPath(name), b, mode.Perm()); err != nil {
 			return err
 		}
 	}

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -469,6 +469,7 @@ func (f *dirFS) ReadFile(name string) ([]byte, error) {
 	}
 	return f.overrides.ReadFile(name)
 }
+
 // WriteFile writes data to the named file. Non-permission bits in mode
 // (setuid/setgid/sticky) are silently stripped for the disk write — *os.Root
 // refuses them. Callers that need those bits on disk must Chmod after.

--- a/pkg/apk/fs/rwosfs_test.go
+++ b/pkg/apk/fs/rwosfs_test.go
@@ -718,6 +718,71 @@ func TestSymlinkEscape_Mknod_Basename(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "outside node must not be created via placeholder")
 }
 
+// TestSpecialModeBits pins dirFS's contract around setuid/setgid/sticky:
+// OpenFile and WriteFile silently strip them (*os.Root refuses them in these
+// calls). Callers that need those bits on disk use Chmod after the write —
+// dirFS.Chmod forwards to root.Chmod which does accept them.
+func TestSpecialModeBits(t *testing.T) {
+	specials := fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky
+	for _, tt := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{"setuid", fs.ModeSetuid | 0o755},
+		{"setgid", fs.ModeSetgid | 0o755},
+		{"sticky", fs.ModeSticky | 0o755},
+		{"setuid_setgid_sticky", fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky | 0o755},
+	} {
+		t.Run(tt.name+"/OpenFile_strips", func(t *testing.T) {
+			dir := t.TempDir()
+			fsys := DirFS(t.Context(), dir)
+			require.NotNil(t, fsys)
+
+			path := "binary"
+			file, err := fsys.OpenFile(path, os.O_CREATE|os.O_WRONLY, tt.mode)
+			require.NoError(t, err, "OpenFile must not error on non-perm mode bits")
+			_, err = file.Write([]byte("payload"))
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+
+			fi, err := os.Stat(filepath.Join(dir, path))
+			require.NoError(t, err)
+			require.Equal(t, tt.mode.Perm(), fi.Mode().Perm(),
+				"on-disk perm bits should match .Perm() of input")
+			require.Zero(t, fi.Mode()&specials,
+				"special bits must be stripped by OpenFile")
+		})
+		t.Run(tt.name+"/WriteFile_strips", func(t *testing.T) {
+			dir := t.TempDir()
+			fsys := DirFS(t.Context(), dir)
+			require.NotNil(t, fsys)
+
+			path := "binary"
+			require.NoError(t, fsys.WriteFile(path, []byte("x"), tt.mode))
+
+			fi, err := os.Stat(filepath.Join(dir, path))
+			require.NoError(t, err)
+			require.Equal(t, tt.mode.Perm(), fi.Mode().Perm())
+			require.Zero(t, fi.Mode()&specials,
+				"special bits must be stripped by WriteFile")
+		})
+		t.Run(tt.name+"/Chmod_preserves", func(t *testing.T) {
+			dir := t.TempDir()
+			fsys := DirFS(t.Context(), dir)
+			require.NotNil(t, fsys)
+
+			path := "binary"
+			require.NoError(t, fsys.WriteFile(path, []byte("x"), 0o755))
+			require.NoError(t, fsys.Chmod(path, tt.mode))
+
+			fi, err := os.Stat(filepath.Join(dir, path))
+			require.NoError(t, err)
+			require.Equal(t, tt.mode, fi.Mode(),
+				"Chmod after write should leave full mode (incl. specials) on disk")
+		})
+	}
+}
+
 // TestDirFSClose ensures the type-assertable Close() releases the root FD.
 func TestDirFSClose(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
os.Root.OpenFile and os.Root.WriteFile reject setuid/setgid/sticky, breaking installs of files like /usr/bin/mount. Strip non-permission bits.