### PR TITLE
build: add a disk cache opt-out

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -95,6 +95,9 @@ func New(ctx context.Context, options ...Option) (*APK, error) {
 			return nil, err
 		}
 	}
+	if opt.cache != nil {
+		opt.cache.offline = opt.offline
+	}
 
 	if opt.fs == nil {
 		// This is expensive so we only want to do it if we aren't passed WithFS.
@@ -114,6 +117,9 @@ func New(ctx context.Context, options ...Option) (*APK, error) {
 	client.Logger = clog.FromContext(ctx)
 
 	httpClient := client.StandardClient()
+	if opt.offline {
+		httpClient.Transport = offlineTransport{}
+	}
 
 	// Create default PackageGetter if none provided
 	packageGetter := opt.packageGetter

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -33,6 +33,7 @@ type opts struct {
 	fs                 apkfs.FullFS
 	version            string
 	cache              *cache
+	offline            bool
 	noSignatureIndexes []string
 	auth               auth.Authenticator
 	ignoreSignatures   bool
@@ -113,10 +114,19 @@ func WithCache(cacheDir string, offline bool, shared *Cache) Option {
 			}
 		}
 		o.cache = &cache{
-			dir:     cacheDir,
-			offline: offline,
-			shared:  shared,
+			dir:    cacheDir,
+			shared: shared,
 		}
+		o.offline = offline
+		return nil
+	}
+}
+
+// WithOffline controls whether network requests are permitted. Cached and
+// local resources remain available in offline mode.
+func WithOffline(offline bool) Option {
+	return func(o *opts) error {
+		o.offline = offline
 		return nil
 	}
 }

--- a/pkg/apk/apk/transport.go
+++ b/pkg/apk/apk/transport.go
@@ -21,6 +21,25 @@ import (
 	"net/http"
 )
 
+// OfflineNetworkError reports a network request blocked by offline mode.
+type OfflineNetworkError struct {
+	Method string
+	URL    string
+}
+
+func (e *OfflineNetworkError) Error() string {
+	return fmt.Sprintf("network request blocked in offline mode: %s %s", e.Method, e.URL)
+}
+
+type offlineTransport struct{}
+
+func (offlineTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, &OfflineNetworkError{
+		Method: req.Method,
+		URL:    req.URL.Redacted(),
+	}
+}
+
 type rangeRetryTransport struct {
 	base http.RoundTripper
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -289,22 +289,18 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 			HTTPResponseMaxSize:         bc.o.SizeLimits.HTTPResponseMaxSize,
 		}),
 	}
-	// only try to pass the cache dir if one of the following is true:
-	// - the user has explicitly set a cache dir
-	// - the user's system-determined cachedir, as set by os.UserCacheDir(), can be found
-	// if neither of these are true, then we don't want to pass a cache dir, because
-	// go-apk will try to set it to os.UserCacheDir() which returns an error if $HOME
-	// is not set.
-
-	// note that this is not easy to do in a switch statement, because of the second
-	// condition, if err := ...; err == nil {}
-	if bc.o.CacheDir != "" {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
-	} else if _, err := os.UserCacheDir(); err == nil {
-		apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
-	} else {
-		log.Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
+	// WithCache resolves an empty directory through os.UserCacheDir. Check it
+	// here so builds can run in environments without a system cache directory.
+	if bc.o.DiskCacheEnabled {
+		if bc.o.CacheDir != "" {
+			apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
+		} else if _, err := os.UserCacheDir(); err == nil {
+			apkOpts = append(apkOpts, apk.WithCache(bc.o.CacheDir, bc.o.Offline, bc.o.SharedCache))
+		} else {
+			log.Warnf("cache disabled because cache dir was not set, and cannot determine system default: %v", err)
+		}
 	}
+	apkOpts = append(apkOpts, apk.WithOffline(bc.o.Offline))
 
 	if bc.ic.Contents.BaseImage != nil {
 		imgPath, err := paths.ResolvePath(bc.ic.Contents.BaseImage.Image, bc.o.IncludePaths)

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -21,12 +21,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build"
@@ -125,6 +128,125 @@ func TestBuildImage(t *testing.T) {
 	require.Equal(t, installed[0].Version, "1.0.0-r0")
 	require.Equal(t, installed[1].Name, "replayout")
 	require.Equal(t, installed[1].Version, "1.0.0-r0")
+}
+
+func TestLockImageConfigurationWithoutDiskCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	srv := httptest.NewServer(http.FileServer(http.Dir("testdata/packages")))
+	defer srv.Close()
+
+	ic := types.ImageConfiguration{
+		Contents: types.ImageContents{
+			Repositories: []string{srv.URL},
+			Keyring:      []string{srv.URL + "/melange.rsa.pub"},
+			Packages:     []string{"pretend-baselayout"},
+		},
+		Archs: []types.Architecture{types.ParseArchitecture("amd64")},
+	}
+
+	_, _, err := build.LockImageConfiguration(t.Context(), ic, build.WithoutDiskCache())
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(cacheDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestLockImageConfigurationOfflineWithoutDiskCache(t *testing.T) {
+	t.Run("local repository", func(t *testing.T) {
+		repository, err := filepath.Abs("testdata/packages")
+		require.NoError(t, err)
+
+		ic := types.ImageConfiguration{
+			Contents: types.ImageContents{
+				Repositories: []string{repository},
+				Keyring:      []string{filepath.Join(repository, "melange.rsa.pub")},
+				Packages:     []string{"pretend-baselayout"},
+			},
+			Archs: []types.Architecture{types.ParseArchitecture("amd64")},
+		}
+
+		_, _, err = build.LockImageConfiguration(t.Context(), ic,
+			build.WithOffline(true),
+			build.WithoutDiskCache(),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("remote repository", func(t *testing.T) {
+		var requests atomic.Int64
+		files := http.FileServer(http.Dir("testdata/packages"))
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			files.ServeHTTP(w, r)
+		}))
+		defer srv.Close()
+
+		ic := types.ImageConfiguration{
+			Contents: types.ImageContents{
+				Repositories: []string{srv.URL},
+				Keyring:      []string{srv.URL + "/melange.rsa.pub"},
+				Packages:     []string{"pretend-baselayout"},
+			},
+			Archs: []types.Architecture{types.ParseArchitecture("amd64")},
+		}
+
+		_, _, err := build.LockImageConfiguration(t.Context(), ic,
+			build.WithCache(t.TempDir(), true, apk.NewCache(false)),
+			build.WithoutDiskCache(),
+		)
+		var got *apk.OfflineNetworkError
+		require.ErrorAs(t, err, &got)
+		require.Equal(t, &apk.OfflineNetworkError{
+			Method: http.MethodGet,
+			URL:    srv.URL + "/melange.rsa.pub",
+		}, got)
+		require.Equal(t, int64(0), requests.Load())
+	})
+}
+
+func TestDiskCacheOptions(t *testing.T) {
+	sharedCache := apk.NewCache(false)
+
+	tests := []struct {
+		name        string
+		options     []build.Option
+		wantEnabled bool
+	}{
+		{
+			name:        "default",
+			wantEnabled: true,
+		},
+		{
+			name:    "disabled",
+			options: []build.Option{build.WithoutDiskCache()},
+		},
+		{
+			name: "empty directory enables automatic location",
+			options: []build.Option{
+				build.WithoutDiskCache(),
+				build.WithCache("", false, sharedCache),
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "last option disables",
+			options: []build.Option{
+				build.WithCache("custom", false, sharedCache),
+				build.WithoutDiskCache(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := build.NewOptions(tt.options...)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantEnabled, got.DiskCacheEnabled)
+		})
+	}
 }
 
 func TestBuildImageWithCertPackages(t *testing.T) {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -202,12 +202,32 @@ func WithAnnotations(annotations map[string]string) Option {
 	}
 }
 
-// WithCache set the cache directory to use
+// WithCache enables disk caching in cacheDir. An empty cacheDir uses the
+// system cache directory.
 func WithCache(cacheDir string, offline bool, shared *apk.Cache) Option {
 	return func(bc *Context) error {
 		bc.o.CacheDir = cacheDir
+		bc.o.DiskCacheEnabled = true
 		bc.o.Offline = offline
 		bc.o.SharedCache = shared
+		return nil
+	}
+}
+
+// WithOffline controls whether network requests are permitted. Cached and
+// local resources remain available in offline mode.
+func WithOffline(offline bool) Option {
+	return func(bc *Context) error {
+		bc.o.Offline = offline
+		return nil
+	}
+}
+
+// WithoutDiskCache keeps downloaded packages and repository indexes out of
+// the filesystem cache. In-memory package-resolution caches remain available.
+func WithoutDiskCache() Option {
+	return func(bc *Context) error {
+		bc.o.DiskCacheEnabled = false
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -76,6 +76,7 @@ type Options struct {
 	TagSuffix               string                `json:"tagSuffix,omitempty"`
 	Local                   bool                  `json:"local,omitempty"`
 	CacheDir                string                `json:"cacheDir,omitempty"`
+	DiskCacheEnabled        bool                  `json:"-"`
 	Offline                 bool                  `json:"offline,omitempty"`
 	SharedCache             *apk.Cache            `json:"-"`
 	Lockfile                string                `json:"lockfile,omitempty"`
@@ -90,11 +91,12 @@ type Options struct {
 type Auth struct{ User, Pass string }
 
 var Default = Options{
-	Arch:            types.ParseArchitecture(runtime.GOARCH),
-	SourceDateEpoch: time.Unix(0, 0).UTC(),
-	Auth:            auth.DefaultAuthenticators,
-	SharedCache:     apk.NewCache(false),
-	SizeLimits:      DefaultSizeLimits(),
+	Arch:             types.ParseArchitecture(runtime.GOARCH),
+	SourceDateEpoch:  time.Unix(0, 0).UTC(),
+	Auth:             auth.DefaultAuthenticators,
+	DiskCacheEnabled: true,
+	SharedCache:      apk.NewCache(false),
+	SizeLimits:       DefaultSizeLimits(),
 }
 
 // Tempdir returns the temporary directory where apko will create


### PR DESCRIPTION
Build contexts select `os.UserCacheDir` when `CacheDir` is empty. Library consumers using high-level operations such as `LockImageConfiguration` therefore cannot prevent rotating repository indexes from being persisted to disk.

Disk caching and offline policy were also carried through the same APK option. Disabling the disk cache after selecting offline mode dropped that policy before it reached the APK client, allowing network requests. Cache-free offline builds are valid when their repositories, keys, and packages are available locally.

Add `WithoutDiskCache` and represent its policy separately from `CacheDir`, preserving the existing empty-directory semantics and in-memory package-resolution caches. Add an independent `WithOffline` policy at the build and APK layers. Offline HTTP requests now return a typed `OfflineNetworkError`, while cached and local resources remain available. `WithCache` continues to re-enable disk caching so functional-option order remains meaningful.

Tests cover cache-free online resolution, cache-free offline resolution from a local repository, typed errors for blocked HTTP requests, and verification that blocked requests never reach the transport.

## Related work

The lower-level cache-free APK API has an existing nil dereference when Alpine key discovery fails. [#2374] fixes that path independently. This PR makes cache-free operation available through the high-level build API but does not otherwise alter the Alpine key-discovery path.

[#2374]: https://github.com/chainguard-dev/apko/pull/2374