### PR TITLE
Lower SBOM duplicate-package log from info to debug

### DIFF
--- a/pkg/sbom/generator/spdx/spdx.go
+++ b/pkg/sbom/generator/spdx/spdx.go
@@ -167,7 +167,7 @@ func (sx *SPDX) Generate(ctx context.Context, opts *options.Options, path string
 			seenIDs[doc.Packages[i].ID] = struct{}{}
 			dedupedPackages = append(dedupedPackages, doc.Packages[i])
 		} else {
-			clog.FromContext(ctx).Info("duplicate package ID found in SBOM, deduplicating package...", "ID", doc.Packages[i].ID)
+			clog.FromContext(ctx).Debug("duplicate package ID found in SBOM, deduplicating package...", "ID", doc.Packages[i].ID)
 		}
 	}
 	doc.Packages = dedupedPackages


### PR DESCRIPTION
When apko deduplicates a package ID while generating an SBOM, it currently logs each occurrence at info level. This is routine bookkeeping, not something an operator needs to act on, and it adds noise to SBOM generation output. Drop it to debug so it's available when troubleshooting but out of the way otherwise.

Assisted by Claude Opus 4.8