### PR TITLE
fix: fall back to GET when APKINDEX HEAD is unsupported

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -131,16 +131,6 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			return nil, fmt.Errorf("unable to add auth to request: %w", err)
 		}
 
-		resp, err := client.Do(head)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
-		}
-
 		fetchAndParse := func(etag string) (NamedIndex, error) {
 			b, err := fetchRepositoryIndex(ctx, u, etag, opts)
 			if err != nil {
@@ -151,6 +141,19 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 				return nil, fmt.Errorf("parsing %s: %w", asURL.Redacted(), err)
 			}
 			return NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(idx)), nil
+		}
+
+		resp, err := client.Do(head)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented {
+				return fetchAndParse("")
+			}
+			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 
 		etag, ok := etagFromResponse(resp)

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base32"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"net/http"
@@ -90,6 +91,21 @@ guyM+Ks3c29KlRf3iX35Gt0CAwEAAQ==
 	}
 	testArch = "aarch64"
 )
+
+type headMethodNotAllowedTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *headMethodNotAllowedTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.Method == http.MethodHead {
+		return &http.Response{
+			StatusCode: http.StatusMethodNotAllowed,
+			Body:       io.NopCloser(strings.NewReader("method not allowed")),
+		}, nil
+	}
+
+	return t.wrapped.RoundTrip(request)
+}
 
 func TestGetRepositoryIndexes(t *testing.T) {
 	prepLayout := func(t *testing.T, tr http.RoundTripper, cache string, repos []string) *APK {
@@ -183,6 +199,16 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		index2, err := os.ReadFile(filepath.Join(testPrimaryPkgDir, indexFilename))
 		require.NoError(t, err, "unable to read previous index file")
 		require.Equal(t, index1, index2, "index files do not match")
+	})
+	t.Run("head method not allowed falls back to get", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		a := prepLayout(t, &headMethodNotAllowedTransport{
+			wrapped: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true},
+		}, tmpDir, nil)
+
+		indexes, err := a.GetRepositoryIndexes(context.Background(), false)
+		require.NoErrorf(t, err, "unable to get indexes")
+		require.Greater(t, len(indexes), 0, "no indexes found")
 	})
 	t.Run("repo url with http basic auth", func(t *testing.T) {
 		tmpDir := t.TempDir()


### PR DESCRIPTION
Some Alpine registries reject HEAD requests for APKINDEX.tar.gz with 405, which currently makes index resolution fail before we ever fetch the index.

This change treats 405 and 501 from the HEAD probe as unsupported-method responses and falls back to fetching and parsing the index via GET without etag-based HEAD caching. Other non-200 statuses still fail as before.

I also added a regression test that simulates HEAD returning 405 while GET succeeds.

Fixes #2251

Verification:
- go test ./pkg/apk/apk -run TestGetRepositoryIndexes
- go test ./pkg/apk/apk