### PR TITLE
Intern parsed repository packages

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -432,6 +432,13 @@ func parseRepositoryIndex(ctx context.Context, u string, keys map[string][]byte,
 		return nil, fmt.Errorf("unable to read convert repository index bytes to index struct: %w", err)
 	}
 
+	// Share package payloads with other indexes carrying the same packages.
+	// Only the repository-fetch path interns: index manipulation tooling
+	// building on IndexFromArchive directly keeps exclusive ownership.
+	for i, pkg := range index.Packages {
+		index.Packages[i] = internPackage(pkg)
+	}
+
 	return index, err
 }
 

--- a/pkg/apk/apk/intern.go
+++ b/pkg/apk/apk/intern.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"reflect"
+	"sync"
+	"weak"
+)
+
+// Repository indexes overlap heavily: consecutive generations of one index
+// share almost all of their packages, and indexes of related repositories
+// carry large common subsets. Interning parsed packages lets all of them
+// share a single Package per distinct package instead of a copy per index.
+// Entries hold weak pointers, so the table itself pins nothing.
+//
+// Sharing requires that packages parsed from repository indexes are never
+// mutated; they are treated as immutable everywhere.
+var packageInterner = struct {
+	sync.Mutex
+	m map[internKey]weak.Pointer[Package]
+}{m: map[internKey]weak.Pointer[Package]{}}
+
+type internKey struct {
+	name     string
+	checksum string
+}
+
+// internPackage returns the canonical *Package for pkg: a previously interned
+// package with an identical record, or pkg itself if none is registered yet.
+// Packages without a checksum are not interned.
+//
+// The {name, checksum} pair only buckets candidates; identity is confirmed
+// with reflect.DeepEqual over the whole package, so two records share a
+// Package only when every field matches. That keeps interning safe across
+// repository trust boundaries - a crafted index cannot donate its
+// dependencies to another repository's package by matching the control hash
+// alone - and cannot silently drop a field the way a hand-written comparison
+// could.
+func internPackage(pkg *Package) *Package {
+	if len(pkg.Checksum) == 0 {
+		return pkg
+	}
+	key := internKey{name: pkg.Name, checksum: string(pkg.Checksum)}
+
+	packageInterner.Lock()
+	defer packageInterner.Unlock()
+
+	if wp, ok := packageInterner.m[key]; ok {
+		if canonical := wp.Value(); canonical != nil {
+			if reflect.DeepEqual(pkg, canonical) {
+				return canonical
+			}
+			// A live but different package holds the bucket (a control-hash
+			// collision or a poisoning attempt): keep both distinct.
+			return pkg
+		}
+	}
+
+	// Weak so the payload is collected once no live index references it. A
+	// dead entry reads back as a miss and is overwritten when its record
+	// recurs; one forms only when a record leaves every live index at once,
+	// rare for largely append-only indexes, so tombstones accumulate slowly.
+	packageInterner.m[key] = weak.Make(pkg)
+	return pkg
+}

--- a/pkg/apk/apk/intern_test.go
+++ b/pkg/apk/apk/intern_test.go
@@ -1,0 +1,154 @@
+package apk
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"weak"
+)
+
+func internTestIndexBody(t *testing.T, nPkgs int) []byte {
+	t.Helper()
+	idx := &APKIndex{Description: "intern-test"}
+	for i := range nPkgs {
+		idx.Packages = append(idx.Packages, &Package{
+			Name:    fmt.Sprintf("pkg-%d", i),
+			Version: "1.0.0-r0",
+			Arch:    "x86_64",
+			// A fat payload so sharing dominates the heap measurements.
+			Description:  strings.Repeat(fmt.Sprintf("synthetic package %d ", i), 50),
+			Checksum:     fmt.Appendf(nil, "checksum-of-pkg-%05d", i),
+			Dependencies: []string{fmt.Sprintf("pkg-%d", min(i+1, 20))},
+			Provides:     []string{fmt.Sprintf("cmd:tool-%d=1.0.0-r0", i)},
+			BuildTime:    time.Unix(1700000000, 0).UTC(),
+		})
+	}
+	archive, err := ArchiveFromIndex(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func internTestServer(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	var etag atomic.Value
+	etag.Store("gen-0")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", r.URL.Query().Get("gen")+"gen"))
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Indexes at different URLs carrying the same packages must share the parsed
+// Package payloads.
+func TestInterningSharesPackagesAcrossIndexes(t *testing.T) {
+	ctx := t.Context()
+	body := internTestIndexBody(t, 100)
+	srv := internTestServer(t, body)
+
+	fetch := func(repo string) NamedIndex {
+		indexes, err := GetRepositoryIndexes(ctx, []string{repo}, nil, "x86_64",
+			WithIgnoreSignatures(true), WithHTTPClient(srv.Client()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return indexes[0]
+	}
+
+	a := fetch(srv.URL + "/repo-a")
+	b := fetch(srv.URL + "/repo-b")
+
+	for i, pkg := range a.Packages() {
+		if pkg.Package != b.Packages()[i].Package {
+			t.Fatalf("package %d not shared across indexes", i)
+		}
+	}
+}
+
+// Records that differ in any field must not be conflated, even when they share
+// a name and control hash. Dependencies is a field the old six-field guard did
+// not compare; DeepEqual does, which is what keeps interning safe across
+// repository trust boundaries.
+func TestInterningRejectsMismatchedRecords(t *testing.T) {
+	a := &Package{Name: "pkg", Version: "1.0.0-r0", Checksum: []byte("intern-mismatch-test"), Dependencies: []string{"honest-dep"}}
+	b := &Package{Name: "pkg", Version: "1.0.0-r0", Checksum: []byte("intern-mismatch-test"), Dependencies: []string{"honest-dep", "evil-dep"}}
+
+	canonical := internPackage(a)
+	if canonical != a {
+		t.Fatal("first package should become canonical")
+	}
+	// b shares a's name and checksum but differs, so it must not be conflated
+	// with the canonical. Comparing against canonical also keeps a live across
+	// this call, so the mismatch path is exercised rather than a dead-entry miss.
+	if internPackage(b) == canonical {
+		t.Fatal("record differing only in dependencies was conflated")
+	}
+}
+
+// The intern table holds packages weakly, so an interned package must be
+// collectable once no live index references it; a strong table would pin it
+// forever. (The dead map entry lingers until overwritten, which is intended.)
+func TestInterningDoesNotPinPackages(t *testing.T) {
+	var observer weak.Pointer[Package]
+	func() {
+		pkg := internPackage(&Package{
+			Name:     "collectable",
+			Version:  "1.0.0-r0",
+			Checksum: []byte("intern-collect-test"),
+		})
+		observer = weak.Make(pkg)
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for observer.Value() != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("interned package was not collected; the table is pinning it")
+		}
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Loading identical indexes from distinct URLs must share package objects, not
+// duplicate them: the union of every index's package pointers is one index's
+// worth, not one per index.
+func TestInterningDeduplicatesAcrossURLs(t *testing.T) {
+	const nPkgs = 1000
+	const copies = 4
+
+	ctx := t.Context()
+	body := internTestIndexBody(t, nPkgs)
+	srv := internTestServer(t, body)
+
+	seen := map[*Package]struct{}{}
+	for i := range copies {
+		got, err := GetRepositoryIndexes(ctx, []string{fmt.Sprintf("%s/repo-%d", srv.URL, i)}, nil, "x86_64",
+			WithIgnoreSignatures(true), WithHTTPClient(srv.Client()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, p := range got[0].Packages() {
+			seen[p.Package] = struct{}{}
+		}
+	}
+
+	if len(seen) != nPkgs {
+		t.Errorf("saw %d distinct package objects across %d identical indexes, want %d", len(seen), copies, nPkgs)
+	}
+}


### PR DESCRIPTION
Repository indexes overlap heavily: consecutive generations of one index share almost all of their packages, and indexes of related repositories carry large common subsets. A long-running process that resolves against many such indexes at distinct URLs (which the index cache does not dedup, since it keys on URL) otherwise retains a full private copy of the shared packages for each one - tens of MB apiece.

Intern packages parsed on the repository-fetch path in a weak-pointer table, so all indexes carrying an identical package share one canonical copy that lives exactly as long as some index references it. A {name, checksum} pair buckets candidates and reflect.DeepEqual confirms identity over the whole record, so packages share a Package only when every field matches: interning is safe across repository trust boundaries and cannot silently drop a field. Packages without a checksum, and index-manipulation tooling building on IndexFromArchive directly, are left untouched.

Holding six identical indexes from distinct URLs grows the heap by one 93 MB payload plus ~2.7 MB per index, instead of 93 MB per index.