### PR TITLE
Evict superseded index generations from the derived caches

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -56,6 +56,7 @@ type Signature struct {
 var globalIndexCache = &indexCache{
 	indexes:  newFlightCache[cacheKey, NamedIndex](),
 	modtimes: map[string]time.Time{},
+	current:  map[string]NamedIndex{},
 }
 
 type cacheKey struct {
@@ -69,6 +70,39 @@ type indexCache struct {
 	// For local indexes.
 	sync.Mutex
 	modtimes map[string]time.Time
+
+	// current is the latest index object served per index URL. When a newer
+	// generation replaces an entry, derived data cached for the superseded
+	// index is purged, and the resolver caches consult isCurrent to avoid
+	// re-caching data for superseded indexes that in-flight resolutions
+	// still hold.
+	currentMu sync.Mutex
+	current   map[string]NamedIndex
+}
+
+// setCurrent records idx as the latest generation for the index URL u,
+// purging derived caches for the generation it replaces.
+func (i *indexCache) setCurrent(u string, idx NamedIndex) {
+	i.currentMu.Lock()
+	prev := i.current[u]
+	i.current[u] = idx
+	i.currentMu.Unlock()
+
+	if prev != nil && prev != idx {
+		globalResolverCache.ForgetIndex(prev)
+		globalDisqualifyCache.ForgetIndex(prev)
+	}
+}
+
+// isCurrent reports whether idx is still the latest generation of its index.
+// Indexes this cache has never served (e.g. locally constructed ones) are
+// considered current: they are not subject to generation replacement.
+func (i *indexCache) isCurrent(idx NamedIndex) bool {
+	i.currentMu.Lock()
+	defer i.currentMu.Unlock()
+
+	cur, ok := i.current[idx.Source()]
+	return !ok || cur == idx
 }
 
 func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map[string][]byte, arch string, opts *indexOpts) (NamedIndex, error) {
@@ -144,6 +178,9 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			return k.url == u && k.etag != etag
 		})
 
+		if err == nil {
+			i.setCurrent(u, idx)
+		}
 		return idx, err
 	} else {
 		i.Lock()
@@ -166,7 +203,7 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		}
 		i.modtimes[u] = mod
 
-		return i.indexes.Do(key, func() (NamedIndex, error) {
+		idx, err := i.indexes.Do(key, func() (NamedIndex, error) {
 			b, err := os.ReadFile(u)
 			if err != nil {
 				return nil, fmt.Errorf("reading file: %w", err)
@@ -177,6 +214,10 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			}
 			return NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(idx)), nil
 		})
+		if err == nil {
+			i.setCurrent(u, idx)
+		}
+		return idx, err
 	}
 }
 

--- a/pkg/apk/apk/index_eviction_test.go
+++ b/pkg/apk/apk/index_eviction_test.go
@@ -1,0 +1,205 @@
+package apk
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSupersededGenerationsAreCollectable guards against derived resolution
+// data (resolvers, disqualify sets) pinning superseded index generations.
+// Every etag rotation used to leak the entire previous generation via the
+// global resolver and disqualify caches; replacing a generation now purges
+// its derived entries, and resolutions still holding a superseded generation
+// (as concurrent builds do when an index rotates mid-flight) must not
+// re-insert it.
+func TestSupersededGenerationsAreCollectable(t *testing.T) {
+	const nPkgs = 10000
+
+	idx := &APKIndex{Description: "leak-test"}
+	for i := range nPkgs {
+		idx.Packages = append(idx.Packages, &Package{
+			Name:        fmt.Sprintf("pkg-%d", i),
+			Version:     "1.0.0-r0",
+			Arch:        "x86_64",
+			Description: fmt.Sprintf("synthetic package %d", i),
+			Checksum:    []byte("01234567890123456789"),
+			// A short chain keeps the resolve cheap; the index stays large.
+			Dependencies: []string{fmt.Sprintf("pkg-%d", min(i+1, 20))},
+			Provides:     []string{fmt.Sprintf("cmd:tool-%d=1.0.0-r0", i)},
+			BuildTime:    time.Unix(1700000000, 0).UTC(),
+		})
+	}
+	archive, err := ArchiveFromIndex(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	if _, err := body.ReadFrom(archive); err != nil {
+		t.Fatal(err)
+	}
+
+	var etag atomic.Value
+	etag.Store("gen-0")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", etag.Load()))
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body.Bytes())
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	heapMB := func() float64 {
+		runtime.GC()
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		return float64(m.HeapAlloc) / (1 << 20)
+	}
+
+	resolve := func(indexes []NamedIndex) {
+		p := NewPkgResolver(ctx, indexes)
+		// Two arches so the disqualify cache is exercised too.
+		if _, _, err := p.GetPackagesWithDependencies(ctx, []string{"pkg-0"},
+			map[string][]NamedIndex{"x86_64": indexes, "aarch64": indexes}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fetch := func(g int) []NamedIndex {
+		etag.Store(fmt.Sprintf("gen-%d", g))
+		indexes, err := GetRepositoryIndexes(ctx, []string{srv.URL}, nil, "x86_64",
+			WithIgnoreSignatures(true), WithHTTPClient(srv.Client()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return indexes
+	}
+
+	// Warm up allocator and caches, then measure growth across generations.
+	resolve(fetch(0))
+	base := heapMB()
+	const generations = 8
+	prev := fetch(1)
+	for g := 2; g <= generations+1; g++ {
+		// Fetching generation g evicts generation g-1, which an unfinished
+		// resolution still holds — like a build racing an index rotation.
+		// Resolving with it afterwards must not re-pin it.
+		indexes := fetch(g)
+		resolve(prev)
+		resolve(indexes)
+		prev = indexes
+	}
+	prev = nil
+	_ = prev
+	grown := heapMB() - base
+
+	// Each pinned generation retains several MB (index, resolver maps,
+	// disqualify sets). With correct purging, growth stays near zero; the
+	// unpurged caches grew by roughly generations * per-generation size
+	// (tens of MB here).
+	if grown > 20 {
+		t.Errorf("heap grew by %.1f MB across %d index generations, derived data is likely pinned", grown, generations)
+	}
+}
+
+// TestSupersededGenerationsConcurrentlyBounded drives index rotations and
+// resolutions concurrently, so a purge genuinely races an in-flight Get that
+// still holds a superseded generation - the case the insert gate exists for
+// and the sequential test above does not reach. It asserts the resolver cache
+// retains only a bounded number of generations for the URL rather than one
+// per rotation. Run under -race to also catch data races and deadlocks.
+func TestSupersededGenerationsConcurrentlyBounded(t *testing.T) {
+	const nPkgs = 300
+
+	idx := &APKIndex{Description: "concurrent-leak-test"}
+	for i := range nPkgs {
+		idx.Packages = append(idx.Packages, &Package{
+			Name:         fmt.Sprintf("pkg-%d", i),
+			Version:      "1.0.0-r0",
+			Arch:         "x86_64",
+			Checksum:     []byte("01234567890123456789"),
+			Dependencies: []string{fmt.Sprintf("pkg-%d", min(i+1, 20))},
+			BuildTime:    time.Unix(1700000000, 0).UTC(),
+		})
+	}
+	archive, err := ArchiveFromIndex(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	if _, err := body.ReadFrom(archive); err != nil {
+		t.Fatal(err)
+	}
+
+	// ETag tracks a counter the workers bump; each distinct value the HEAD
+	// observes is a new generation of the same URL.
+	var gen atomic.Int64
+	gen.Store(1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", fmt.Sprintf("gen-%d", gen.Load())))
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body.Bytes())
+	}))
+	defer srv.Close()
+
+	ctx := t.Context()
+	const (
+		workers = 4
+		rounds  = 60
+	)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for range rounds {
+				gen.Add(1) // rotate: a new generation supersedes the current one
+				indexes, err := GetRepositoryIndexes(ctx, []string{srv.URL}, nil, "x86_64",
+					WithIgnoreSignatures(true), WithHTTPClient(srv.Client()))
+				if err != nil {
+					t.Errorf("fetch: %v", err)
+					return
+				}
+				// Populates globalResolverCache for the current generation, or
+				// takes the gate's uncached path if this index was superseded
+				// by a concurrent rotation in the meantime.
+				_ = NewPkgResolver(ctx, indexes)
+			}
+		})
+	}
+	wg.Wait()
+
+	// The workers drove workers*rounds rotations. Without eviction the resolver
+	// cache would hold ~that many generations for the URL; with it, only the
+	// current generation and a few racing stragglers survive.
+	url := IndexURL(srv.URL, "x86_64")
+	if got := countResolverGenerations(url); got > 20 {
+		t.Errorf("resolver cache retains %d generations for %s; superseded generations are not being evicted (expected a small bound)", got, url)
+	}
+}
+
+// countResolverGenerations counts the distinct index generations the global
+// resolver cache still holds for a single index URL (one top-level trie child
+// per generation, since these resolvers are built from a single index).
+func countResolverGenerations(url string) int {
+	globalResolverCache.Lock()
+	defer globalResolverCache.Unlock()
+
+	n := 0
+	for k := range globalResolverCache.children {
+		if k.Source() == url {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/apk/apk/shameful_global_caches.go
+++ b/pkg/apk/apk/shameful_global_caches.go
@@ -69,6 +69,13 @@ func (r *resolverCache) fill(indexes []NamedIndex, pr *PkgResolver) {
 }
 
 func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResolver {
+	// A superseded index generation will never be requested again once the
+	// in-flight resolutions holding it finish, and no future replacement
+	// will purge it, so it must not (re-)enter the cache.
+	if !currentAll(indexes) {
+		return newPkgResolver(ctx, indexes)
+	}
+
 	r.Lock()
 	defer r.Unlock()
 
@@ -79,7 +86,40 @@ func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResol
 	pr := newPkgResolver(ctx, indexes)
 	r.fill(indexes, pr)
 
+	// A generation replacement that raced the fill has already run its
+	// purge, so purge its index ourselves.
+	for _, idx := range indexes {
+		if !globalIndexCache.isCurrent(idx) {
+			r.forgetIndex(idx)
+		}
+	}
+
 	return pr.Clone()
+}
+
+func currentAll(indexes []NamedIndex) bool {
+	for _, idx := range indexes {
+		if !globalIndexCache.isCurrent(idx) {
+			return false
+		}
+	}
+	return true
+}
+
+// ForgetIndex removes every cached entry whose index combination includes
+// idx: a resolver over a superseded generation is superseded itself.
+func (r *resolverCache) ForgetIndex(idx NamedIndex) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.forgetIndex(idx)
+}
+
+func (r *resolverCache) forgetIndex(idx NamedIndex) {
+	delete(r.children, idx)
+	for _, child := range r.children {
+		child.forgetIndex(idx)
+	}
 }
 
 // It is expensive to compute the complement
@@ -135,6 +175,10 @@ func (r *disqualifyCache) Get(ctx context.Context, byArch map[string][]NamedInde
 	defer r.Unlock()
 
 	indexes := slices.Concat(slices.Collect(maps.Values(byArch))...)
+	if !currentAll(indexes) {
+		return disqualifyDifference(ctx, byArch)
+	}
+
 	slices.SortFunc(indexes, func(a, b NamedIndex) int {
 		return strings.Compare(a.Name(), b.Name())
 	})
@@ -145,5 +189,27 @@ func (r *disqualifyCache) Get(ctx context.Context, byArch map[string][]NamedInde
 	dq := disqualifyDifference(ctx, byArch)
 	r.fill(indexes, dq)
 
+	for _, idx := range indexes {
+		if !globalIndexCache.isCurrent(idx) {
+			r.forgetIndex(idx)
+		}
+	}
+
 	return maps.Clone(dq)
+}
+
+// ForgetIndex removes every cached entry whose index combination includes
+// idx: a difference over a superseded generation is superseded itself.
+func (r *disqualifyCache) ForgetIndex(idx NamedIndex) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.forgetIndex(idx)
+}
+
+func (r *disqualifyCache) forgetIndex(idx NamedIndex) {
+	delete(r.children, idx)
+	for _, child := range r.children {
+		child.forgetIndex(idx)
+	}
 }


### PR DESCRIPTION
The global resolver and disqualify caches key derived data by NamedIndex combinations and never evict, so every etag rotation of an APKINDEX pins the entire previous generation (parsed index, PkgResolver maps, disqualify sets) for the life of the process. Long-running processes that periodically re-resolve against rotating indexes leak tens of MB per rotation and eventually OOM.

Track the latest generation served per index URL, and purge derived entries for a generation when a newer one replaces it. Cached entries for superseded generations are unreachable for new resolutions anyway (a fresh fetch yields fresh index objects and therefore a cache miss), so this frees memory without changing any resolution result.

Resolutions that fetched their indexes just before a rotation still hold the superseded generation and would re-insert it after the purge, with nothing left to evict it again. The derived caches therefore refuse to memoize any combination containing a superseded index, building and returning the result uncached instead; it dies with the resolution holding it. A re-check after fill closes the window where a replacement races the memoization.