### PR TITLE
chore(harden-runner): add production.cloudfront.docker.com endpoint

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -43,6 +43,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -112,6 +113,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -169,6 +171,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -234,6 +237,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -299,6 +303,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -360,6 +365,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -408,6 +414,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443

--- a/.github/workflows/examples-test.yaml
+++ b/.github/workflows/examples-test.yaml
@@ -40,6 +40,7 @@ jobs:
             objects.githubusercontent.com:443
             packages.wolfi.dev:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443


### PR DESCRIPTION
- Docker Hub started serving image config blobs from `production.cloudfront.docker.com` (AWS CloudFront) around 2026-05-20, in addition to the long-standing `production.cloudflare.docker.com` (Cloudflare). Every CI run since has failed when the harden-runner egress policy blocks the DNS lookup.
- Add `production.cloudfront.docker.com:443` to the `allowed-endpoints` list in `build.yaml`, `examples-test.yaml`, and `build-samples.yml` (one entry per job in the matrix).
- Keeps the Cloudflare entry — Docker Hub still routes some traffic there.

Failing run for reference: https://github.com/chainguard-dev/apko/actions/runs/26255529583/job/77277157325

Error from the log:
```
docker: error pulling image configuration: download failed after attempts=6:
  dial tcp: lookup production.cloudfront.docker.com on 127.0.0.53:53:
  write udp 127.0.0.1:37840->127.0.0.53:53: write: operation not permitted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)