### PR TITLE
fix(apk): honour offline mode in InitDB key discovery without a cache

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -66,6 +66,7 @@ type APK struct {
 	ignoreMknodErrors  bool
 	client             *http.Client
 	cache              *cache
+	offline            bool
 	ignoreSignatures   bool
 	noSignatureIndexes []string
 	auth               auth.Authenticator
@@ -144,6 +145,7 @@ func New(ctx context.Context, options ...Option) (*APK, error) {
 		ignoreMknodErrors:  opt.ignoreMknodErrors,
 		version:            opt.version,
 		cache:              opt.cache,
+		offline:            opt.offline,
 		ignoreSignatures:   opt.ignoreSignatures,
 		noSignatureIndexes: opt.noSignatureIndexes,
 		installedFiles:     map[string]*Package{},
@@ -351,7 +353,7 @@ func (a *APK) InitDB(ctx context.Context, buildRepos ...string) error {
 		if ver, ok := ParseAlpineVersion(repo); ok {
 			if err := a.fetchAlpineKeys(ctx, ver); err != nil {
 				var nokeysErr *NoKeysFoundError
-				if (a.cache == nil || !a.cache.offline) && !errors.As(err, &nokeysErr) {
+				if !a.offline && !errors.As(err, &nokeysErr) {
 					return &AlpineKeyFetchError{
 						Repository: repo,
 						Version:    ver,

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -136,6 +136,23 @@ func TestInitDBWithoutCacheReturnsAlpineKeyFetchError(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestInitDBOfflineWithoutCacheIgnoresMissingAlpineKeys(t *testing.T) {
+	src := apkfs.NewMemFS()
+	a, err := New(t.Context(),
+		WithFS(src),
+		WithIgnoreMknodErrors(ignoreMknodErrors),
+		WithOffline(true),
+	)
+	require.NoError(t, err)
+
+	err = a.InitDB(t.Context(), "https://example.invalid/alpine/v3.22/main")
+	require.NoError(t, err)
+
+	ent, err := fs.ReadDir(src, "etc/apk/keys")
+	require.NoError(t, err)
+	require.Empty(t, ent)
+}
+
 func TestInitDB_ChainguardDiscovery(t *testing.T) {
 	src := apkfs.NewMemFS()
 	apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))


### PR DESCRIPTION
When online, `InitDB` fails with an `AlpineKeyFetchError` when it can't fetch keys. When offline, this is downgraded to a debug message only, since missing keys are expected without network access.

We detect offline mode via the cache's `offline` flag. `WithOffline` (#2373) made offline mode configurable independently of `WithCache`, and made it possible for there to be no cache. We aren't handling the "no cache" case properly. An offline run without a disk cache is therefore treated as online.

The fix is to record the offline flag on the `APK` struct in `New` and consult it directly in `InitDB`, so the offline path applies regardless of whether a disk cache is configured.