### PR TITLE
chore(harden-runner): allow apple endpoints to OSX builds

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            *.apple.com:443
             *.blob.core.windows.net:443
             *.githubapp.com:443
             9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
@@ -105,6 +106,7 @@ jobs:
             api.github.com:443
             apk.cgr.dev:443
             auth.docker.io:443
+            cp*.cloudflare.com
             cgr.dev:443
             dl-cdn.alpinelinux.org:443
             dl.google.com:443
@@ -121,6 +123,7 @@ jobs:
             storage.googleapis.com:443
             sum.golang.org:443
             updates.cdn-apple.com:443
+            updates-http.cdn-apple.com:80
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false


### PR DESCRIPTION
Example blocked calls result:
https://github.com/chainguard-dev/apko/pull/2359/checks?check_run_id=90895600126

The following anomalous outbound network calls were detected.

| Endpoint 		        |	Workflow 	| Workflow Run Insights	| status |
| ------------------------------|-----------------------|-----------------------| ------- |
| api.apple-cloudkit.com	| build-samples.yml	| Insights URL		| ❌ Blocked |
| configuration.apple.com	| build-samples.yml	| Insights URL		| ❌ Blocked |
| xp.apple.com		        | build-samples.yml	| Insights URL		| ❌ Blocked |
| itunes.apple.com	        | build-samples.yml	| Insights URL		| ❌ Blocked |
| bag.itunes.apple.com	        | build-samples.yml	| Insights URL		| ❌ Blocked | 
| stocks-data-service.apple.com | build-samples.yml     | Insights URL	        | ❌ Blocked |
| cp10.cloudflare.com	        | build-samples.yml	| Insights URL		| ❌ Blocked |
| ipcdn.apple.com		| build-samples.yml	| Insights URL		| ❌ Blocked |
| cds.apple.com		        | build-samples.yml	| Insights URL		| ❌ Blocked |
| configuration.apple.com	| build-samples.yml	| Insights URL		| ❌ Blocked |
| configuration.apple.com	| build-samples.yml	| Insights URL		| ❌ Blocked |
| valid.apple.com		| build-samples.yml	| Insights URL		| ❌ Blocked |
| updates-http.cdn-apple.com    | build-samples.yml	| Insights URL		| ❌ Blocked |
| help.apple.com		| build-samples.yml	| Insights URL		| ❌ Blocked |