### PR TITLE
expandapk: materialize uncompressed .dat.tar atomically

### DIFF
--- a/pkg/apk/expandapk/atomic.go
+++ b/pkg/apk/expandapk/atomic.go
@@ -1,0 +1,31 @@
+package expandapk
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic streams r into path by writing to a temporary file in the
+// same directory and atomically renaming it into place.
+func writeFileAtomic(path string, r io.Reader) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file for %q: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if _, err := io.Copy(tmp, r); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("renaming %q onto %q: %w", tmpName, path, err)
+	}
+	return nil
+}

--- a/pkg/apk/expandapk/atomic_test.go
+++ b/pkg/apk/expandapk/atomic_test.go
@@ -1,0 +1,114 @@
+package expandapk
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// midWriteChecker is an io.Reader that, after the first chunk it returns has
+// been written by the copier, asserts that the destination path does not yet
+// exist. If the write were done in place (os.Create on the destination), the
+// destination would already hold a partial file at this point.
+type midWriteChecker struct {
+	t       *testing.T
+	dst     string
+	data    []byte
+	off     int
+	checked bool
+}
+
+func (r *midWriteChecker) Read(p []byte) (int, error) {
+	if r.off > 0 && !r.checked {
+		r.checked = true
+		if _, err := os.Stat(r.dst); !errors.Is(err, fs.ErrNotExist) {
+			r.t.Errorf("destination %q is observable mid-write (stat err=%v); write is not atomic", r.dst, err)
+		}
+	}
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	// Cap each Read at 64 KiB to force several Read calls, so a chunk is
+	// flushed before the next destination check.
+	n := min(copy(p, r.data[r.off:]), 64*1024)
+	r.off += n
+	return n, nil
+}
+
+func TestWriteFileAtomic_DestinationNotVisibleUntilComplete(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "data.tar")
+
+	payload := bytes.Repeat([]byte("x"), 256*1024)
+	r := &midWriteChecker{t: t, dst: dst, data: payload}
+
+	if err := writeFileAtomic(dst, r); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	if !r.checked {
+		t.Fatal("mid-write check never ran; the test would not catch a regression")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading destination: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("destination content mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+
+	// The temp file must have been renamed, not left behind.
+	if ents, err := os.ReadDir(dir); err != nil {
+		t.Fatal(err)
+	} else if len(ents) != 1 {
+		t.Fatalf("expected only the destination file, found %v (temp not cleaned up?)", entryNames(ents))
+	}
+}
+
+// errAfter yields its data once and then returns a fixed error.
+type errAfter struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errAfter) Read(p []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(p, r.data), nil
+	}
+	return 0, r.err
+}
+
+func TestWriteFileAtomic_FailedWriteLeavesNoDestination(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "data.tar")
+
+	payload := bytes.Repeat([]byte("y"), 256*1024)
+	outOfReadsError := errors.New("single-use reader has no reads left")
+	r := &errAfter{data: payload, err: outOfReadsError}
+
+	if err := writeFileAtomic(dst, r); !errors.Is(err, outOfReadsError) {
+		t.Fatalf("expected error wrapping %v, got %v", outOfReadsError, err)
+	}
+	if _, err := os.Stat(dst); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("destination must not exist after a failed write (stat err=%v)", err)
+	}
+	if ents, err := os.ReadDir(dir); err != nil {
+		t.Fatal(err)
+	} else if len(ents) != 0 {
+		t.Fatalf("temp file not cleaned up after failed write: %v", entryNames(ents))
+	}
+}
+
+func entryNames(ents []os.DirEntry) []string {
+	names := make([]string, len(ents))
+	for i, e := range ents {
+		names[i] = e.Name()
+	}
+	return names
+}

--- a/pkg/apk/expandapk/expandapk.go
+++ b/pkg/apk/expandapk/expandapk.go
@@ -30,16 +30,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-var slicePool = sync.Pool{
-	New: func() interface{} {
-		return make([]byte, 1<<20)
-	},
-}
-
-func pooledSlice() []byte {
-	return slicePool.Get().([]byte)
-}
-
 var readerPool = sync.Pool{
 	New: func() interface{} {
 		return bufio.NewReaderSize(nil, 1<<20)
@@ -186,14 +176,6 @@ func (a *APKExpanded) PackageData() (*os.File, error) {
 		return nil, fmt.Errorf("parsing %q: %w", a.PackageFile, err)
 	}
 
-	uf, err = os.Create(a.TarFile)
-	if err != nil {
-		return nil, fmt.Errorf("opening tar file %q: %w", a.TarFile, err)
-	}
-
-	buf := pooledSlice()
-	defer slicePool.Put(buf)
-
 	// Wrap the gzip reader with a limit to protect against decompression bombs
 	var maxSize int64
 	if a.opts != nil {
@@ -201,12 +183,10 @@ func (a *APKExpanded) PackageData() (*os.File, error) {
 	}
 	limitedZr := limitio.NewLimitedReaderWithDefault(zr, maxSize, DefaultMaxDataSize)
 
-	if _, err := io.CopyBuffer(uf, limitedZr, buf); err != nil {
+	// Write the decompressed tar file atomically to avoid a concurrent
+	// reader of the cache seeing an empty or truncated file.
+	if err := writeFileAtomic(a.TarFile, limitedZr); err != nil {
 		return nil, fmt.Errorf("decompressing %q: %w", a.PackageFile, err)
-	}
-
-	if err := uf.Close(); err != nil {
-		return nil, fmt.Errorf("closing %q: %w", a.TarFile, err)
 	}
 
 	return os.Open(a.TarFile)


### PR DESCRIPTION
PackageData() decompresses the cached .dat.tar.gz into the uncompressed .dat.tar by creating that file in place (os.Create) and streaming the decompressed bytes into it. .dat.tar is a content-addressed path that can be shared by multiple apko processes through a common --cache-dir (e.g. parallel image builds on one runner). A concurrent process can therefore read the file while it is still being written and cause one of these problems:

- reading it mid-stream fails the build with "installing packages: expanding <pkg>: unexpected EOF"
- reading it at zero length yields a valid empty tar, so the build succeeds but the package contributes no files while the apk database still records it as installed

Add a writeFileAtomic helper that streams into a temporary file in the same directory and atomically renames it into place, and use it from PackageData. Readers then observe either no file (and materialize their own) or the complete file. The temporary file is created alongside the destination so the rename stays on one filesystem.

Add deterministic tests for writeFileAtomic covering the atomicity invariant (the destination is never observable mid-write) and the error path (a failed write leaves no destination and no leftover temp).

Fixes: #2268 