### PR TITLE
paths: honor `recursive` for `type: permissions`, make uid/gid nullable

### DIFF
--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -210,10 +210,17 @@ The `paths` element contains the following children:
    - `symlink`: create a symbolic link (`ln -s`) at the path, linking to the value specified in
      `source`
    - `permissions`: sets file permissions on the file or directory at the path.
- - `uid`: UID to associate with the file
- - `gid`: GID to associate with the file
+ - `uid`: UID to associate with the file. If both `uid` and `gid` are omitted, ownership is left
+   untouched; if only one is set, the other defaults to `0` (root).
+ - `gid`: GID to associate with the file. See the note on `uid` above.
  - `permissions`: file permissions to set. Permissions should be specified in octal e.g. 0o755 (see `man chmod` for details).
  - `source`: used in `hardlink` and `symlink`, this represents the path to link to.
+ - `recursive`: when `true`, apply `permissions` (and `uid`/`gid` when set) to the path and, if it
+   is a directory, to every entry beneath it. Honored for the `directory` and `permissions` types
+   (ignored for `empty-file`, `hardlink`, and `symlink`). The same mode is applied to files and
+   directories alike, and only paths that already exist when the mutation runs are affected.
+   Combine with omitted `uid`/`gid` to fix permissions across an existing tree without changing
+   ownership.
 
 
 ### Includes

--- a/pkg/build/paths.go
+++ b/pkg/build/paths.go
@@ -37,7 +37,26 @@ var pathMutators = map[string]PathMutator{
 }
 
 func mutatePermissions(fsys apkfs.FullFS, o *options.Options, mut types.PathMutation) error {
+	if mut.Recursive {
+		return mutatePermissionsRecursive(fsys, mut.Path, mut.Permissions, mut.UID, mut.GID)
+	}
 	return mutatePermissionsDirect(fsys, mut.Path, mut.Permissions, mut.UID, mut.GID)
+}
+
+// mutatePermissionsRecursive applies perms (and uid/gid, when set) to path and,
+// if path is a directory, to every entry beneath it. WalkDir does not follow
+// symlinks, so a symlink entry is mutated in place rather than its target's
+// tree being descended.
+func mutatePermissionsRecursive(fsys apkfs.FullFS, path string, perms uint32, uid types.UID, gid types.GID) error {
+	return fs.WalkDir(fsys, path, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := mutatePermissionsDirect(fsys, p, perms, uid, gid); err != nil {
+			return fmt.Errorf("mutating permissions for path %q: %w", p, err)
+		}
+		return nil
+	})
 }
 
 // unixModeToFsMode converts raw unix permission bits (as written in apko
@@ -57,37 +76,40 @@ func unixModeToFsMode(perms uint32) fs.FileMode {
 	return mode
 }
 
-func mutatePermissionsDirect(fsys apkfs.FullFS, path string, perms, uid, gid uint32) error {
+func mutatePermissionsDirect(fsys apkfs.FullFS, path string, perms uint32, uid types.UID, gid types.GID) error {
 	target := path
 
 	if err := fsys.Chmod(target, unixModeToFsMode(perms)); err != nil {
 		return fmt.Errorf("chmod %q: %w", target, err)
 	}
-	if err := fsys.Chown(target, int(uid), int(gid)); err != nil {
+
+	// Only chown when at least one of uid/gid is set. Omitting both leaves
+	// ownership untouched (mode-only), which is what makes a recursive
+	// "permissions" mutation safe to run over a pre-existing tree. When only
+	// one of the two is set, the other defaults to 0 (root), preserving the
+	// historical single-path behavior.
+	if uid == nil && gid == nil {
+		return nil
+	}
+	u, g := uint32(0), uint32(0)
+	if uid != nil {
+		u = *uid
+	}
+	if gid != nil {
+		g = *gid
+	}
+	if err := fsys.Chown(target, int(u), int(g)); err != nil {
 		return fmt.Errorf("chown %q: %w", target, err)
 	}
 	return nil
 }
 
+// mutateDirectory creates the directory tree. Applying the requested
+// permissions and ownership (recursively, when mut.Recursive is set) is left to
+// the mutatePermissions follow-up that mutatePaths runs for every non-permissions
+// mutation, so the recursive walk lives in exactly one place.
 func mutateDirectory(fsys apkfs.FullFS, o *options.Options, mut types.PathMutation) error {
-	perms := unixModeToFsMode(mut.Permissions)
-
-	if err := fsys.MkdirAll(mut.Path, perms); err != nil {
-		return err
-	}
-
-	if mut.Recursive {
-		return fs.WalkDir(fsys, mut.Path, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if err := mutatePermissionsDirect(fsys, path, mut.Permissions, mut.UID, mut.GID); err != nil {
-				return fmt.Errorf("mutating permissions for path %q: %w", path, err)
-			}
-			return nil
-		})
-	}
-	return nil
+	return fsys.MkdirAll(mut.Path, unixModeToFsMode(mut.Permissions))
 }
 
 func ensureParentDirectory(fsys apkfs.FullFS, path string) error {

--- a/pkg/build/paths_test.go
+++ b/pkg/build/paths_test.go
@@ -95,13 +95,15 @@ func TestMutateDirectoryRecursiveSpecialBits(t *testing.T) {
 	fsys := apkfs.NewMemFS()
 	require.NoError(t, fsys.MkdirAll("/var/log/kolla/glance", 0o755))
 
-	mut := types.PathMutation{
+	// mutateDirectory only creates the tree; mutatePaths runs the recursive
+	// permissions follow-up, so exercise the full pipeline.
+	ic := &types.ImageConfiguration{Paths: []types.PathMutation{{
 		Path:        "/var/log/kolla",
 		Type:        "directory",
 		Permissions: 0o2775,
 		Recursive:   true,
-	}
-	require.NoError(t, mutateDirectory(fsys, nil, mut))
+	}}}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
 
 	for _, path := range []string{"/var/log/kolla", "/var/log/kolla/glance"} {
 		fi, err := fsys.Stat(path)
@@ -113,7 +115,185 @@ func TestMutateDirectoryRecursiveSpecialBits(t *testing.T) {
 
 func TestMutatePermissionsMissingPath(t *testing.T) {
 	fsys := apkfs.NewMemFS()
-	require.Error(t, mutatePermissionsDirect(fsys, "/does/not/exist", 0o2775, 0, 0))
+	require.Error(t, mutatePermissionsDirect(fsys, "/does/not/exist", 0o2775, nil, nil))
+}
+
+// TestMutatePermissionsRecursive applies a "permissions" mutation recursively
+// over a pre-existing tree and asserts perms + ownership reach every entry.
+func TestMutatePermissionsRecursive(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data/sub", 0o700))
+	f, err := fsys.Create("/srv/data/sub/file")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	ic := &types.ImageConfiguration{Paths: []types.PathMutation{{
+		Path:        "/srv/data",
+		Type:        "permissions",
+		Permissions: 0o2750,
+		UID:         new(uint32(64045)),
+		GID:         new(uint32(64045)),
+		Recursive:   true,
+	}}}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
+
+	for _, path := range []string{"/srv/data", "/srv/data/sub", "/srv/data/sub/file"} {
+		fi, err := fsys.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, fs.FileMode(0o750), fi.Mode().Perm(), "perms wrong on %s", path)
+		require.Equal(t, fs.ModeSetgid, fi.Mode()&fs.ModeSetgid, "setgid missing on %s", path)
+		require.Equal(t, 64045, fileUID(t, fsys, path), "uid wrong on %s", path)
+		require.Equal(t, 64045, fileGID(t, fsys, path), "gid wrong on %s", path)
+	}
+}
+
+// fileUID/fileGID read ownership from the memfs FileInfo, whose Sys() returns a
+// *tar.Header carrying Uid/Gid.
+func fileUID(t *testing.T, fsys apkfs.FullFS, path string) int {
+	t.Helper()
+	fi, err := fsys.Stat(path)
+	require.NoError(t, err)
+	hdr, ok := fi.Sys().(*tar.Header)
+	require.True(t, ok, "unexpected FileInfo.Sys() type for %s", path)
+	return hdr.Uid
+}
+
+func fileGID(t *testing.T, fsys apkfs.FullFS, path string) int {
+	t.Helper()
+	fi, err := fsys.Stat(path)
+	require.NoError(t, err)
+	hdr, ok := fi.Sys().(*tar.Header)
+	require.True(t, ok, "unexpected FileInfo.Sys() type for %s", path)
+	return hdr.Gid
+}
+
+// TestMutatePermissionsRecursiveModeOnly verifies that omitting uid/gid leaves
+// ownership untouched while still applying the mode recursively.
+func TestMutatePermissionsRecursiveModeOnly(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data/sub", 0o700))
+	require.NoError(t, fsys.Chown("/srv/data", 1000, 1000))
+	require.NoError(t, fsys.Chown("/srv/data/sub", 1000, 1000))
+
+	ic := &types.ImageConfiguration{Paths: []types.PathMutation{{
+		Path:        "/srv/data",
+		Type:        "permissions",
+		Permissions: 0o755,
+		Recursive:   true,
+	}}}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
+
+	for _, path := range []string{"/srv/data", "/srv/data/sub"} {
+		fi, err := fsys.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, fs.FileMode(0o755), fi.Mode().Perm(), "perms wrong on %s", path)
+		// Ownership must be left as-is (1000:1000), not reset to root.
+		require.Equal(t, 1000, fileUID(t, fsys, path), "ownership changed on %s", path)
+	}
+}
+
+// TestMutatePermissionsRecursiveOnFile applies a recursive "permissions"
+// mutation to a single regular file: it must affect just that file, no error.
+func TestMutatePermissionsRecursiveOnFile(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/usr/bin", 0o755))
+	f, err := fsys.Create("/usr/bin/tool")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, mutatePermissionsRecursive(fsys, "/usr/bin/tool", 0o4755, new(uint32(0)), new(uint32(0))))
+
+	fi, err := fsys.Stat("/usr/bin/tool")
+	require.NoError(t, err)
+	require.Equal(t, fs.ModeSetuid, fi.Mode()&fs.ModeSetuid)
+	require.Equal(t, fs.FileMode(0o755), fi.Mode().Perm())
+}
+
+func TestMutatePermissionsRecursiveMissingPath(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.Error(t, mutatePermissionsRecursive(fsys, "/does/not/exist", 0o755, nil, nil))
+}
+
+// TestMutatePermissionsNonRecursiveDoesNotRecurse guards the original bug: a
+// non-recursive "permissions" mutation must touch only the named path, never
+// its children.
+func TestMutatePermissionsNonRecursiveDoesNotRecurse(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data/sub", 0o700))
+
+	ic := &types.ImageConfiguration{Paths: []types.PathMutation{{
+		Path:        "/srv/data",
+		Type:        "permissions",
+		Permissions: 0o755,
+		// Recursive intentionally omitted (false).
+	}}}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
+
+	top, err := fsys.Stat("/srv/data")
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0o755), top.Mode().Perm(), "top path should change")
+
+	child, err := fsys.Stat("/srv/data/sub")
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0o700), child.Mode().Perm(), "child must be untouched without recursive")
+}
+
+// TestMutatePermissionsExplicitZeroResetsOwnership verifies an explicit
+// uid:0/gid:0 (non-nil) resets ownership, distinct from omitting them (which
+// leaves it untouched, see TestMutatePermissionsRecursiveModeOnly). This is the
+// core distinction the nullable uid/gid type enables.
+func TestMutatePermissionsExplicitZeroResetsOwnership(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data", 0o755))
+	require.NoError(t, fsys.Chown("/srv/data", 1000, 1000))
+
+	require.NoError(t, mutatePermissionsDirect(fsys, "/srv/data", 0o755, new(uint32(0)), new(uint32(0))))
+
+	require.Equal(t, 0, fileUID(t, fsys, "/srv/data"), "explicit uid:0 must reset owner to root")
+	require.Equal(t, 0, fileGID(t, fsys, "/srv/data"), "explicit gid:0 must reset group to root")
+}
+
+// TestMutatePermissionsOneOwnerDefaultsOtherToZero verifies that setting only
+// one of uid/gid defaults the other to 0 (root), preserving historical behavior.
+func TestMutatePermissionsOneOwnerDefaultsOtherToZero(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data", 0o755))
+
+	// uid set, gid omitted -> gid defaults to 0.
+	require.NoError(t, fsys.Chown("/srv/data", 1000, 1000))
+	require.NoError(t, mutatePermissionsDirect(fsys, "/srv/data", 0o755, new(uint32(42)), nil))
+	require.Equal(t, 42, fileUID(t, fsys, "/srv/data"))
+	require.Equal(t, 0, fileGID(t, fsys, "/srv/data"))
+
+	// gid set, uid omitted -> uid defaults to 0.
+	require.NoError(t, fsys.Chown("/srv/data", 1000, 1000))
+	require.NoError(t, mutatePermissionsDirect(fsys, "/srv/data", 0o755, nil, new(uint32(7))))
+	require.Equal(t, 0, fileUID(t, fsys, "/srv/data"))
+	require.Equal(t, 7, fileGID(t, fsys, "/srv/data"))
+}
+
+// TestMutatePermissionsRecursiveWithSymlink ensures a symlink inside the tree
+// does not abort the recursive walk (WalkDir does not follow symlinks) and that
+// regular entries are still mutated.
+func TestMutatePermissionsRecursiveWithSymlink(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("/srv/data", 0o700))
+	f, err := fsys.Create("/srv/data/real")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, fsys.Symlink("/srv/data/real", "/srv/data/link"))
+
+	ic := &types.ImageConfiguration{Paths: []types.PathMutation{{
+		Path:        "/srv/data",
+		Type:        "permissions",
+		Permissions: 0o750,
+		Recursive:   true,
+	}}}
+	require.NoError(t, mutatePaths(fsys, nil, ic))
+
+	fi, err := fsys.Stat("/srv/data/real")
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0o750), fi.Mode().Perm(), "regular file in tree must be mutated")
 }
 
 // TestPathMutationSpecialBitsReachTar covers the full chain: paths mutation →
@@ -133,8 +313,8 @@ func TestPathMutationSpecialBitsReachTar(t *testing.T) {
 			Path:        "var/log/kolla",
 			Type:        "directory",
 			Permissions: 0o2775,
-			UID:         0,
-			GID:         42400,
+			UID:         new(uint32(0)),
+			GID:         new(uint32(42400)),
 		}},
 	}
 	require.NoError(t, mutatePaths(fsys, nil, ic))
@@ -165,7 +345,7 @@ func TestMutatePermissionsSpecialBitsOnFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	require.NoError(t, mutatePermissionsDirect(fsys, "/usr/bin/suidtool", 0o4755, 0, 0))
+	require.NoError(t, mutatePermissionsDirect(fsys, "/usr/bin/suidtool", 0o4755, new(uint32(0)), new(uint32(0))))
 
 	fi, err := fsys.Stat("/usr/bin/suidtool")
 	require.NoError(t, err)

--- a/pkg/build/types/schema.json
+++ b/pkg/build/types/schema.json
@@ -270,11 +270,11 @@
         },
         "uid": {
           "type": "integer",
-          "description": "The mutation's desired user ID"
+          "description": "The mutation's desired user ID. If unset (nil), ownership is left\nuntouched unless gid is set (see Recursive)."
         },
         "gid": {
           "type": "integer",
-          "description": "The mutation's desired group ID"
+          "description": "The mutation's desired group ID. If unset (nil), ownership is left\nuntouched unless uid is set (see Recursive)."
         },
         "permissions": {
           "type": "integer",
@@ -286,7 +286,7 @@
         },
         "recursive": {
           "type": "boolean",
-          "description": "Toggle whether to mutate recursively"
+          "description": "Toggle whether to mutate recursively. Honored for the \"directory\" and\n\"permissions\" types: the permissions, and uid/gid when set, are applied\nto every entry beneath the path."
         }
       },
       "additionalProperties": false,

--- a/pkg/build/types/types.go
+++ b/pkg/build/types/types.go
@@ -68,6 +68,10 @@ type User struct {
 
 type GID *uint32
 
+// UID is a nullable user ID. A nil UID means "unset" (distinct from an
+// explicit 0), which lets path mutations leave ownership untouched.
+type UID *uint32
+
 type Group struct {
 	// Required: The name of the group
 	GroupName string `json:"groupname,omitempty"`
@@ -84,15 +88,19 @@ type PathMutation struct {
 	//
 	// This can be one of: directory, empty-file, hardlink, symlink, permissions
 	Type string `json:"type,omitempty"`
-	// The mutation's desired user ID
-	UID uint32 `json:"uid,omitempty"`
-	// The mutation's desired group ID
-	GID uint32 `json:"gid,omitempty"`
+	// The mutation's desired user ID. If unset (nil), ownership is left
+	// untouched unless gid is set (see Recursive).
+	UID UID `json:"uid,omitempty" yaml:"uid,omitempty"`
+	// The mutation's desired group ID. If unset (nil), ownership is left
+	// untouched unless uid is set (see Recursive).
+	GID GID `json:"gid,omitempty" yaml:"gid,omitempty"`
 	// The permission bits for the path
 	Permissions uint32 `json:"permissions,omitempty"`
 	// The source path to mutate
 	Source string `json:"source,omitempty"`
-	// Toggle whether to mutate recursively
+	// Toggle whether to mutate recursively. Honored for the "directory" and
+	// "permissions" types: the permissions, and uid/gid when set, are applied
+	// to every entry beneath the path.
 	Recursive bool `json:"recursive,omitempty"`
 }
 

--- a/pkg/build/types/types_test.go
+++ b/pkg/build/types/types_test.go
@@ -257,6 +257,59 @@ accounts:
 	}
 }
 
+// Test_YAML_PathMutation_UID_GID locks the wire semantics the recursive
+// permissions feature depends on: an omitted uid/gid must unmarshal to nil
+// (leave ownership untouched), distinct from an explicit 0.
+func Test_YAML_PathMutation_UID_GID(t *testing.T) {
+	const raw = `
+paths:
+  - path: /omitted
+    type: permissions
+    permissions: 0o755
+  - path: /explicit-zero
+    type: permissions
+    permissions: 0o750
+    uid: 0
+    gid: 0
+  - path: /values
+    type: permissions
+    permissions: 0o750
+    uid: 1000
+    gid: 1001
+`
+	var ic ImageConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &ic))
+	require.Len(t, ic.Paths, 3)
+
+	// omitted → nil on both
+	require.Nil(t, ic.Paths[0].UID, "omitted uid should be nil")
+	require.Nil(t, ic.Paths[0].GID, "omitted gid should be nil")
+
+	// explicit 0 → non-nil pointer to 0 (distinct from omitted)
+	require.NotNil(t, ic.Paths[1].UID)
+	require.Equal(t, uint32(0), *ic.Paths[1].UID)
+	require.NotNil(t, ic.Paths[1].GID)
+	require.Equal(t, uint32(0), *ic.Paths[1].GID)
+
+	// explicit values round-trip
+	require.NotNil(t, ic.Paths[2].UID)
+	require.Equal(t, uint32(1000), *ic.Paths[2].UID)
+	require.NotNil(t, ic.Paths[2].GID)
+	require.Equal(t, uint32(1001), *ic.Paths[2].GID)
+
+	// Round-trip through marshal/unmarshal must preserve nil vs explicit-0.
+	out, err := yaml.Marshal(&ic)
+	require.NoError(t, err)
+	var rt ImageConfiguration
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	require.Nil(t, rt.Paths[0].UID, "nil uid must survive round-trip")
+	require.Nil(t, rt.Paths[0].GID, "nil gid must survive round-trip")
+	require.NotNil(t, rt.Paths[1].UID, "explicit 0 uid must survive round-trip")
+	require.Equal(t, uint32(0), *rt.Paths[1].UID)
+	require.NotNil(t, rt.Paths[1].GID, "explicit 0 gid must survive round-trip")
+	require.Equal(t, uint32(0), *rt.Paths[1].GID)
+}
+
 // Ensure marshalling YAML from a User
 // does not result in unexpected GID=0
 func Test_YAML_Marshalling_UID_GID_mapping(t *testing.T) {


### PR DESCRIPTION
## Summary

`recursive: true` was silently ignored for `type: permissions` mutations — only `type: directory` honored it. A config doing a recursive `permissions` mutation (e.g. fixing ownership/perms across an existing tree like `/var/lib/ceph`) parsed and ran "successfully" but only touched the top path, with no error or warning.

This makes `recursive` work for `type: permissions`, and makes `uid`/`gid` nullable so a recursive mutation can change **mode only** without rewriting ownership.

## Changes

- **`mutatePermissions` honors `Recursive`** via a shared `mutatePermissionsRecursive` helper. The recursive walk now lives in exactly one place: `mutateDirectory` is reduced to `MkdirAll` and relies on the existing `mutatePaths` permissions follow-up, so a recursive `directory` mutation no longer walks the tree twice.
- **`PathMutation.UID`/`GID` are now nullable** (`types.UID`/`types.GID`, both `*uint32`), mirroring the existing `User.GID` pattern (#1449):
  - both omitted → ownership left **untouched** (mode-only) — makes recursive `permissions` safe over a pre-existing tree.
  - only one set → the other defaults to `0` (root), preserving historical behavior.
  - explicit `uid: 0` is now distinct from omitted.

## Behavior change to review

Omitting **both** uid and gid on a `permissions`/`directory` mutation now leaves ownership untouched instead of forcing `0:0`. Identical result for freshly created nodes (already `0:0`); differs only when mutating pre-existing paths — the intended fix. The same mode is still applied to files and dirs alike, affecting only paths that exist when the mutation runs.

## Compatibility

- **Wire format unaffected**: `*uint32` serializes identically; the JSON schema still types `uid`/`gid` as `integer` (only descriptions changed).
- **Go API**: `PathMutation.UID`/`GID` change `uint32` → `*uint32` — source-incompatible for code that constructs/reads them, exactly mirroring #1449 for `User.GID`.

## Tests

New/updated coverage in `pkg/build`: recursive over a tree, mode-only (ownership untouched), explicit-`0` resets ownership, one-of-uid/gid defaults the other to `0`, recursive-on-a-file, missing-path errors, a non-recursive-doesn't-recurse regression guard, a symlink-in-tree case, and YAML nil-vs-explicit-`0` round-trip. `docs/apko_file.md` documents `recursive` (previously undocumented) and the ownership semantics.

## Downstream / follow-ups

The Go API change is source-incompatible like #1449. Adaptations are staged and verified (draft, blocked on this release); the rest of the ecosystem (melange, wolfictl, stereo, terraform-provider-apko, …) was checked and needs no change:

- chainguard-dev/mono#43025 — apko↔proto converters (public/sdk → exports to chainguard-dev/sdk, apkoaas, dataplane).
- chainguard-images/images-private#249356 — one entitlements-writer test literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
