### PR TITLE
fix: use content-disposition filename for fetched keys

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -543,6 +543,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 	for _, element := range keyFiles {
 		eg.Go(func() error {
 			log.Debugf("installing key %v", element)
+			keyName := filepath.Base(element)
 
 			var asURL *url.URL
 			var err error
@@ -586,6 +587,9 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				if resp.StatusCode < 200 || resp.StatusCode > 299 {
 					return fmt.Errorf("failed to fetch apk key from %s: http response indicated error code: %d", req.Host, resp.StatusCode)
 				}
+				if contentDispositionFileName := keyFilenameFromContentDisposition(resp.Header.Get("Content-Disposition")); contentDispositionFileName != "" {
+					keyName = contentDispositionFileName
+				}
 
 				data, err = io.ReadAll(resp.Body)
 				if err != nil {
@@ -596,7 +600,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 			}
 
 			// #nosec G306 -- apk keyring must be publicly readable
-			if err := a.fs.WriteFile(filepath.Join("etc", "apk", "keys", filepath.Base(element)), data,
+			if err := a.fs.WriteFile(filepath.Join("etc", "apk", "keys", keyName), data,
 				0o644); err != nil {
 				return fmt.Errorf("failed to write apk key: %w", err)
 			}
@@ -606,6 +610,43 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 	}
 
 	return eg.Wait()
+}
+
+func keyFilenameFromContentDisposition(contentDisposition string) string {
+	if contentDisposition == "" {
+		return ""
+	}
+
+	for _, field := range strings.Split(contentDisposition, ";") {
+		field = strings.TrimSpace(field)
+		lower := strings.ToLower(field)
+
+		if strings.HasPrefix(lower, "filename*=") {
+			filename := strings.TrimSpace(field[len("filename*="):])
+			filename = strings.Trim(filename, `"`)
+			if i := strings.Index(filename, "''"); i >= 0 {
+				filename = filename[i+2:]
+			}
+			if decodedFilename, err := url.PathUnescape(filename); err == nil {
+				filename = decodedFilename
+			}
+			filename = filepath.Base(filename)
+			if filename != "" && filename != "." {
+				return filename
+			}
+		}
+
+		if strings.HasPrefix(lower, "filename=") {
+			filename := strings.TrimSpace(field[len("filename="):])
+			filename = strings.Trim(filename, `"`)
+			filename = filepath.Base(filename)
+			if filename != "" && filename != "." {
+				return filename
+			}
+		}
+	}
+
+	return ""
 }
 
 // ResolveWorld determine the target state for the requested dependencies in /etc/apk/world. Does not install anything.

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -519,6 +519,27 @@ func TestInitKeyring(t *testing.T) {
 	// should be 2 keys
 	require.Len(t, fi, 2)
 
+	t.Run("remote keys use content-disposition filename", func(t *testing.T) {
+		src := apkfs.NewMemFS()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Disposition", `attachment; filename="test@5c6bb80ae094a76863d00718d8ff0fc208ae441d0e3e302d29d185b929eea22c.rsa.pub"; filename*=UTF-8''test@5c6bb80ae094a76863d00718d8ff0fc208ae441d0e3e302d29d185b929eea22c.rsa.pub`)
+			_, _ = w.Write([]byte(testDemoKey))
+		}))
+		defer server.Close()
+
+		a, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		require.NoError(t, err)
+
+		err = a.InitKeyring(context.Background(), []string{server.URL + "/key"}, nil)
+		require.NoError(t, err)
+
+		_, err = src.Stat(filepath.Join(DefaultKeyRingPath, "test@5c6bb80ae094a76863d00718d8ff0fc208ae441d0e3e302d29d185b929eea22c.rsa.pub"))
+		require.NoError(t, err)
+
+		_, err = src.Stat(filepath.Join(DefaultKeyRingPath, "key"))
+		require.Error(t, err)
+	})
+
 	// Add an invalid file
 	keyfiles = []string{
 		"/liksdjlksdjlksjlksjdl",


### PR DESCRIPTION
When a key URL does not include the real key filename in its path (for example `/key` on Forgejo/Gitea), apko currently writes the fetched key to that path basename. That breaks signature verification because APKINDEX signatures reference the actual key filename.

This change uses the response `Content-Disposition` filename (including `filename*` values) when it is present, and falls back to the URL basename otherwise.

I also added a regression test that serves a key from `/key` with a `Content-Disposition` filename and verifies the key is written under the header-provided name.

Fixes #2252

Verification:
- go test ./pkg/apk/apk -run TestInitKeyring
- go test ./pkg/apk/apk -run "TestInitKeyring|TestGetRepositoryIndexes"
- go test ./pkg/apk/apk