### PR TITLE
test: set source date epoch to `0`

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -48,4 +48,21 @@ jobs:
           check-latest: true
 
       - name: Test
-        run: make test
+        run: |
+          # The tests golden fixtures all expect `SOURCE_DATE_EPOCH` to be `0`.
+          # They set this themselves. This environment variable is a guard to
+          # ensure that if the test environment happens to have
+          # `SOURCE_DATE_EPOCH` set, it does not end up being used. The `awk`
+          # program returns a random integer between `1` and now.
+          SOURCE_DATE_EPOCH=$(
+            awk 'BEGIN {
+              now = systime()
+              srand(now)
+
+              print 1 + int(rand() * now)
+            }'
+          )
+
+          export SOURCE_DATE_EPOCH
+
+          make test

--- a/internal/cli/build_test.go
+++ b/internal/cli/build_test.go
@@ -16,7 +16,6 @@ package cli_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -34,7 +33,9 @@ import (
 )
 
 func TestBuild(t *testing.T) {
-	ctx := context.Background()
+	unsetSourceDateEpoch(t)
+
+	ctx := t.Context()
 	tmp := t.TempDir()
 
 	golden := filepath.Join("testdata", "golden")
@@ -114,11 +115,13 @@ func TestBuild(t *testing.T) {
 }
 
 func TestBuildWithBase(t *testing.T) {
+	unsetSourceDateEpoch(t)
+
 	// top_image golden file can be regenerated using ./internal/cli/testdata/regenerate_golden_top_image.sh script.
 
 	// TODO(sfc-gh-mhazy) Check sboms after base image support is reflected in them.
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tmp := t.TempDir()
 	apkoTempDir := t.TempDir()
 

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli_test
+
+import (
+	"os"
+	"testing"
+)
+
+// unsetSourceDateEpoch clears SOURCE_DATE_EPOCH for the duration of the
+// test, so the build derives its epoch from the installed packages. The
+// golden fixtures were generated this way. t.Setenv registers restoration
+// of the caller's value and prevents the test from running in parallel.
+func unsetSourceDateEpoch(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("SOURCE_DATE_EPOCH", "")
+	os.Unsetenv("SOURCE_DATE_EPOCH")
+}

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -16,7 +16,6 @@ package cli_test
 
 import (
 	"archive/tar"
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -45,7 +44,9 @@ import (
 )
 
 func TestPublish(t *testing.T) {
-	ctx := context.Background()
+	unsetSourceDateEpoch(t)
+
+	ctx := t.Context()
 	tmp := t.TempDir()
 
 	// Set up a registry that requires we see a magic header.
@@ -119,7 +120,9 @@ func (s *sentinel) RoundTrip(in *http.Request) (*http.Response, error) {
 }
 
 func TestPublishLayering(t *testing.T) {
-	ctx := context.Background()
+	unsetSourceDateEpoch(t)
+
+	ctx := t.Context()
 	tmp := t.TempDir()
 
 	// Set up a registry that requires we see a magic header.


### PR DESCRIPTION
The CLI golden tests currently inherit `SOURCE_DATE_EPOCH` from the caller's environment. If `SOURCE_DATE_EPOCH` is set in the caller's environment then the tests produce otherwise-valid images with different creation timestamps, causing the digest comparisons to fail even though CI is green.

Tests should be isolated from the host as much as they can be. In this case, we should run with `SOURCE_DATE_EPOCH` unset, so the build derives its epoch from the fixture packages.

This makes their build times be all zero, matching the golden files, and the derivation logic in GetBuildDateEpoch stays under test.

To protect against this regressing accidentally in the future, give the Go test job in CI a non-zero epoch in its environment. This means other tests cannot accidentally depend on the variable being unset or zero.
