### PR TITLE
fix(ldso-cache): Order cache entries to match ld.so's search

### DIFF
--- a/internal/ldso-cache/ldsocache.go
+++ b/internal/ldso-cache/ldsocache.go
@@ -17,6 +17,7 @@ package ldsocache
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"debug/elf"
 	"encoding/binary"
 	"errors"
@@ -26,7 +27,6 @@ import (
 	"log"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"unsafe"
 )
@@ -351,13 +351,53 @@ func LDSOCacheEntriesForDirs(fsys fs.FS, libdirs []string) ([]LDSOCacheEntry, er
 		allEntries = append(allEntries, entries...)
 	}
 
-	// ld expects entries to be reverse-sorted by name. Otherwise
-	// it may report "No such file or directory"
-	sort.Slice(allEntries, func(i, j int) bool {
-		return filepath.Base(allEntries[j].Name) < filepath.Base(allEntries[i].Name)
+	// The dynamic linker binary-searches /etc/ld.so.cache using
+	// _dl_cache_libcmp, so entries must be ordered by that same comparison or
+	// ld.so may fail to find a library that is present in the cache (reporting
+	// "cannot open shared object file"). glibc's ldconfig emits entries in
+	// descending order, so we negate the comparison.
+	slices.SortFunc(allEntries, func(entry, other LDSOCacheEntry) int {
+		return -dlCacheLibcmp(filepath.Base(entry.Name), filepath.Base(other.Name))
 	})
 
 	return allEntries, nil
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// dlCacheLibcmp mirrors glibc's _dl_cache_libcmp (elf/dl-cache.c), the
+// comparison the dynamic linker uses to binary-search /etc/ld.so.cache. Runs of
+// digits are compared numerically, and a digit is considered greater than any
+// non-digit at the same position. It returns a negative number, 0, or a
+// positive number as libName is less than, equal to, or greater than otherName.
+func dlCacheLibcmp(libName, otherName string) int {
+	pos, otherPos := 0, 0
+	for pos < len(libName) && otherPos < len(otherName) {
+		switch char, otherChar := libName[pos], otherName[otherPos]; {
+		case isDigit(char) && isDigit(otherChar):
+			// Compare the two version-number runs numerically.
+			var version, otherVersion int
+			for ; pos < len(libName) && isDigit(libName[pos]); pos++ {
+				version = version*10 + int(libName[pos]-'0')
+			}
+			for ; otherPos < len(otherName) && isDigit(otherName[otherPos]); otherPos++ {
+				otherVersion = otherVersion*10 + int(otherName[otherPos]-'0')
+			}
+			if version != otherVersion {
+				return cmp.Compare(version, otherVersion)
+			}
+		case isDigit(char):
+			return 1 // a digit outranks a non-digit
+		case isDigit(otherChar):
+			return -1
+		case char != otherChar:
+			return cmp.Compare(char, otherChar)
+		default:
+			pos, otherPos = pos+1, otherPos+1
+		}
+	}
+	// Whichever name still has characters left is the greater one.
+	return cmp.Compare(len(libName)-pos, len(otherName)-otherPos)
 }
 
 func BuildCacheFileForDirs(fsys fs.FS, libdirs []string) (*LDSOCacheFile, error) {

--- a/internal/ldso-cache/ldsocache_test.go
+++ b/internal/ldso-cache/ldsocache_test.go
@@ -195,3 +195,30 @@ func Test_GenerateCacheFile(t *testing.T) {
 		require.GreaterOrEqual(t, prev, cur)
 	}
 }
+
+func Test_dlCacheLibcmp_DigitVsNonDigit(t *testing.T) {
+	// A digit outranks a non-digit at the same position (glibc semantics):
+	// "libyaml-0.so.2" > "libyaml-cpp.so.0.8" because '0' > 'c'.
+	require.Greater(t, dlCacheLibcmp("libyaml-0.so.2", "libyaml-cpp.so.0.8"), 0)
+	require.Less(t, dlCacheLibcmp("libyaml-cpp.so.0.8", "libyaml-0.so.2"), 0)
+	// Digit runs compare numerically, not lexically: ".so.9" < ".so.10".
+	require.Less(t, dlCacheLibcmp("libfoo.so.9", "libfoo.so.10"), 0)
+	require.Equal(t, 0, dlCacheLibcmp("libfoo.so.13", "libfoo.so.13"))
+}
+
+func Test_LDSOCacheEntriesForDirs_SortMatchesDlCacheLibcmp(t *testing.T) {
+	getElfInfo = mockGetElfInfo
+	root := os.DirFS("testdata/libroot")
+	libdirs, err := ParseLDSOConf(root, "etc/ld.so.conf")
+	require.NoError(t, err)
+	entries, err := LDSOCacheEntriesForDirs(root, libdirs)
+	require.NoError(t, err)
+	// Entries must be in descending _dl_cache_libcmp order so ld.so's binary
+	// search over the cache succeeds.
+	for i := 1; i < len(entries); i++ {
+		a := filepath.Base(entries[i-1].Name)
+		b := filepath.Base(entries[i].Name)
+		require.GreaterOrEqual(t, dlCacheLibcmp(a, b), 0,
+			"entries not in descending _dl_cache_libcmp order: %q before %q", a, b)
+	}
+}


### PR DESCRIPTION
apko generates /etc/ld.so.cache in glibc's modern format, which the dynamic linker (ld.so) queries with a binary search at process startup. That binary search assumes entries are ordered by glibc's own _dl_cache_libcmp comparison (elf/dl-cache.c) -- which is not a plain bytewise string sort. In _dl_cache_libcmp, runs of digits are compared numerically, and a digit is treated as greater than any non-digit at the same position.

We were sorting entries with a plain bytewise comparison of the library name. That ordering agrees with _dl_cache_libcmp most of the time, so small caches happened to work, but the two diverge wherever a digit meets a non-digit. For example "libyaml-0.so.2" vs "libyaml-cpp.so.0.8": glibc orders the digit '0' before the letter 'c', while a bytewise sort does the opposite. A single out-of-order entry breaks the invariant the binary search relies on, so in large, densely-versioned caches the search can walk past a library that is actually present and fail at startup with "cannot open shared object file" -- even though `ldconfig -p`, which does a linear scan, still lists it. Regenerating the identical cache with the real glibc ldconfig (which uses the correct ordering) makes it resolve, confirming the ordering is the sole cause.

Sort entries with a faithful port of _dl_cache_libcmp instead, negating the result to produce the descending order glibc's ldconfig emits. Add regression tests for the digit/non-digit and numeric-run cases and for the emitted ordering being monotonic under _dl_cache_libcmp.