### PR TITLE
apk: handle Alpine key fetches without a cache

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -345,8 +345,12 @@ func (a *APK) InitDB(ctx context.Context, buildRepos ...string) error {
 		if ver, ok := ParseAlpineVersion(repo); ok {
 			if err := a.fetchAlpineKeys(ctx, ver); err != nil {
 				var nokeysErr *NoKeysFoundError
-				if !a.cache.offline && !errors.As(err, &nokeysErr) {
-					return fmt.Errorf("failed to fetch alpine-keys: %w", err)
+				if (a.cache == nil || !a.cache.offline) && !errors.As(err, &nokeysErr) {
+					return &AlpineKeyFetchError{
+						Repository: repo,
+						Version:    ver,
+						Err:        err,
+					}
 				}
 				log.Debugf("ignoring missing keys: %v", err)
 			}
@@ -894,6 +898,22 @@ type NoKeysFoundError struct {
 
 func (e *NoKeysFoundError) Error() string {
 	return fmt.Sprintf("no keys found for arch %s and releases %v", e.arch, e.releases)
+}
+
+// AlpineKeyFetchError reports a failure to retrieve signing keys for an
+// Alpine package repository.
+type AlpineKeyFetchError struct {
+	Repository string
+	Version    string
+	Err        error
+}
+
+func (e *AlpineKeyFetchError) Error() string {
+	return fmt.Sprintf("failed to fetch Alpine keys for %s: %v", e.Repository, e.Err)
+}
+
+func (e *AlpineKeyFetchError) Unwrap() error {
+	return e.Err
 }
 
 // FetchAlpineReleases fetches and returns the Alpine releases metadata from alpinelinux.org.

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -111,6 +111,31 @@ func TestInitDB(t *testing.T) {
 	require.Len(t, ent, 0) // No keys discovered
 }
 
+func TestInitDBWithoutCacheReturnsAlpineKeyFetchError(t *testing.T) {
+	const repository = "https://example.invalid/alpine/v3.22/main"
+
+	src := apkfs.NewMemFS()
+	a, err := New(t.Context(),
+		WithFS(src),
+		WithIgnoreMknodErrors(ignoreMknodErrors),
+		WithTransport(&testLocalTransport{fail: true}),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = a.InitDB(ctx, repository)
+	var got *AlpineKeyFetchError
+	require.ErrorAs(t, err, &got)
+	require.Equal(t, &AlpineKeyFetchError{
+		Repository: repository,
+		Version:    "v3.22",
+		Err:        got.Err,
+	}, got)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestInitDB_ChainguardDiscovery(t *testing.T) {
 	src := apkfs.NewMemFS()
 	apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))


### PR DESCRIPTION
The lower-level APK API documents that omitting `WithCache` disables caching, but `InitDB` dereferences the absent cache when Alpine key discovery fails. Callers using the supported cache-free mode therefore panic before receiving the repository error.

Treat a missing cache as online mode and return an `AlpineKeyFetchError` that records the repository and version while preserving the underlying cause. Add a hermetic regression test for the uncached failure path.