### PR TITLE
retry package fetch+expand on transient errors

### DIFF
--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -20,12 +20,16 @@ import (
 	"crypto/sha1" //nolint:gosec // this is what apk tools is using
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -38,6 +42,60 @@ import (
 
 	"github.com/chainguard-dev/clog"
 )
+
+const (
+	// maxFetchRetries is the number of additional attempts after the first failure.
+	maxFetchRetries = 2
+	// retryBaseDelay is the base delay between retry attempts (scaled linearly by attempt number).
+	retryBaseDelay = 1 * time.Second
+)
+
+// isRetryableError reports whether err is a transient error that warrants retrying
+// the fetch+expand pipeline from scratch.
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var httpErr *httpStatusError
+	if errors.As(err, &httpErr) {
+		return httpErr.statusCode >= 500 || httpErr.statusCode == http.StatusTooManyRequests
+	}
+	msg := err.Error()
+	for _, substr := range []string{
+		"unexpected EOF",
+		"connection reset",
+		"broken pipe",
+	} {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// httpStatusError represents a non-OK HTTP response status.
+type httpStatusError struct {
+	statusCode int
+	status     string
+	url        string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("unable to get package apk at %s: %s", e.url, e.status)
+}
 
 // PackageGetter abstracts how packages are fetched and expanded.
 type PackageGetter interface {
@@ -152,12 +210,6 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 		}
 	}
 
-	rc, err := d.fetchPackage(ctx, pkg)
-	if err != nil {
-		return nil, fmt.Errorf("fetching package %q: %w", pkg.PackageName(), err)
-	}
-	defer rc.Close()
-
 	var expandOpts []expandapk.Option
 	if d.apkControlMaxSize != 0 {
 		expandOpts = append(expandOpts, expandapk.WithMaxControlSize(d.apkControlMaxSize))
@@ -165,6 +217,54 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 	if d.apkDataMaxSize != 0 {
 		expandOpts = append(expandOpts, expandapk.WithMaxDataSize(d.apkDataMaxSize))
 	}
+
+	exp, err := d.fetchExpandAndVerify(ctx, pkg, cacheDir, expandOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we don't have a cache, we're done.
+	if d.cache == nil {
+		return exp, nil
+	}
+
+	return d.cachePackage(ctx, pkg, exp, cacheDir)
+}
+
+// fetchExpandAndVerify fetches, expands, and verifies a package, retrying on transient errors.
+func (d *defaultPackageGetter) fetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
+	var lastErr error
+	for attempt := range maxFetchRetries + 1 {
+		if attempt > 0 {
+			delay := time.Duration(attempt) * retryBaseDelay
+			clog.FromContext(ctx).Warnf("retrying fetch of %s (attempt %d/%d) after error: %v", pkg.PackageName(), attempt+1, maxFetchRetries+1, lastErr)
+			select {
+			case <-ctx.Done():
+				return nil, context.Cause(ctx)
+			case <-time.After(delay):
+			}
+		}
+
+		exp, err := d.doFetchExpandAndVerify(ctx, pkg, cacheDir, expandOpts)
+		if err == nil {
+			return exp, nil
+		}
+		if !isRetryableError(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", maxFetchRetries+1, lastErr)
+}
+
+// doFetchExpandAndVerify performs a single fetch+expand+verify cycle for a package.
+func (d *defaultPackageGetter) doFetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
+	rc, err := d.fetchPackage(ctx, pkg)
+	if err != nil {
+		return nil, fmt.Errorf("fetching package %q: %w", pkg.PackageName(), err)
+	}
+	defer rc.Close()
+
 	exp, err := expandapk.ExpandApkWithOptions(ctx, rc, cacheDir, expandOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("expanding %s: %w", pkg.PackageName(), err)
@@ -200,12 +300,7 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 		return nil, fmt.Errorf("package %q data hash mismatch: expected %x, got %x", pkg.PackageName(), expectedDataHash, exp.PackageHash)
 	}
 
-	// If we don't have a cache, we're done.
-	if d.cache == nil {
-		return exp, nil
-	}
-
-	return d.cachePackage(ctx, pkg, exp, cacheDir)
+	return exp, nil
 }
 
 // sha1File returns the SHA-1 of the file at path.
@@ -268,7 +363,7 @@ func (d *defaultPackageGetter) fetchPackage(ctx context.Context, pkg FetchablePa
 		}
 		if res.StatusCode != http.StatusOK {
 			res.Body.Close()
-			return nil, fmt.Errorf("unable to get package apk at %s: %v", u, res.Status)
+			return nil, &httpStatusError{statusCode: res.StatusCode, status: res.Status, url: u}
 		}
 		return res.Body, nil
 	default:

--- a/pkg/apk/apk/package_getter_test.go
+++ b/pkg/apk/apk/package_getter_test.go
@@ -3,14 +3,18 @@ package apk
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -365,4 +369,126 @@ func TestGetPackage_HashVerification(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "data hash mismatch")
 	})
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"wrapped unexpected EOF", fmt.Errorf("expanding foo: %w", io.ErrUnexpectedEOF), true},
+		{"connection reset", syscall.ECONNRESET, true},
+		{"connection aborted", syscall.ECONNABORTED, true},
+		{"net.OpError", &net.OpError{Op: "read", Err: errors.New("reset")}, true},
+		{"string unexpected EOF", errors.New("something unexpected EOF happened"), true},
+		{"string connection reset", errors.New("connection reset by peer"), true},
+		{"string broken pipe", errors.New("write: broken pipe"), true},
+		{"http 500", &httpStatusError{statusCode: 500, status: "500 Internal Server Error", url: "https://example.com/pkg.apk"}, true},
+		{"http 502", &httpStatusError{statusCode: 502, status: "502 Bad Gateway", url: "https://example.com/pkg.apk"}, true},
+		{"http 429", &httpStatusError{statusCode: 429, status: "429 Too Many Requests", url: "https://example.com/pkg.apk"}, true},
+		{"http 404", &httpStatusError{statusCode: 404, status: "404 Not Found", url: "https://example.com/pkg.apk"}, false},
+		{"wrapped http 503", fmt.Errorf("fetching package: %w", &httpStatusError{statusCode: 503, status: "503 Service Unavailable", url: "https://example.com/pkg.apk"}), true},
+		{"checksum mismatch", errors.New("control hash mismatch: expected abc, got def"), false},
+		{"generic error", errors.New("some other error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableError(tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// truncatingTransport serves a valid APK file but truncates the response on the first N requests.
+type truncatingTransport struct {
+	root      string
+	failCount int32 // number of remaining requests to truncate
+	attempts  atomic.Int32
+}
+
+func (t *truncatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	attempt := t.attempts.Add(1)
+
+	filename := filepath.Base(req.URL.Path)
+	data, err := os.ReadFile(filepath.Join(t.root, filename))
+	if err != nil {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+		}, nil
+	}
+
+	if attempt <= atomic.LoadInt32(&t.failCount) {
+		// Return a truncated response to simulate unexpected EOF during decompression.
+		truncated := data[:len(data)/2]
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(truncated))),
+		}, nil
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+	}, nil
+}
+
+func TestGetPackage_RetryOnTransientError(t *testing.T) {
+	repo := Repository{URI: fmt.Sprintf("%s/%s", testAlpineRepos, testArch)}
+	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}})
+	pkg := NewRepositoryPackage(&testPkg, repoWithIndex)
+	ctx := context.Background()
+
+	tr := &truncatingTransport{
+		root:      testPrimaryPkgDir,
+		failCount: 1, // fail once, then succeed
+	}
+
+	getter := newDefaultPackageGetter(
+		&http.Client{Transport: tr},
+		nil,
+		auth.DefaultAuthenticators,
+	)
+
+	exp, err := getter.GetPackage(ctx, pkg)
+	require.NoError(t, err, "expected retry to succeed")
+	require.NotNil(t, exp)
+	_ = exp.Close()
+
+	// Should have taken 2 attempts (1 failure + 1 success).
+	require.Equal(t, int32(2), tr.attempts.Load(), "expected exactly 2 fetch attempts")
+}
+
+func TestGetPackage_NoRetryOnPermanentError(t *testing.T) {
+	tampered := testPkg
+	tampered.Checksum = make([]byte, len(testPkg.Checksum)) // wrong checksum
+	ctx := context.Background()
+
+	repo := Repository{URI: fmt.Sprintf("%s/%s", testAlpineRepos, testArch)}
+	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&tampered}})
+	pkg := NewRepositoryPackage(&tampered, repoWithIndex)
+
+	// Use a transport that always serves the real APK data so we can count attempts.
+	tr := &truncatingTransport{
+		root:      testPrimaryPkgDir,
+		failCount: 0, // never truncate — always serve valid data
+	}
+
+	getter := newDefaultPackageGetter(
+		&http.Client{Transport: tr},
+		nil,
+		auth.DefaultAuthenticators,
+	)
+
+	_, err := getter.GetPackage(ctx, pkg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "control hash mismatch")
+
+	// Should have attempted exactly once — permanent errors must not be retried.
+	require.Equal(t, int32(1), tr.attempts.Load(), "expected exactly 1 fetch attempt for permanent error")
 }


### PR DESCRIPTION
Adds retry logic around the fetch→expand→verify pipeline in
getPackageImpl(). Random "unexpected EOF" errors during gzip/tar
decompression are now retried up to 3 times with linear backoff.

Fixes #1903

🤖 Generated with [Claude Code](https://claude.com/claude-code)