### PR TITLE
fix(ci): harden against template injection and credential exposure

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -69,15 +69,15 @@ jobs:
       - name: Check SBOM Conformance
         run: |
           set -euxo pipefail
-          if ! ls *.spdx.json; then
+          if ! ls ./*.spdx.json; then
             echo "no SBOMs found!"
             exit 1
           fi
-          for f in *.spdx.json; do
+          for f in ./*.spdx.json; do
             echo ::group::sbom.json
-            cat $f
+            cat "$f"
             echo ::endgroup::
-            docker run --rm -v $(pwd)/$f:/$f --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /$f"
+            docker run --rm -v "$(pwd)/$f:/$f" --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /$f"
           done
 
   build-all-examples-one-arch:
@@ -130,17 +130,17 @@ jobs:
       - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
       - run: |
           make apko
-          for cfg in $(find ./examples/ -name '*.yaml'); do
-            name=$(basename ${cfg} .yaml)
+          while IFS= read -r cfg; do
+            name=$(basename "${cfg}" .yaml)
             echo "Building ${name}..."
-            build_script=$(dirname ${cfg})/build.sh
-            if [ -f ${build_script} ]; then
-              ${build_script} ./apko
+            build_script=$(dirname "${cfg}")/build.sh
+            if [ -f "${build_script}" ]; then
+              "${build_script}" ./apko
             else
-              ./apko build ${cfg} ${name}:build /tmp/${name}.tar
-              ./apko build --offline ${cfg} ${name}:build /tmp/${name}.tar
+              ./apko build "${cfg}" "${name}:build" /tmp/"${name}".tar
+              ./apko build --offline "${cfg}" "${name}:build" /tmp/"${name}".tar
             fi
-          done
+          done < <(find ./examples/ -name '*.yaml')
 
   build-wolfi-source-date-epoch:
     name: source-date-epoch
@@ -325,13 +325,13 @@ jobs:
           ref=$(./apko publish ./examples/nginx.yaml localhost:5000/nginx --arch x86_64,aarch64)
 
           # Check index annotations.
-          crane manifest $ref | jq -r '.annotations.foo' | grep bar
+          crane manifest "$ref" | jq -r '.annotations.foo' | grep bar
 
           # Check per-image annotations.
-          crane manifest --platform=linux/arm64 $ref | jq -r '.annotations.foo' | grep bar
+          crane manifest --platform=linux/arm64 "$ref" | jq -r '.annotations.foo' | grep bar
 
           # Check per-image config labels.
-          crane config --platform=linux/arm64 $ref | jq -r '.config.Labels' | grep bar
+          crane config --platform=linux/arm64 "$ref" | jq -r '.config.Labels' | grep bar
 
   certificates:
     name: certificates

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -60,9 +60,11 @@ jobs:
           check-latest: true
       - name: Setup QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      - run: |
+      - env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+        run: |
           make apko
-          ./apko build ./examples/nginx.yaml nginx:build /tmp/nginx-${{ matrix.arch }}.tar --arch ${{ matrix.arch }}
+          ./apko build ./examples/nginx.yaml nginx:build "/tmp/nginx-${MATRIX_ARCH}.tar" --arch "${MATRIX_ARCH}"
 
       - name: Check SBOM Conformance
         run: |

--- a/.github/workflows/examples-test.yaml
+++ b/.github/workflows/examples-test.yaml
@@ -65,55 +65,58 @@ jobs:
         run: make apko
 
       - name: Test on_top_of_base example - usr-merge base image handling
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_PLATFORM: ${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }}
         run: |
           set -euxo pipefail
 
           # Test with busybox base image (has usr-merge layout with /lib -> /usr/lib symlink)
           # This verifies that apko correctly handles building on top of base images with usr-merge layout
           BASE_IMAGE="cgr.dev/chainguard/busybox:latest"
-          OUTPUT_TAR="test-output-${{ matrix.arch }}.tar"
+          OUTPUT_TAR="test-output-${MATRIX_ARCH}.tar"
 
-          echo "Testing on_top_of_base example with ${{ matrix.arch }} architecture..."
+          echo "Testing on_top_of_base example with ${MATRIX_ARCH} architecture..."
 
           # Build image on top of base using the parameterized build.sh script
           ./examples/on_top_of_base/build.sh \
             ./apko \
             "$BASE_IMAGE" \
             "$OUTPUT_TAR" \
-            "${{ matrix.arch }}"
+            "${MATRIX_ARCH}"
 
           # Load the built image
           docker load -i "$OUTPUT_TAR"
 
           # Determine the correct image tag based on architecture
-          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+          if [ "${MATRIX_ARCH}" = "x86_64" ]; then
             IMAGE_TAG="base_image:latest-amd64"
           else
             IMAGE_TAG="base_image:latest-arm64"
           fi
 
           # Test that shell works (verifies /lib symlink is preserved correctly)
-          echo "Testing shell execution on ${{ matrix.arch }}..."
-          if docker run --rm --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+          echo "Testing shell execution on ${MATRIX_ARCH}..."
+          if docker run --rm --platform "linux/${MATRIX_PLATFORM}" \
              --entrypoint /bin/sh "$IMAGE_TAG" \
-             -c "echo 'Shell works on ${{ matrix.arch }}'" | grep -q "Shell works"; then
-            echo "Shell executes correctly on ${{ matrix.arch }}"
+             -c "echo 'Shell works on ${MATRIX_ARCH}'" | grep -q "Shell works"; then
+            echo "Shell executes correctly on ${MATRIX_ARCH}"
           else
-            echo "FAILED: Shell failed to execute on ${{ matrix.arch }} (indicates broken /lib symlink)"
+            echo "FAILED: Shell failed to execute on ${MATRIX_ARCH} (indicates broken /lib symlink)"
             exit 1
           fi
 
           # Test another binary to be thorough
-          echo "Testing busybox execution on ${{ matrix.arch }}..."
-          if docker run --rm --platform linux/${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }} \
+          echo "Testing busybox execution on ${MATRIX_ARCH}..."
+          if docker run --rm --platform "linux/${MATRIX_PLATFORM}" \
              --entrypoint /bin/busybox "$IMAGE_TAG" echo "Busybox works" | grep -q "Busybox works"; then
-            echo "Busybox executes correctly on ${{ matrix.arch }}"
+            echo "Busybox executes correctly on ${MATRIX_ARCH}"
           else
-            echo "FAILED: Busybox failed to execute on ${{ matrix.arch }}"
+            echo "FAILED: Busybox failed to execute on ${MATRIX_ARCH}"
             exit 1
           fi
 
-          echo "PASSED: on_top_of_base example test for ${{ matrix.arch }}"
+          echo "PASSED: on_top_of_base example test for ${MATRIX_ARCH}"
 
       - name: Clean up
         if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,13 +41,15 @@ jobs:
             uploads.github.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check if any changes since last release
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch --tags
+          git fetch --tags  # no creds needed: repo is public; if this ever goes private, pass token explicitly here
           TAG=$(git tag --points-at HEAD)
           if [ -z "$TAG" ]; then
             echo "No tag points at HEAD, checking if changes warrant a release."
@@ -98,6 +100,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.check.outputs.need_release == 'yes'
         with:
+          persist-credentials: false
           ref: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,25 +68,25 @@ jobs:
 
               if [ -z "$RELEASE_WORTHY_CHANGES" ]; then
                 echo "No Go source files, go.mod, go.sum, or LICENSE changed since last release. Skipping release."
-                echo "need_release=no" >> $GITHUB_OUTPUT
+                echo "need_release=no" >> "$GITHUB_OUTPUT"
               else
                 echo "Found release-worthy changes since last release:"
                 echo "$RELEASE_WORTHY_CHANGES"
-                echo "need_release=yes" >> $GITHUB_OUTPUT
+                echo "need_release=yes" >> "$GITHUB_OUTPUT"
               fi
             else
               echo "No previous tags found. Creating first release."
-              echo "need_release=yes" >> $GITHUB_OUTPUT
+              echo "need_release=yes" >> "$GITHUB_OUTPUT"
             fi
           else
             RELEASE=$(gh release view "$TAG" --json tagName --jq '.tagName' || echo "none")
             if [ "$RELEASE" == "$TAG" ]; then
               echo "A release exists for tag $TAG, which has the latest changes, so no need for a new tag or release."
-              echo "need_release=no" >> $GITHUB_OUTPUT
+              echo "need_release=no" >> "$GITHUB_OUTPUT"
             else
               echo "Tag $TAG exists, but no release is associated. Need a new release."
-              echo "need_release=yes" >> $GITHUB_OUTPUT
-              echo "existing_tag=$TAG" >> $GITHUB_OUTPUT
+              echo "need_release=yes" >> "$GITHUB_OUTPUT"
+              echo "existing_tag=$TAG" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -46,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,12 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  # Pedantic-only; low security value but noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
## Summary

This 4-patch series addresses GitHub Actions security findings in `chainguard-dev/apko`
as part of the PSEC-923 hardening campaign. All findings were identified by zizmor
(auditor persona) and actionlint/shellcheck.

### Patches

**0001 — fix(ci): resolve template injection findings**
Moves all `${{ context }}` expressions out of `run:` blocks into `env:` variables in
`build-samples.yml` and `examples-test.yaml`. Affects `matrix.arch` expansions
(16 zizmor `template-injection` findings). Includes a computed platform expression
(`matrix.arch == 'x86_64' && 'amd64' || 'arm64'`) moved to `MATRIX_PLATFORM`.

**0002 — fix(ci): add persist-credentials: false to checkout steps**
Adds `persist-credentials: false` to both `actions/checkout` steps in `release.yaml`.
All downstream write operations receive their tokens explicitly (`github_token:` input
on `mathieudutour/github-tag-action`, `env: GITHUB_TOKEN:` on the Release step), so
git credential store persistence is not needed. Adds a comment on `git fetch --tags`
noting the public-repo assumption (2 zizmor `artipacked` findings).

**0003 — fix(ci): add pedantic persona and suppress noisy zizmor rules**
- Adds `persona: pedantic` to the `zizmorcore/zizmor-action` invocation in
  `.github/workflows/zizmor.yaml` so CI catches all `run:` block template expansions
- Extends `.github/zizmor.yml` (which already had `dependabot-cooldown`) with
  suppressions for `anonymous-definition`, `undocumented-permissions`, and
  `concurrency-limits` — pedantic-only rules with no security impact
  (1 + 2 + 9 = 12 suppressed findings)

**0004 — fix(ci): address actionlint and shellcheck findings**
Fixes 24 shellcheck findings across `build-samples.yml` and `release.yaml`:
- SC2035: `ls *.spdx.json` → `ls ./*.spdx.json` (dash-safe glob)
- SC2086: Quote all unquoted `$var` and `${var}` usages
- SC2046: Quote `$(pwd)` subshell in docker `-v` mount argument
- SC2044: Convert fragile `for cfg in $(find ...)` to safe `while IFS= read -r cfg; done < <(find ...)`
- SC2086 in release.yaml: Quote all `>> $GITHUB_OUTPUT` redirections

## Not Fixed (see manual-review.md)

- **2 cache-poisoning findings**: `actions/setup-go` in `build.yaml` and `release.yaml`
  restore the Go module cache. Remediation requires a deliberate choice (disable cache
  restore, conditionally disable for PRs, or split workflows). Documented with
  recommended fix options in `manual-review.md`.

Refs: PSEC-923
https://linear.app/chainguard/issue/PSEC-923/