### PR TITLE
paths: preserve setuid/setgid/sticky bits in permissions

### DIFF
--- a/pkg/build/paths.go
+++ b/pkg/build/paths.go
@@ -40,10 +40,27 @@ func mutatePermissions(fsys apkfs.FullFS, o *options.Options, mut types.PathMuta
 	return mutatePermissionsDirect(fsys, mut.Path, mut.Permissions, mut.UID, mut.GID)
 }
 
+// unixModeToFsMode converts raw unix permission bits (as written in apko
+// configs, e.g. 0o2775) to fs.FileMode, mapping setuid/setgid/sticky to
+// their Go fs.FileMode equivalents.
+func unixModeToFsMode(perms uint32) fs.FileMode {
+	mode := fs.FileMode(perms & 0o777)
+	if perms&0o4000 != 0 {
+		mode |= fs.ModeSetuid
+	}
+	if perms&0o2000 != 0 {
+		mode |= fs.ModeSetgid
+	}
+	if perms&0o1000 != 0 {
+		mode |= fs.ModeSticky
+	}
+	return mode
+}
+
 func mutatePermissionsDirect(fsys apkfs.FullFS, path string, perms, uid, gid uint32) error {
 	target := path
 
-	if err := fsys.Chmod(target, fs.FileMode(perms)); err != nil {
+	if err := fsys.Chmod(target, unixModeToFsMode(perms)); err != nil {
 		return fmt.Errorf("chmod %q: %w", target, err)
 	}
 	if err := fsys.Chown(target, int(uid), int(gid)); err != nil {
@@ -53,7 +70,7 @@ func mutatePermissionsDirect(fsys apkfs.FullFS, path string, perms, uid, gid uin
 }
 
 func mutateDirectory(fsys apkfs.FullFS, o *options.Options, mut types.PathMutation) error {
-	perms := fs.FileMode(mut.Permissions)
+	perms := unixModeToFsMode(mut.Permissions)
 
 	if err := fsys.MkdirAll(mut.Path, perms); err != nil {
 		return err

--- a/pkg/build/paths_test.go
+++ b/pkg/build/paths_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+func TestMutateDirectorySpecialBits(t *testing.T) {
+	for _, test := range []struct {
+		desc         string
+		permissions  uint32
+		expectedMode fs.FileMode
+	}{
+		{
+			desc:         "plain permissions",
+			permissions:  0o755,
+			expectedMode: 0o755,
+		},
+		{
+			desc:         "setgid",
+			permissions:  0o2775,
+			expectedMode: 0o775 | fs.ModeSetgid,
+		},
+		{
+			desc:         "setuid",
+			permissions:  0o4755,
+			expectedMode: 0o755 | fs.ModeSetuid,
+		},
+		{
+			desc:         "sticky",
+			permissions:  0o1777,
+			expectedMode: 0o777 | fs.ModeSticky,
+		},
+		{
+			desc:         "all special bits",
+			permissions:  0o7775,
+			expectedMode: 0o775 | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky,
+		},
+		{
+			desc: "bits above 0o7777 are dropped, not misinterpreted",
+			// 1<<22 is fs.ModeSetgid; passing it raw must not smuggle in
+			// setgid (or any other fs.FileMode flag).
+			permissions:  1<<22 | 0o755,
+			expectedMode: 0o755,
+		},
+		{
+			desc: "decimal-vs-octal typo only yields its actual mode bits",
+			// "permissions: 775" (decimal, missing 0o) = 0o1407: sticky + 407.
+			permissions:  775,
+			expectedMode: 0o407 | fs.ModeSticky,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			fsys := apkfs.NewMemFS()
+			mut := types.PathMutation{
+				Path:        "/var/log/kolla",
+				Type:        "directory",
+				Permissions: test.permissions,
+			}
+			require.NoError(t, mutateDirectory(fsys, nil, mut))
+			// mutatePaths follows up non-permissions mutations with
+			// mutatePermissions; exercise that path too.
+			require.NoError(t, mutatePermissions(fsys, nil, mut))
+
+			fi, err := fsys.Stat("/var/log/kolla")
+			require.NoError(t, err)
+			require.Equal(t, test.expectedMode, fi.Mode().Perm()|fi.Mode()&(fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky))
+		})
+	}
+}
+
+func TestMutateDirectoryRecursiveSpecialBits(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/var/log/kolla/glance", 0o755))
+
+	mut := types.PathMutation{
+		Path:        "/var/log/kolla",
+		Type:        "directory",
+		Permissions: 0o2775,
+		Recursive:   true,
+	}
+	require.NoError(t, mutateDirectory(fsys, nil, mut))
+
+	for _, path := range []string{"/var/log/kolla", "/var/log/kolla/glance"} {
+		fi, err := fsys.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, fs.ModeSetgid, fi.Mode()&fs.ModeSetgid, "setgid missing on %s", path)
+		require.Equal(t, fs.FileMode(0o775), fi.Mode().Perm(), "perms wrong on %s", path)
+	}
+}
+
+func TestMutatePermissionsMissingPath(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.Error(t, mutatePermissionsDirect(fsys, "/does/not/exist", 0o2775, 0, 0))
+}
+
+// TestPathMutationSpecialBitsReachTar covers the full chain: paths mutation →
+// FS → tar header. This is where the dropped bits were observable in images.
+func TestPathMutationSpecialBitsReachTar(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	ic := &types.ImageConfiguration{
+		Paths: []types.PathMutation{{
+			Path:        "var",
+			Type:        "directory",
+			Permissions: 0o755,
+		}, {
+			Path:        "var/log",
+			Type:        "directory",
+			Permissions: 0o755,
+		}, {
+			Path:        "var/log/kolla",
+			Type:        "directory",
+			Permissions: 0o2775,
+			UID:         0,
+			GID:         42400,
+		}},
+	}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, writeTar(context.Background(), tw, fsys))
+	require.NoError(t, tw.Close())
+
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		require.NoError(t, err, "tar must contain var/log/kolla")
+		if hdr.Name != "var/log/kolla" {
+			continue
+		}
+		require.Equal(t, int64(0o2775), hdr.Mode&0o7777, "tar header mode")
+		require.Equal(t, fs.ModeSetgid, hdr.FileInfo().Mode()&fs.ModeSetgid)
+		require.Equal(t, 42400, hdr.Gid)
+		return
+	}
+}
+
+func TestMutatePermissionsSpecialBitsOnFile(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/usr/bin", 0o755))
+	f, err := fsys.Create("/usr/bin/suidtool")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, mutatePermissionsDirect(fsys, "/usr/bin/suidtool", 0o4755, 0, 0))
+
+	fi, err := fsys.Stat("/usr/bin/suidtool")
+	require.NoError(t, err)
+	require.Equal(t, fs.ModeSetuid, fi.Mode()&fs.ModeSetuid)
+	require.Equal(t, fs.FileMode(0o755), fi.Mode().Perm())
+}


### PR DESCRIPTION
## Summary

`paths` mutations silently drop the setuid/setgid/sticky bits: `mutateDirectory` and `mutatePermissionsDirect` cast the raw unix mode straight into `fs.FileMode`, but in `fs.FileMode` the special bits are `ModeSetuid`/`ModeSetgid`/`ModeSticky` (high bits), not unix `0o4000/0o2000/0o1000`. The bogus low bit survives `Chmod` in memfs/tarfs, and `tar.FileInfoHeader` then masks the mode to `Perm()` — so a config like

```yaml
paths:
  - path: /var/log/kolla
    type: directory
    permissions: 0o2775
```

produces a plain `drwxrwxr-x` (0775) directory in the published layer. This affects every Chainguard image that declares special bits via `paths` (15 modules / 25 repos in images-private; verified in published images: clamav's `/var/lib/clamav` 2755→755, spilo's `/run/lock` 1777→777 and `/run/postgresql` 2775→775, the openstack kolla images' `/var/log/kolla` 2775→775).

The fix converts the unix special bits to their `fs.FileMode` equivalents at the config boundary, masking everything else to `0o7777`-expressible bits.

## Verification

- Unit tests for the directory and permissions mutators: plain modes, each special bit, all combined, recursive mutation, error path, and two pinned edge cases — values above `0o7777` are dropped rather than misinterpreted as `fs.FileMode` flags, and a decimal-vs-octal typo (`permissions: 775`) yields exactly its literal bits.
- An end-to-end test from `mutatePaths` through `writeTar` asserting `c_ISGID` and gid in the tar header — the layer where the bug was observable.
- Full `go test ./pkg/...` passes; `mut.Permissions` has no other consumers in the codebase.
- E2e with the built binary: a minimal config with `0o2775` and `0o1777` paths stanzas yields `drwxrwxr-x`/`drwxrwxrwx` unpatched and `drwxrwsr-x`/`drwxrwxrwt` patched in the layer tar.

## Compatibility

- Configs using only `0o000`–`0o777` modes are bit-for-bit unaffected (the dominant case).
- Configs declaring special bits start shipping them — that's the fix; in several cases the current behavior is a real degradation (a declared `0o1777` tmp dir ships world-writable `0777` *without* sticky protection).
- Configs with out-of-range values change subtly: previously a raw value with Go's `1<<22` bit would have accidentally produced setgid; now everything above `0o7777` is dropped. No known config does this (images-private scanned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



