### PR TITLE
Disable Go module caching in goreleaser workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
+          # Disable caching to avoid cache poisoning of release artifacts.
+          cache: false
 
       - name: build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,8 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
+          # Disable caching to avoid cache poisoning of release artifacts.
+          cache: false
 
       # Cosign is used by goreleaser to sign release artifacts.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
Addresses zizmor's cache-poisoning audit: these jobs build artifacts with goreleaser, and the audit recommends not restoring shared caches in workflows that publish artifacts, as a defense-in-depth measure.
