### PR TITLE
release: fetch full history for goreleaser changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
         if: steps.check.outputs.need_release == 'yes'
         with:
           ref: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}
+          fetch-depth: 0
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.check.outputs.need_release == 'yes'


### PR DESCRIPTION
## Summary
- The release workflow's pre-goreleaser checkout was using a shallow clone (default `fetch-depth: 1`), so goreleaser only saw the HEAD commit when generating release notes.
- This is why [v1.2.7's release notes](https://github.com/chainguard-dev/apko/releases/tag/v1.2.7) only list #2191 and omit #2190, even though both landed on `main` before the tag was cut.
- Goreleaser prints `running against a shallow clone - check your CI documentation at https://goreleaser.com/ci` in the release log, and the [GitHub Actions guide](https://goreleaser.com/ci/actions/) explicitly calls out that `fetch-depth: 0` is required.

## Test plan
- [ ] Next release's notes include every commit between the previous tag and the new tag.
- [ ] The `running against a shallow clone` warning no longer appears in the release workflow log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)