### PR TITLE
apk: verify package control hash against signed APKINDEX

### DIFF
--- a/pkg/apk/apk/install_test.go
+++ b/pkg/apk/apk/install_test.go
@@ -416,7 +416,7 @@ func fakePackage(t *testing.T, pkg *Package, entries []testDirEntry) Installable
 	return &testPackage{
 		pkg:      pkg,
 		file:     f.Name(),
-		checksum: base64.StdEncoding.EncodeToString(h.Sum(nil)),
+		checksum: "Q1" + base64.StdEncoding.EncodeToString(h.Sum(nil)),
 	}
 }
 

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -170,12 +170,54 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 		return nil, fmt.Errorf("expanding %s: %w", pkg.PackageName(), err)
 	}
 
+	if err := verifyControlHash(pkg, exp.ControlHash); err != nil {
+		_ = exp.Close()
+		return nil, err
+	}
+
 	// If we don't have a cache, we're done.
 	if d.cache == nil {
 		return exp, nil
 	}
 
 	return d.cachePackage(ctx, pkg, exp, cacheDir)
+}
+
+// sha1File returns the SHA-1 of the file at path.
+func sha1File(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha1.New() //nolint:gosec // this is what apk tools is using
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+// verifyControlHash compares the SHA-1 of the downloaded package's control
+// section against the Q1-prefixed base64 checksum recorded in the signed
+// APKINDEX (or lock file). Without this check a compromised mirror or
+// poisoned cache could substitute arbitrary package contents even though
+// the index itself is signature-verified.
+func verifyControlHash(pkg InstallablePackage, controlHash []byte) error {
+	chk := pkg.ChecksumString()
+	if !strings.HasPrefix(chk, "Q1") {
+		return fmt.Errorf("package %q has unexpected checksum format: %q", pkg.PackageName(), chk)
+	}
+	expected, err := base64.StdEncoding.DecodeString(chk[2:])
+	if err != nil {
+		return fmt.Errorf("package %q has malformed checksum %q: %w", pkg.PackageName(), chk, err)
+	}
+	if len(expected) == 0 {
+		return fmt.Errorf("package %q has empty checksum", pkg.PackageName())
+	}
+	if !bytes.Equal(expected, controlHash) {
+		return fmt.Errorf("package %q control hash mismatch: expected %x, got %x", pkg.PackageName(), expected, controlHash)
+	}
+	return nil
 }
 
 // fetchPackage fetches a package from the network or local filesystem.
@@ -322,8 +364,21 @@ func (d *defaultPackageGetter) cachedPackage(ctx context.Context, pkg Installabl
 	if err != nil {
 		return nil, err
 	}
+
+	// Recompute the hash of the on-disk control file rather than trusting
+	// the content-addressable filename. A missed check here would let a
+	// tampered or corrupted cache entry be served without the verification
+	// that getPackageImpl applies on the fetch path.
+	ctlHash, err := sha1File(ctl)
+	if err != nil {
+		return nil, fmt.Errorf("hashing cached control %q: %w", ctl, err)
+	}
+	if err := verifyControlHash(pkg, ctlHash); err != nil {
+		return nil, fmt.Errorf("cached %q: %w", ctl, err)
+	}
+
 	exp.ControlFile = ctl
-	exp.ControlHash = checksum
+	exp.ControlHash = ctlHash
 	exp.ControlSize = cf.Size()
 
 	control, err := exp.ControlData()

--- a/pkg/apk/apk/package_getter_test.go
+++ b/pkg/apk/apk/package_getter_test.go
@@ -2,6 +2,7 @@ package apk
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -262,4 +263,90 @@ func TestAuth_bad(t *testing.T) {
 	_, err := getter.GetPackage(ctx, pkg)
 	require.Error(t, err, "unable to expand package")
 	require.True(t, called, "did not make request")
+}
+
+// TestGetPackage_ChecksumMismatch confirms that a package served by a repository
+// that does not match the checksum recorded in the (signed) APKINDEX is rejected
+// rather than silently installed. This guards against compromised mirrors or
+// poisoned caches substituting package contents.
+func TestGetPackage_ChecksumMismatch(t *testing.T) {
+	tampered := testPkg
+	// Flip one byte of the recorded checksum so the downloaded content's
+	// real control-section SHA-1 will not match.
+	tampered.Checksum = append([]byte(nil), testPkg.Checksum...)
+	tampered.Checksum[0] ^= 0xff
+
+	repo := Repository{URI: fmt.Sprintf("%s/%s", testAlpineRepos, testArch)}
+	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&tampered}})
+	pkg := NewRepositoryPackage(&tampered, repoWithIndex)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	httpClient := &http.Client{Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true}}
+	a := newDefaultPackageGetter(httpClient, &cache{
+		dir:     tmpDir,
+		offline: false,
+		shared:  NewCache(false),
+	}, auth.DefaultAuthenticators)
+
+	_, err := a.GetPackage(ctx, pkg)
+	require.Error(t, err, "expected checksum mismatch to be detected")
+	require.Contains(t, err.Error(), "control hash mismatch")
+}
+
+// TestCachedPackage_TamperedControl confirms that a cache entry whose
+// on-disk control file no longer matches its content-addressable filename
+// is rejected rather than served. This protects against cache corruption
+// or tampering after an entry was originally written.
+func TestCachedPackage_TamperedControl(t *testing.T) {
+	repo := Repository{URI: fmt.Sprintf("%s/%s", testAlpineRepos, testArch)}
+	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}})
+	pkg := NewRepositoryPackage(&testPkg, repoWithIndex)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	httpClient := &http.Client{Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true}}
+	a := newDefaultPackageGetter(httpClient, &cache{
+		dir:     tmpDir,
+		offline: false,
+		shared:  NewCache(false),
+	}, auth.DefaultAuthenticators)
+
+	// Populate the cache.
+	exp, err := a.GetPackage(ctx, pkg)
+	require.NoError(t, err, "populating cache")
+	ctlPath := exp.ControlFile
+	require.FileExists(t, ctlPath)
+
+	cacheDir := filepath.Dir(ctlPath)
+
+	// Tamper with the cached control file. Overwrite with different bytes
+	// so its SHA-1 no longer matches the content-addressable filename.
+	require.NoError(t, os.WriteFile(ctlPath, []byte("tampered"), 0o644))
+
+	_, err = a.cachedPackage(ctx, pkg, cacheDir)
+	require.Error(t, err, "expected tampered cache entry to be rejected")
+	require.Contains(t, err.Error(), "control hash mismatch")
+}
+
+func TestVerifyControlHash(t *testing.T) {
+	want := make([]byte, 20)
+	for i := range want {
+		want[i] = byte(i)
+	}
+	pkg := &testPackage{
+		pkg:      &Package{Name: "example"},
+		checksum: "Q1" + base64.StdEncoding.EncodeToString(want),
+	}
+
+	require.NoError(t, verifyControlHash(pkg, want))
+
+	bad := append([]byte(nil), want...)
+	bad[0] ^= 0xff
+	require.Error(t, verifyControlHash(pkg, bad))
+
+	require.Error(t, verifyControlHash(&testPackage{pkg: &Package{Name: "x"}, checksum: ""}, want))
+	require.Error(t, verifyControlHash(&testPackage{pkg: &Package{Name: "x"}, checksum: "Q1"}, want))
+	require.Error(t, verifyControlHash(&testPackage{pkg: &Package{Name: "x"}, checksum: "Q1!!!"}, want))
+	require.Error(t, verifyControlHash(&testPackage{pkg: &Package{Name: "x"}, checksum: "raw-no-prefix"}, want))
 }


### PR DESCRIPTION
## Summary
- apko verified the signature on `APKINDEX.tar.gz` but never compared downloaded `.apk` packages against the checksum in the signed index, meaning package contents could diverge from what was attested (e.g. via mirror substitution, HTTP repos, poisoned CDN caches) without detection.
- The on-disk cache was similarly trusted: cached control sections are stored under a content-addressable filename derived from the expected hash, but the contents were never re-hashed on read.
- After expansion in `getPackageImpl`, decode the Q1-prefixed base64 checksum from the signed index and compare against the SHA-1 of the control section. Fail closed on missing, malformed, or mismatched checksums; discard the expanded temp dir on mismatch. Apply the same check in `cachedPackage` by hashing the on-disk control file before returning it.

## Test plan
- [ ] `go test ./pkg/apk/apk/...` passes
- [ ] New tests in `package_getter_test.go` cover mismatched checksums, missing checksums, and cache-read verification
- [ ] Manual smoke test: build an image with a valid repo + signed index

🤖 Generated with [Claude Code](https://claude.com/claude-code)