### PR TITLE
Group codeql-action bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
   open-pull-requests-limit: 10
   cooldown:
     default-days: 3
+  groups:
+    codeql:
+      patterns:
+        - "github/codeql-action*"


### PR DESCRIPTION
Dependabot treats github/codeql-action/init and github/codeql-action/analyze as separate dependencies and bumps them in separate PRs, which fail CI because a version-mismatched init/analyze pair is rejected. Grouping them makes future bumps arrive as a single PR updating both in lockstep.
