### PR TITLE
Write sha256 checksum sidecar next to CA bundles

### DIFF
--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -198,6 +198,12 @@ func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) 
 		return nil, fmt.Errorf("failed to install certificates: %w", err)
 	}
 
+	// Record checksums of the (possibly updated) CA bundles so downstream
+	// tooling (e.g. OpenSCAP) can verify they were not modified post-build.
+	if err := bc.writeCABundleChecksums(ctx); err != nil {
+		return nil, fmt.Errorf("failed to write CA bundle checksums: %w", err)
+	}
+
 	if err := bc.installRuntimeKeyring(ctx); err != nil {
 		return nil, fmt.Errorf("failed to install runtime keyring: %w", err)
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -16,6 +16,9 @@ package build_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -179,6 +182,18 @@ func TestBuildImageWithCertPackages(t *testing.T) {
 		_, err := fsys.Stat(p)
 		require.NoError(t, err, "cert file %s should exist", p)
 	}
+
+	// A sha256 sidecar should be written next to the bundle, in sha256sum -c
+	// format, matching the final (post-append) contents of the bundle.
+	sidecarPath := "etc/ssl/certs/.ca-certificates.crt.sha256"
+	sidecarData, err := fsys.ReadFile(sidecarPath)
+	require.NoError(t, err, "CA bundle checksum sidecar should exist at %s", sidecarPath)
+
+	sum := sha256.Sum256(bundleData)
+	require.Equal(t,
+		fmt.Sprintf("%s  ca-certificates.crt\n", hex.EncodeToString(sum[:])),
+		string(sidecarData),
+		"sidecar must record the sha256 of the updated bundle")
 }
 
 func TestBuildImageFromLockFile(t *testing.T) {

--- a/pkg/build/certificates.go
+++ b/pkg/build/certificates.go
@@ -268,10 +268,11 @@ func caBundleChecksumSidecar(bundlePath string) string {
 }
 
 // writeCABundleChecksums writes a sha256sum-compatible sidecar file next to each
-// existing CA bundle so that downstream integrity tooling (e.g. OpenSCAP) can
-// later verify the bundle has not been modified since build time. It runs
-// unconditionally after certificate installation, so every image that ships a CA
-// bundle gets a baseline, whether or not additional certificates were configured.
+// existing CA bundle and Java truststore so that downstream integrity tooling
+// (e.g. OpenSCAP) can later verify they have not been modified since build time.
+// It runs unconditionally after certificate installation, so every image that
+// ships a CA bundle or truststore gets a baseline, whether or not additional
+// certificates were configured.
 func (bc *Context) writeCABundleChecksums(ctx context.Context) error {
 	_, span := otel.Tracer("apko").Start(ctx, "writeCABundleChecksums")
 	defer span.End()
@@ -281,29 +282,31 @@ func (bc *Context) writeCABundleChecksums(ctx context.Context) error {
 		return fmt.Errorf("failed to get build date epoch: %w", err)
 	}
 
-	for _, bundlePath := range caBundlePaths {
+	// PEM CA bundles plus the binary Java truststore(s). For the truststore the
+	// checksum is a plain file-level hash of the JKS keystore as written.
+	for _, bundlePath := range slices.Concat(caBundlePaths, javaTruststorePaths) {
 		data, err := bc.fs.ReadFile(bundlePath)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				// No bundle at this path, nothing to checksum.
+				// No file at this path, nothing to checksum.
 				continue
 			}
-			return fmt.Errorf("failed to read CA bundle %s: %w", bundlePath, err)
+			return fmt.Errorf("failed to read certificate store %s: %w", bundlePath, err)
 		}
 
 		sum := sha256.Sum256(data)
 		// sha256sum-compatible line ("<hex>  <basename>\n"). Using the basename
-		// keeps the sidecar verifiable with `sha256sum -c` from the bundle's dir.
+		// keeps the sidecar verifiable with `sha256sum -c` from the file's dir.
 		line := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), filepath.Base(bundlePath))
 
 		sidecar := caBundleChecksumSidecar(bundlePath)
 		// Read-only (r--r--r--): a baseline that shouldn't be casually
 		// overwritten, matching the mode used for /etc/apko.json.
 		if err := bc.fs.WriteFile(sidecar, []byte(line), 0o444); err != nil {
-			return fmt.Errorf("failed to write CA bundle checksum %s: %w", sidecar, err)
+			return fmt.Errorf("failed to write certificate store checksum %s: %w", sidecar, err)
 		}
 		if err := bc.fs.Chtimes(sidecar, builtTime, builtTime); err != nil {
-			return fmt.Errorf("failed to change times on CA bundle checksum %s: %w", sidecar, err)
+			return fmt.Errorf("failed to change times on certificate store checksum %s: %w", sidecar, err)
 		}
 	}
 

--- a/pkg/build/certificates.go
+++ b/pkg/build/certificates.go
@@ -260,6 +260,56 @@ func (bc *Context) installCertificates(ctx context.Context) error {
 	return nil
 }
 
+// caBundleChecksumSidecar returns the sidecar checksum path for a given CA
+// bundle path, e.g. "etc/ssl/certs/ca-certificates.crt" becomes
+// "etc/ssl/certs/.ca-certificates.crt.sha256".
+func caBundleChecksumSidecar(bundlePath string) string {
+	return filepath.Join(filepath.Dir(bundlePath), "."+filepath.Base(bundlePath)+".sha256")
+}
+
+// writeCABundleChecksums writes a sha256sum-compatible sidecar file next to each
+// existing CA bundle so that downstream integrity tooling (e.g. OpenSCAP) can
+// later verify the bundle has not been modified since build time. It runs
+// unconditionally after certificate installation, so every image that ships a CA
+// bundle gets a baseline, whether or not additional certificates were configured.
+func (bc *Context) writeCABundleChecksums(ctx context.Context) error {
+	_, span := otel.Tracer("apko").Start(ctx, "writeCABundleChecksums")
+	defer span.End()
+
+	builtTime, err := bc.GetBuildDateEpoch()
+	if err != nil {
+		return fmt.Errorf("failed to get build date epoch: %w", err)
+	}
+
+	for _, bundlePath := range caBundlePaths {
+		data, err := bc.fs.ReadFile(bundlePath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// No bundle at this path, nothing to checksum.
+				continue
+			}
+			return fmt.Errorf("failed to read CA bundle %s: %w", bundlePath, err)
+		}
+
+		sum := sha256.Sum256(data)
+		// sha256sum-compatible line ("<hex>  <basename>\n"). Using the basename
+		// keeps the sidecar verifiable with `sha256sum -c` from the bundle's dir.
+		line := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), filepath.Base(bundlePath))
+
+		sidecar := caBundleChecksumSidecar(bundlePath)
+		// Read-only (r--r--r--): a baseline that shouldn't be casually
+		// overwritten, matching the mode used for /etc/apko.json.
+		if err := bc.fs.WriteFile(sidecar, []byte(line), 0o444); err != nil {
+			return fmt.Errorf("failed to write CA bundle checksum %s: %w", sidecar, err)
+		}
+		if err := bc.fs.Chtimes(sidecar, builtTime, builtTime); err != nil {
+			return fmt.Errorf("failed to change times on CA bundle checksum %s: %w", sidecar, err)
+		}
+	}
+
+	return nil
+}
+
 // loadJavaTruststores loads all existing Java truststores from the configured paths.
 // It is ok if no truststores exist; in that case, an empty slice is returned.
 func (bc *Context) loadJavaTruststores() ([]loadedTruststore, error) {

--- a/pkg/build/certificates_test.go
+++ b/pkg/build/certificates_test.go
@@ -18,6 +18,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -646,5 +648,88 @@ func TestInstallCertificates(t *testing.T) {
 				return nil
 			})
 		})
+	}
+}
+
+func TestWriteCABundleChecksums(t *testing.T) {
+	epoch := time.Unix(1337, 0)
+	t.Setenv("SOURCE_DATE_EPOCH", fmt.Sprintf("%d", epoch.Unix()))
+
+	// sha256sum -c compatible line for the given content and basename.
+	sumLine := func(content []byte, name string) []byte {
+		sum := sha256.Sum256(content)
+		return []byte(fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name))
+	}
+
+	bundle := []byte("-----BEGIN CERTIFICATE-----\nbundle\n-----END CERTIFICATE-----\n")
+	awsBundle := []byte("-----BEGIN CERTIFICATE-----\naws\n-----END CERTIFICATE-----\n")
+	truststore := []byte("not-really-jks-but-bytes-are-hashed-as-is")
+
+	fsys := apkfs.NewMemFS()
+	existing := map[string][]byte{
+		caBundlePaths[0]:       bundle,     // etc/ssl/certs/ca-certificates.crt
+		caBundlePaths[1]:       awsBundle,  // AWS ECS bundle
+		javaTruststorePaths[0]: truststore, // Java cacerts
+	}
+	for path, content := range existing {
+		if err := fsys.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create dir for %s: %v", path, err)
+		}
+		if err := fsys.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+	}
+
+	bc := &Context{
+		o:  options.Options{SourceDateEpoch: epoch},
+		fs: fsys,
+	}
+	if err := bc.writeCABundleChecksums(context.Background()); err != nil {
+		t.Fatalf("writeCABundleChecksums() error = %v", err)
+	}
+
+	wantSidecars := map[string][]byte{
+		caBundleChecksumSidecar(caBundlePaths[0]):       sumLine(bundle, "ca-certificates.crt"),
+		caBundleChecksumSidecar(caBundlePaths[1]):       sumLine(awsBundle, "tls-ca-bundle.pem"),
+		caBundleChecksumSidecar(javaTruststorePaths[0]): sumLine(truststore, "cacerts"),
+	}
+	for path, want := range wantSidecars {
+		got, err := fsys.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected sidecar %s: %v", path, err)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("sidecar content mismatch for %s (-want +got):\n%s", path, diff)
+		}
+		stat, err := fsys.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat sidecar %s: %v", path, err)
+		}
+		if stat.Mode().Perm() != 0o444 {
+			t.Errorf("sidecar %s has mode %v, want 0444", path, stat.Mode().Perm())
+		}
+		if !stat.ModTime().Equal(epoch) {
+			t.Errorf("sidecar %s has mod time %v, want %v", path, stat.ModTime(), epoch)
+		}
+	}
+}
+
+func TestWriteCABundleChecksumsNoBundles(t *testing.T) {
+	epoch := time.Unix(1337, 0)
+	t.Setenv("SOURCE_DATE_EPOCH", fmt.Sprintf("%d", epoch.Unix()))
+
+	fsys := apkfs.NewMemFS()
+	bc := &Context{
+		o:  options.Options{SourceDateEpoch: epoch},
+		fs: fsys,
+	}
+	// No bundles present: should be a no-op, not an error.
+	if err := bc.writeCABundleChecksums(context.Background()); err != nil {
+		t.Fatalf("writeCABundleChecksums() error = %v", err)
+	}
+	for _, p := range append(append([]string{}, caBundlePaths...), javaTruststorePaths...) {
+		if _, err := fsys.Stat(caBundleChecksumSidecar(p)); err == nil {
+			t.Errorf("unexpected sidecar created for missing bundle %s", p)
+		}
 	}
 }

--- a/pkg/build/certificates_test.go
+++ b/pkg/build/certificates_test.go
@@ -658,7 +658,7 @@ func TestWriteCABundleChecksums(t *testing.T) {
 	// sha256sum -c compatible line for the given content and basename.
 	sumLine := func(content []byte, name string) []byte {
 		sum := sha256.Sum256(content)
-		return []byte(fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), name))
+		return fmt.Appendf(nil, "%s  %s\n", hex.EncodeToString(sum[:]), name)
 	}
 
 	bundle := []byte("-----BEGIN CERTIFICATE-----\nbundle\n-----END CERTIFICATE-----\n")


### PR DESCRIPTION
## What

Writes a `sha256sum`-compatible sidecar file next to each CA bundle **and Java truststore** in the built image, so downstream tooling (e.g. OpenSCAP) can detect **accidental/benign drift** after the image was built.

For `etc/ssl/certs/ca-certificates.crt` the sidecar is `etc/ssl/certs/.ca-certificates.crt.sha256`, containing:

```
<hex>  ca-certificates.crt
```

## Files covered

- `etc/ssl/certs/ca-certificates.crt` (Alpine default)
- `var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem` (AWS ECS)
- `etc/ssl/certs/java/cacerts` (Java truststore)

## Details

- Runs unconditionally after `installCertificates`, for **every** existing bundle/truststore — not just when `.certificates` is configured — so every image gets a baseline.
- Captures the **final** contents (after any additional/provider certs are appended).
- Written **read-only (`0444`)**, matching the mode apko already uses for `/etc/apko.json`.
- Timestamped with the build epoch to preserve reproducibility.

## Verify

```sh
cd /etc/ssl/certs && sha256sum -c .ca-certificates.crt.sha256
```

## Notes

- Intended for detecting accidental/benign drift, **not** tamper-evidence — the sidecar lives inside the image and can be rewritten alongside the file. For a cryptographic guarantee the hash would need to live in an image signature/attestation instead.
- The Java truststore sidecar is a plain file-level hash of the JKS keystore as apko writes it.

## Tests

- `TestWriteCABundleChecksums` — asserts sidecars for both PEM bundles and the Java truststore, plus read-only mode and build-epoch timestamp.
- `TestWriteCABundleChecksumsNoBundles` — missing-file no-op.
- `TestBuildImageWithCertPackages` — asserts the sidecar matches the sha256 of the updated bundle end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)