### PR TITLE
Match apk-tools' provider comparison ordering in the solver

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -1012,7 +1012,47 @@ func (p *PkgResolver) comparePackages(compare *RepositoryPackage, name string, e
 			return 1
 		}
 
-		// check provider priority
+		// The remaining steps follow apk-tools' compare_providers ordering
+		// (latest by requested name, then latest by principal name, then the
+		// highest declared provider priority), with one deliberate divergence
+		// in the final tiebreak below.
+		// https://github.com/alpinelinux/apk-tools/blob/20fe3dccc423bd401b9828958124664704dedb00/src/solver.c#L641-L688
+
+		// Latest by requested name: compare the versions the candidates carry
+		// for the name being resolved. An unversioned provide carries no
+		// version for the name and ties with anything.
+		if iVersionStr != "" && jVersionStr != "" && iVersionStr != jVersionStr {
+			iVersion, err := cachedParseVersion(iVersionStr)
+			if err != nil {
+				return 1
+			}
+			jVersion, err := cachedParseVersion(jVersionStr)
+			if err != nil {
+				// If j fails to parse, prefer i.
+				return -1
+			}
+			if versions := CompareVersions(iVersion, jVersion); versions != equal {
+				return -1 * versions
+			}
+		}
+
+		// Latest by principal name.
+		if a.Name == b.Name && a.Version != b.Version {
+			iVersion, err := cachedParseVersion(a.Version)
+			if err != nil {
+				return 1
+			}
+			jVersion, err := cachedParseVersion(b.Version)
+			if err != nil {
+				// If j fails to parse, prefer i.
+				return -1
+			}
+			if versions := CompareVersions(iVersion, jVersion); versions != equal {
+				return -1 * versions
+			}
+		}
+
+		// Highest declared provider priority.
 		if a.ProviderPriority != b.ProviderPriority {
 			if a.ProviderPriority > b.ProviderPriority {
 				return -1
@@ -1021,23 +1061,17 @@ func (p *PkgResolver) comparePackages(compare *RepositoryPackage, name string, e
 			// a < b
 			return 1
 		}
-		// both matched or both did not, so just compare versions
-		// version priority
-		iVersion, err := cachedParseVersion(iVersionStr)
-		if err != nil {
-			return 1
-		}
-		jVersion, err := cachedParseVersion(jVersionStr)
-		if err != nil {
-			// If j fails to parse, prefer i.
-			return -1
-		}
-		versions := CompareVersions(iVersion, jVersion)
-		if versions != equal {
-			return -1 * versions
-		}
-		// if versions are equal, they might not be the same as the package versions
-		if iVersionStr != a.Version || jVersionStr != b.Version {
+
+		// Prefer the more recent build, regardless of which repository carries
+		// it. This is where we deliberately diverge from apk-tools, which
+		// prefers the lowest available repository. Image configurations can
+		// layer a variant repository ahead of the main one, with packages
+		// providing the same virtual names, such as sonames, as the main
+		// repository's packages. Preferring the earlier repository would let
+		// those builds capture shared provides from every package in later
+		// repositories. Preferring the higher version also stops a stale
+		// build lingering in any index from winning the tie.
+		if a.Version != b.Version {
 			iVersion, err := cachedParseVersion(a.Version)
 			if err != nil {
 				return 1
@@ -1066,7 +1100,8 @@ func (p *PkgResolver) bestPackage(pkgs []*repositoryPackage, compare *Repository
 
 // getDepVersionForName get the version of the package that provides the given name.
 // If the name matches the package name, then the version of the package is used;
-// if it does not, then the version of the provides is used.
+// if it does not, then the version of the provides is used. An unversioned
+// provide carries no version for the name, so it returns "".
 //
 // For example, if pkg foo v2.3 provides bar=1.2, and we look for name=bar then it returns
 // 1.2 (from the provides); else it return 2.3 (from the package itself).
@@ -1079,12 +1114,8 @@ func (p *PkgResolver) getDepVersionForName(pkg *repositoryPackage, name string) 
 	}
 	for _, prov := range pkg.Provides {
 		constraint := cachedResolvePackageNameVersionPin(prov)
-		pName, pVersion := constraint.Name, constraint.Version
-		if pVersion == "" {
-			pVersion = pkg.Version
-		}
-		if pName == name {
-			return pVersion
+		if constraint.Name == name {
+			return constraint.Version
 		}
 	}
 	return ""

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -937,6 +937,40 @@ func TestProviderAcrossOriginVersionBump(t *testing.T) {
 	require.Contains(t, got, "glibc-2.apk")
 }
 
+// An index can retain old builds of a package whose provider priority is
+// higher than the current build's, for example when a priority assignment bug
+// was fixed in between. Provider priority is compared before version, so a
+// direct dependency on the package name would select the stale build. The
+// same-origin heuristic must rescue this: once the origin is pulled in at the
+// current version (here via the meta package), the candidate matching that
+// origin version wins over the stale higher-priority build.
+//
+// This is the py3-pybind11 case from the wolfi index: py3.10-pybind11
+// 2.13.6-r1 lingers with k=312 while the current 3.0.4-r0 build has k=310.
+func TestSameOriginVersionBeatsStaleProviderPriority(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "py3.10-pybind11", Version: "2.13.6-r1", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11", "py3-pybind11-dev"}, ProviderPriority: 312},
+			{Name: "py3.10-pybind11", Version: "3.0.4-r0", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11", "py3-pybind11-dev"}, ProviderPriority: 310},
+			{Name: "py3-supported-pybind11", Version: "3.0.4-r0", Origin: "py3-pybind11",
+				Dependencies: []string{"py3.10-pybind11"}},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"py3-supported-pybind11"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Contains(t, got, "py3.10-pybind11-3.0.4-r0.apk", "should select the current build of py3.10-pybind11")
+	require.NotContains(t, got, "py3.10-pybind11-2.13.6-r1.apk", "should not select the stale higher-priority build")
+}
+
 func TestConstrains(t *testing.T) {
 	providers := map[string][]string{
 		"ld-linux=2.38-r10": {"so:ld-linux-aarch64.so.1=1.0"},

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -971,6 +971,118 @@ func TestSameOriginVersionBeatsStaleProviderPriority(t *testing.T) {
 	require.NotContains(t, got, "py3.10-pybind11-2.13.6-r1.apk", "should not select the stale higher-priority build")
 }
 
+// Provider priority arbitrates between different packages providing the same
+// virtual name. It must not arbitrate between builds of the named package
+// itself: there, the higher version wins, regardless of what priority each
+// build declared for its virtual provides.
+//
+// This is the py3-pybind11 case again, but with a direct dependency on the
+// package name, so the same-origin heuristic cannot help.
+func TestDirectDependencyPrefersVersionOverProviderPriority(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "py3.10-pybind11", Version: "2.13.6-r1", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11", "py3-pybind11-dev"}, ProviderPriority: 312},
+			{Name: "py3.10-pybind11", Version: "3.0.4-r0", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11", "py3-pybind11-dev"}, ProviderPriority: 310},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"py3.10-pybind11"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Equal(t, []string{"py3.10-pybind11-3.0.4-r0.apk"}, got)
+}
+
+// Between different packages providing the same unversioned virtual name,
+// provider priority decides, as in apk-tools' compare_providers:
+// https://github.com/alpinelinux/apk-tools/blob/20fe3dccc423bd401b9828958124664704dedb00/src/solver.c#L641-L667
+func TestProviderPriorityArbitratesVirtualProvides(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "py3.10-pybind11", Version: "3.0.4-r0", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11-dev"}, ProviderPriority: 310},
+			{Name: "py3.13-pybind11", Version: "3.0.4-r0", Origin: "py3-pybind11",
+				Provides: []string{"py3-pybind11-dev"}, ProviderPriority: 313},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"py3-pybind11-dev"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Equal(t, []string{"py3.13-pybind11-3.0.4-r0.apk"}, got)
+}
+
+// Between providers of a versioned virtual name, the version each provides
+// for that name decides before provider priority, as in apk-tools'
+// compare_providers:
+// https://github.com/alpinelinux/apk-tools/blob/20fe3dccc423bd401b9828958124664704dedb00/src/solver.c#L641-L667
+func TestVersionedProvideBeatsProviderPriority(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "prov-a", Version: "1.0-r0", Origin: "prov-a",
+				Provides: []string{"virt=2.0"}, ProviderPriority: 1},
+			{Name: "prov-b", Version: "9.0-r0", Origin: "prov-b",
+				Provides: []string{"virt=1.0"}, ProviderPriority: 999},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"virt"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Equal(t, []string{"prov-a-1.0-r0.apk"}, got)
+}
+
+// When providers of a virtual name tie on the version they provide for it and
+// on priority, the higher build version wins, regardless of repository order.
+//
+// This is a deliberate divergence from apk-tools, which prefers the lowest
+// available repository here. Image configurations can layer a variant
+// repository ahead of the main one, with packages providing the same sonames
+// as the main repository's packages. An image depending on such a soname must
+// not resolve it to the variant build just because the variant repository is
+// configured first.
+func TestHigherVersionBreaksProviderTieAcrossRepositories(t *testing.T) {
+	repoA := Repository{URI: "https://example.invalid/a"}
+	indexA := repoA.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "prov-variant", Version: "1.0-r1", Origin: "prov-variant",
+				Provides: []string{"so:libprov.so.12=12"}},
+		},
+	})
+	repoB := Repository{URI: "https://example.invalid/b"}
+	indexB := repoB.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "prov", Version: "1.0-r2", Origin: "prov",
+				Provides: []string{"so:libprov.so.12=12"}},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{indexA, indexB}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), []string{"so:libprov.so.12"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Equal(t, []string{"prov-1.0-r2.apk"}, got)
+}
+
 func TestConstrains(t *testing.T) {
 	providers := map[string][]string{
 		"ld-linux=2.38-r10": {"so:ld-linux-aarch64.so.1=1.0"},


### PR DESCRIPTION
When an index holds several builds of the same package, the solver compares their provider priorities before their versions. Priorities can vary across versions. If a priority assignment is lowered between releases, an old build can permanently outrank every newer one.

The wolfi index currently hits exactly this: `py3.10-pybind11` 2.13.6-r1 is a superseded package published with priority 312. The current version 3.0.4-r0 has priority 310. Direct dependencies on `py3.10-pybind11` are resolving to the older version.

`apk` resolves things differently. Its solver selects the latest by requested name, then the latest by principal name, and only then prefers the declared provider priority, falling back to the lowest available repository:

  https://github.com/alpinelinux/apk-tools/blob/20fe3dccc423bd401b9828958124664704dedb00/src/solver.c#L641-L688

Priorities therefore only come into play on the same package if their versions tie. An unversioned provide carries no version and ties with anything, which is how different providers of a virtual name still resolve by priority.

Reorder `comparePackages` to follow that sequence: the version each candidate carries for the requested name, then package versions between builds of the same name, then provider priority, then repository order, which `PkgResolver` now tracks from the configured index order.

One deliberate divergence remains, as the previous behaviour is explicitly tested for in `TestProviderAcrossOriginVersionBump`: when apk-tools has no preference left (same repository, all else tied), prefer the higher package version so that a stale build lingering in the index cannot win the tie.

The `apk` resolution can be reproduced in a Wolfi image:

```console
$ docker run --rm cgr.dev/chainguard/wolfi-base sh -ec '
    apk update --quiet
    tar -xzOf /var/cache/apk/APKINDEX.*.tar.gz APKINDEX |
      awk -v RS="" "/\nP:py3\.10-pybind11\nV:(2\.13\.6-r1|3\.0\.4-r0)\n/" |
      grep -E "^(P|V|k):"
    apk add --simulate py3.10-pybind11 | grep pybind11'
P:py3.10-pybind11
V:2.13.6-r1
k:312
P:py3.10-pybind11
V:3.0.4-r0
k:310
(15/15) Installing py3.10-pybind11 (3.0.4-r0)
```

...upstream `apk` installs the current build even though the stale one declares a higher priority.

Other orderings were verified the same way with apk-tools 2.14.10 against synthetic indexes: a versioned provide beats a higher-priority provider of a lower version, unversioned providers resolve by priority, and providers tying on priority resolve in favour of the repository listed first. Each case is covered by a test.
