### PR TITLE
apk: don't disqualify a package for an unversioned provide

### DIFF
--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -470,6 +470,11 @@ func (p *PkgResolver) constrain(constraints []string, dq map[*RepositoryPackage]
 					if pp.Name != parsed.Name {
 						continue
 					}
+					// An unversioned provide can't satisfy a versioned
+					// constraint, and must not disqualify the package either.
+					if pp.Version == "" {
+						continue
+					}
 					actualVersion, err := cachedParseVersion(pp.Version)
 					// skip invalid ones
 					if err != nil {

--- a/pkg/apk/apk/repo_test.go
+++ b/pkg/apk/apk/repo_test.go
@@ -999,6 +999,63 @@ func TestDirectDependencyPrefersVersionOverProviderPriority(t *testing.T) {
 	require.Equal(t, []string{"py3.10-pybind11-3.0.4-r0.apk"}, got)
 }
 
+// A package that carries an unversioned provide can still satisfy a versioned pin
+// on its own name. A pinned closure names every package as a versioned
+// constraint, so here both unbound-mailcow-compat (which provides unbound-config
+// unversioned) and the unbound-config pin resolve cleanly.
+//
+// The unbound-config pin resolves to the compat package alone through the compat
+// package's own version: filterPackages matches a candidate against its package
+// version, and because unbound-config and unbound-mailcow-compat are subpackages
+// of the same origin they share the version the pin asks for.
+// TestUnversionedProvideVersionMismatchDivergesFromApk covers differing versions.
+func TestUnversionedProvideDoesNotDisqualifyAgainstVersionedConstraint(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "unbound-config", Version: "1.25.1-r2", Origin: "unbound"},
+			{Name: "unbound-mailcow-compat", Version: "1.25.1-r2", Origin: "unbound",
+				Provides: []string{"unbound-config"}},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(),
+		[]string{"unbound-mailcow-compat=1.25.1-r2", "unbound-config=1.25.1-r2"}, nil)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.Filename())
+	}
+	require.Equal(t, []string{"unbound-mailcow-compat-1.25.1-r2.apk"}, got)
+}
+
+// apko satisfies a versioned pin from a candidate's own package version or from a
+// versioned provides: entry. apk-tools is more permissive: it treats an
+// unversioned provide as a null version that matches any versioned constraint,
+// since apk_dep_is_provided defers to apk_version_match where a null version
+// compares equal to anything:
+// https://github.com/alpinelinux/apk-tools/blob/097d611f2b7da0f6aa42955d53de7ad569133503/src/version.c#L285-L289
+//
+// So apko looks to the named package for the version, and a pin that only a
+// differently-versioned, unversioned provider could satisfy goes unmet. This is a
+// deliberate, known difference from apk-tools; the pinned closures that motivate
+// the fix above stay within apko's behaviour, because the provider and the
+// provided name share an origin and so a version.
+func TestUnversionedProvideVersionMismatchDivergesFromApk(t *testing.T) {
+	repo := Repository{}
+	index := repo.WithIndex(&APKIndex{
+		Packages: []*Package{
+			{Name: "unbound-mailcow-compat", Version: "9.9.9-r9", Origin: "unbound",
+				Provides: []string{"unbound-config"}},
+		},
+	})
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*RepositoryWithIndex{index}))
+	_, _, err := resolver.GetPackagesWithDependencies(context.Background(),
+		[]string{"unbound-config=1.25.1-r2"}, nil)
+	require.ErrorContains(t, err, "unbound-config=1.25.1-r2")
+}
+
 // Between different packages providing the same unversioned virtual name,
 // provider priority decides, as in apk-tools' compare_providers:
 // https://github.com/alpinelinux/apk-tools/blob/20fe3dccc423bd401b9828958124664704dedb00/src/solver.c#L641-L667


### PR DESCRIPTION
When `constrain` evaluates a versioned constraint, it walks every package that provides that name and parses the version each one provides for it. For an unversioned `provides:` entry the provided version is the empty string, which fails to parse, and the package is disqualified outright. The disqualification is cached and shared across the whole resolution, so the package can then no longer satisfy even its own name.

This shows up with a pinned package closure, where every package is named as a versioned constraint, and one package substitutes another through an unversioned provide.

## Example

Two packages from the same origin, where `unbound-mailcow-compat` substitutes `unbound-config` via an unversioned provide:

```
P:unbound-config
V:1.25.1-r2
o:unbound

P:unbound-mailcow-compat
V:1.25.1-r2
o:unbound
p:unbound-config
```

Resolving a closure that pins both:

```
unbound-mailcow-compat=1.25.1-r2
unbound-config=1.25.1-r2
```

fails:

```
solving "unbound-mailcow-compat=1.25.1-r2" constraint:   unbound-mailcow-compat-1.25.1-r2.apk disqualified because parsing "": invalid version , could not parse
```

The `unbound-config` pin walks every provider of that name. It reaches `unbound-mailcow-compat`, whose `p:unbound-config` carries no version, tries to parse `""`, and disqualifies the compat package. That cached disqualification then prevents the compat package from satisfying even its own `unbound-mailcow-compat=1.25.1-r2` pin, which is the constraint the error names.

## Fix

apk-tools never disqualifies a package on this basis. It evaluates each dependency against each provider on its own, and an unversioned provide carries a null version that `apk_version_match` treats as matching any versioned constraint, not as a parse failure[1]. The hard, resolution-wide disqualification is an artefact of our shared cache, not something we are modelling from apk-tools.

Our provider selection stays as it is, and differs from apk-tools by design: `filterPackages` satisfies a versioned constraint from a candidate's own package version or from a versioned `provides:` entry, where apk-tools would also accept an unversioned provide against any version. The pinned closures that motivate this fix stay within our behaviour, because a provider and the name it substitutes are subpackages of one origin and so share a version. The only thing to fix is the spurious disqualification: skip empty provided versions in `constrain`, just as the selection path already skips them, so an unversioned provide no longer disqualifies the package that declares it.

[1]: https://github.com/alpinelinux/apk-tools/blob/097d611f2b7da0f6aa42955d53de7ad569133503/src/version.c#L285-L289
