### PR TITLE
ci: bump golangci-lint to v2.11 and clear new findings

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6
+          version: v2.11
 
       - run: |
           make generate

--- a/internal/cli/dot.go
+++ b/internal/cli/dot.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"os"
@@ -515,7 +516,7 @@ func DotCmd(ctx context.Context, configFile string, archs []types.Architecture, 
 			cmd.Stdout = &svgBuf
 
 			if err := cmd.Run(); err != nil {
-				fmt.Fprintf(w, "error rendering %v: %v", nodes, err)
+				fmt.Fprintf(w, "error rendering %s: %s", html.EscapeString(strings.Join(nodes, ",")), html.EscapeString(err.Error()))
 				return
 			}
 

--- a/internal/ldso-cache/ldsocache.go
+++ b/internal/ldso-cache/ldsocache.go
@@ -491,13 +491,8 @@ func LoadCacheFile(r io.ReadSeeker) (*LDSOCacheFile, error) {
 // extractShlibName extracts a shared library from the string table.
 func extractShlibName(strtable []byte, startIdx uint32) string {
 	subset := strtable[startIdx:]
-	terminatorPos := bytes.IndexByte(subset, 0x0)
-
-	if terminatorPos == -1 {
-		return string(subset)
-	}
-
-	return string(subset[:terminatorPos])
+	name, _, _ := bytes.Cut(subset, []byte{0x0})
+	return string(name)
 }
 
 func (cf *LDSOCacheFile) Write(w io.Writer) error {
@@ -508,7 +503,7 @@ func (cf *LDSOCacheFile) Write(w io.Writer) error {
 	fileEntryTableSize := int(unsafe.Sizeof(LDSORawCacheHeader{}) + (uintptr(len(cf.Entries)) * unsafe.Sizeof(LDSORawCacheEntry{})))
 
 	// Build the string table.
-	lrcEntries := []LDSORawCacheEntry{}
+	lrcEntries := make([]LDSORawCacheEntry, 0, len(cf.Entries))
 	stringTable := []byte{}
 	for _, lib := range cf.Entries {
 		cursor := uint32(fileEntryTableSize) + uint32(len(stringTable))

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -188,7 +188,7 @@ func (t *cacheTransport) RoundTrip(request *http.Request) (*http.Response, error
 			defer span.End()
 
 			// We don't cache the response for these because they get cached later in cachePackage.
-			return t.wrapped.Do(request)
+			return t.wrapped.Do(request) //#nosec G704 -- transport wrapper executes caller-provided request
 		}
 
 		return &http.Response{
@@ -213,7 +213,7 @@ func (t *cacheTransport) head(request *http.Request, cacheFile string) (*http.Re
 	v, err, _ := t.cache.headFlight.Do(cacheFile, func() (any, error) {
 		req := request.Clone(request.Context())
 		req.Method = http.MethodHead
-		resp, err := t.wrapped.Do(req)
+		resp, err := t.wrapped.Do(req) //#nosec G704 -- transport wrapper executes caller-provided request
 		if err != nil {
 			return nil, err
 		}
@@ -278,7 +278,7 @@ func (t *cacheTransport) fetchAndCache(ctx context.Context, request *http.Reques
 
 		etag, ok := etagFromResponse(resp)
 		if !ok {
-			return t.wrapped.Do(request)
+			return t.wrapped.Do(request) //#nosec G704 -- transport wrapper executes caller-provided request
 		}
 
 		initialEtag = etag
@@ -295,7 +295,7 @@ func (t *cacheTransport) fetchAndCache(ctx context.Context, request *http.Reques
 		return nil, err
 	}
 
-	f, err := os.Open(etagFile)
+	f, err := os.Open(etagFile) //#nosec G304 G703 -- etagFile is sanitized by cacheFileFromEtag to stay within cacheDir
 	if err != nil {
 		return nil, fmt.Errorf("open(%q): %w", etagFile, err)
 	}
@@ -421,7 +421,7 @@ func (t *cacheTransport) retrieveAndSaveFile(ctx context.Context, request *http.
 	if t.wrapped == nil {
 		return "", fmt.Errorf("wrapped client is nil")
 	}
-	resp, err := t.wrapped.Do(request)
+	resp, err := t.wrapped.Do(request) //#nosec G704 -- transport wrapper executes caller-provided request
 	if err != nil {
 		return "", err
 	} else if resp.StatusCode != 200 {

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -1098,7 +1098,7 @@ func TestParseInstalledFiles(t *testing.T) {
 				t.Fatalf("package %s not found installed in %s\n", c.pkgName, c.installedFile)
 			}
 
-			got := []string{}
+			got := make([]string, 0, len(installedPkg.Files))
 			for _, i := range installedPkg.Files {
 				got = append(got, i.Name)
 			}

--- a/pkg/apk/auth/auth.go
+++ b/pkg/apk/auth/auth.go
@@ -101,8 +101,8 @@ func (c CGRAuth) AddAuth(ctx context.Context, req *http.Request) error {
 	}
 
 	sometimes.Do(func() {
-		cmd := exec.CommandContext(ctx, "chainctl", "auth", "token", "--audience", host)
-		cmd.Stderr = io.Discard // Don't pollute logs when things fail
+		cmd := exec.CommandContext(ctx, "chainctl", "auth", "token", "--audience", host) //#nosec G702 -- host is from env/default, passed as argv (no shell)
+		cmd.Stderr = io.Discard                                                          // Don't pollute logs when things fail
 		out, err := cmd.Output()
 		if err != nil {
 			// Document that automatic auth failed and how to reproduce.

--- a/pkg/apk/fs/rwosfs_test.go
+++ b/pkg/apk/fs/rwosfs_test.go
@@ -426,8 +426,8 @@ func TestScriptsTarPattern(t *testing.T) {
 	require.NoError(t, err, "OpenFile for temp should succeed")
 
 	// Step 5: Write existing + new content to temp
-	combinedData := make([]byte, len(existingData))
-	copy(existingData, combinedData)
+	combinedData := make([]byte, 0, len(existingData)+14)
+	combinedData = append(combinedData, existingData...)
 	combinedData = append(combinedData, []byte(" + new content")...)
 
 	_, err = tempFile.Write(combinedData)

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -87,7 +87,7 @@ func (bc *Context) initializeApk(ctx context.Context) error {
 		// Get all packages from base image and merge them into the desired world.
 		if bc.baseimg != nil {
 			basePkgs := bc.baseimg.InstalledPackages()
-			var basePkgsNames []string
+			basePkgsNames := make([]string, 0, len(basePkgs))
 			for _, basePkg := range basePkgs {
 				basePkgsNames = append(basePkgsNames, fmt.Sprintf("%s=%s", basePkg.Name, basePkg.Version))
 			}

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -244,11 +244,12 @@ func updateCache(ctx context.Context, fsys apkfs.FullFS) error {
 		return nil
 	}
 
-	libdirs := []string{"/lib"}
 	dirs, err := ldsocache.ParseLDSOConf(fsys, "etc/ld.so.conf")
 	if err != nil {
 		return fmt.Errorf("parsing /etc/ld.so.conf: %w", err)
 	}
+	libdirs := make([]string, 0, 1+len(dirs))
+	libdirs = append(libdirs, "/lib")
 	libdirs = append(libdirs, dirs...)
 	cacheFile, err := ldsocache.BuildCacheFileForDirs(fsys, libdirs)
 	if err != nil {

--- a/pkg/sbom/generator/spdx/spdx_test.go
+++ b/pkg/sbom/generator/spdx/spdx_test.go
@@ -297,7 +297,7 @@ func TestReproducible(t *testing.T) {
 	fsys := apkfs.NewMemFS()
 	opts := testOpts(fsys)
 	sx := New()
-	d := [][]byte{}
+	d := make([][]byte, 0, 2)
 	for i := range 2 {
 		path := filepath.Join(dir, fmt.Sprintf("sbom%d.%s", i, sx.Ext()))
 		require.NoError(t, sx.Generate(t.Context(), opts, path))

--- a/pkg/sbom/options/options.go
+++ b/pkg/sbom/options/options.go
@@ -127,7 +127,7 @@ func (o *Options) ImagePurlQualifiers() (qualifiers PurlQualifiers) {
 // This function is here while a fix in the purl library gets merged
 // ref: https://github.com/package-url/packageurl-go/pull/22
 func (pq PurlQualifiers) String() string {
-	q := []purl.Qualifier{}
+	q := make([]purl.Qualifier, 0, len(pq))
 	for k, v := range pq {
 		q = append(q, purl.Qualifier{Key: k, Value: v})
 	}


### PR DESCRIPTION
The pinned v2.6 binary is built with go1.25 and refuses to lint code targeting Go 1.26. v2.9.0 added Go 1.26 support, so bump the action pin to v2.11.

Newer linter ruleset surfaced 15 issues. Most are mechanical: prealloc capacity hints across seven slice initializations, and a bytes.IndexByte → bytes.Cut modernize fix. The new gosec G70x taint-analysis rules flagged a handful of legitimate false positives in the apk caching transport (which by design executes caller-provided requests) and the chainctl auth helper (host comes from env and is passed as argv, not via a shell); those get per-line //#nosec annotations with rationale. The G705 hit in the local dot.go debug server was real — user-supplied query params were written into the HTTP response unescaped — so it gets html.EscapeString.
