### PR TITLE
Allow GitHub verified signatures in source policy

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -11,3 +11,6 @@ spec:
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg
+  # Allow Github verified ssh, gpg, and smime signatures
+  github:
+    verified: true


### PR DESCRIPTION
## What

Adds `github.verified: true` to `.chainguard/source.yaml` so that commits carrying **GitHub-verified ssh, gpg, and smime signatures** are accepted by the source policy.

```yaml
  # Allow Github verified ssh, gpg, and smime signatures
  github:
    verified: true
```

## Why

This matches the source policy already used in other Chainguard repos (e.g. `stereo`), which accept GitHub's verified signatures in addition to the existing keyless (GitHub/Google OIDC) and `web-flow.gpg` authorities. It unblocks contributors who sign commits with hardware-backed ssh/gpg keys that GitHub verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)