### PR TITLE
Offline apk cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ apko publish examples/alpine-base.yaml myrepo/alpine-apko:test
 
 See the [docs](./docs/apko_file.md) for details of the file format and the [examples directory](./examples) for more, err, examples!
 
+To build without network access from a mirror of the apks a build used, see the [offline cache docs](./docs/offline-cache.md).
+
 ## Why
 
 apko was created by [Chainguard](https://www.chainguard.dev), who require secure and reproducible

--- a/docs/offline-cache.md
+++ b/docs/offline-cache.md
@@ -1,0 +1,192 @@
+# Offline cache
+
+The offline cache is a mirror of the raw `.apk` files a build uses, kept so that
+a build with a fully pinned configuration can be repeated later with no index and
+no network access.
+
+This document covers using it from the Go library.
+For the on-disk layout, the verification model and the guarantees it does and
+does not give, see [CACHE.md](../pkg/apk/docs/CACHE.md).
+From the command line, `--offline-cache` is available on `apko build`,
+`apko publish` and `apko lock`, and `--offline` on `apko build` and
+`apko publish`.
+`apko lock` can only populate a cache, since locking resolves by definition.
+
+## The two modes
+
+`build.WithOfflineCache(dir)` on its own **populates**: the build resolves against
+the index as usual and mirrors every apk it uses into `dir`.
+
+Adding `build.WithOffline(true)` makes `dir` the **only** source of packages: no
+index is read and no network request is made.
+Every package must then be pinned to an exact version, and the list must be the
+complete transitive closure, because there is no index to resolve against.
+
+The offline cache is separate from `build.WithCache`, which stores apks pre-split
+into their component sections and is not usable as a standalone source of apks.
+Both can be enabled at once.
+
+## Populating a cache
+
+```go
+import (
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+const offlineDir = "/path/to/mirror"
+
+bc, err := build.New(ctx, apkfs.NewMemFS(),
+	build.WithImageConfiguration(ic),
+	build.WithArch(types.ParseArchitecture("amd64")),
+	build.WithCache(cacheDir, false, apk.NewCache(true)),
+	build.WithOfflineCache(offlineDir),
+)
+if err != nil {
+	return err
+}
+if _, _, err := bc.BuildLayer(ctx); err != nil {
+	return err
+}
+```
+
+Afterwards `offlineDir` holds each apk, a `.apk.Q1` sidecar recording the
+checksum the index reported for it, and the signing keys under `keys/`.
+
+## Capturing the pinned closure
+
+An offline build needs the full closure, pinned, and **in install order**.
+`InstalledPackages` reports packages in the order they were installed, so it is
+the right source for that list:
+
+```go
+installed, err := bc.InstalledPackages()
+if err != nil {
+	return err
+}
+pinned := make([]string, 0, len(installed))
+for _, p := range installed {
+	pinned = append(pinned, p.Name+"="+p.Version)
+}
+```
+
+Order matters because offline builds install in the order listed, and that
+decides which package wins when two of them write the same path.
+It shows up in the mtimes of shared directories and in the order of
+`/usr/lib/apk/db/installed`.
+
+## Building offline
+
+```go
+offlineIC := ic
+offlineIC.Contents.Packages = pinned
+
+obc, err := build.New(ctx, apkfs.NewMemFS(),
+	build.WithImageConfiguration(offlineIC),
+	build.WithArch(types.ParseArchitecture("amd64")),
+	build.WithOffline(true),
+	build.WithOfflineCache(offlineDir),
+)
+if err != nil {
+	return err
+}
+if _, _, err := obc.BuildLayer(ctx); err != nil {
+	return err
+}
+```
+
+Nothing else changes: the repositories and keyring in the configuration stay as
+they are, and the remote keyring entries are served from the cache's `keys/`
+directory rather than fetched.
+
+## Reproducing a build byte for byte
+
+Given the closure in install order, an offline build reproduces an ordinary build
+exactly.
+There is one thing to get right: the build you are comparing against must record
+the same package set.
+`build.New` on its own leaves `Contents.Packages` as written, so an unpinned
+reference build and a pinned offline build differ in `/etc/apko.json`.
+
+`apko build` avoids this by resolving the configuration first, and a library
+caller should do the same with `build.LockImageConfiguration`:
+
+```go
+configs, _, err := build.LockImageConfiguration(ctx, ic,
+	build.WithOfflineCache(offlineDir),
+)
+if err != nil {
+	return err
+}
+resolved, ok := configs["amd64"] // keyed by types.Architecture.String(), plus "index"
+if !ok {
+	return fmt.Errorf("no resolved config for amd64")
+}
+```
+
+Build the reference image from `*resolved`, then the offline image from the same
+configuration with `Contents.Packages` replaced by `pinned`.
+Both then record the same sorted package set, and the resulting layers are
+identical.
+
+## Multiple architectures
+
+One cache directory serves every architecture, because the architecture is part
+of each apk's path.
+
+Pinned versions are not shared, though: `Contents.Packages` applies to whichever
+architecture is being built, so a package at different versions per architecture
+cannot be expressed in one list.
+Build each architecture from its own configuration, which is what
+`build.LockImageConfiguration` returns.
+
+## Using the apk library directly
+
+`pkg/apk/apk` has the same option, which populates and verifies the mirror:
+
+```go
+a, err := apk.New(ctx,
+	apk.WithFS(fs),
+	apk.WithArch("x86_64"),
+	apk.WithCache(cacheDir, false, apk.NewCache(true)),
+	apk.WithOfflineCache(offlineDir),
+)
+```
+
+The index-free install path itself lives in `pkg/build`, so combining
+`apk.WithOfflineCache` with `apk.WithOffline` at this layer only disables
+populating.
+To install from a mirror at this layer, locate the packages yourself and pass
+them to `InstallPackages`:
+
+```go
+path, err := apk.OfflineCachePath(offlineDir, apk.APKURL(repo, arch, name, version))
+if err != nil {
+	return err
+}
+checksum, err := apk.ReadOfflineChecksum(path)
+if err != nil {
+	return err
+}
+```
+
+`path` and `checksum` are the `URL()` and `ChecksumString()` of an
+`apk.InstallablePackage`, whose third method is `PackageName()`.
+Passing the local path as the URL is what makes the install read from disk.
+
+## Limitations
+
+* The pinned list must be the complete transitive closure.
+  A missing dependency produces a broken image, not an error, because there is no
+  dependency graph to check against.
+* The guarantee is "these are the bytes the index vouched for when the cache was
+  populated", not "these bytes are currently signed by the repository key".
+  Individual apk signatures are not verified against the keyring.
+* Local (`file://` or path) repositories and base images are not supported
+  offline, as both resolve packages through an index.
+* Version ranges, tilde matches, repository pins (`@tag`) and virtuals (`so:`,
+  `cmd:`) are refused offline, since resolving them needs the index.
+* A lockfile and an offline build are two ways to pin the same thing, so
+  combining them is an error rather than one silently winning.

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -56,6 +56,7 @@ func buildCmd() *cobra.Command {
 	var rawAnnotations []string
 	var cacheDir string
 	var offline bool
+	var offlineCache string
 	var lockfile string
 	var includePaths []string
 	var ignoreSignatures bool
@@ -114,6 +115,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 				build.WithVCS(withVCS),
 				build.WithAnnotations(annotations),
 				build.WithCache(cacheDir, offline, apk.NewCache(true)),
+				build.WithOfflineCache(offlineCache),
 				build.WithLockFile(lockfile),
 				build.WithTempDir(tmp),
 				build.WithIncludePaths(includePaths),
@@ -139,6 +141,7 @@ Along the image, apko will generate SBOMs (software bill of materials) describin
 	cmd.Flags().StringVar(&lockfile, "lockfile", "", "a path to .lock.json file (e.g. produced by apko lock) that constraints versions of packages to the listed ones (default '' means no additional constraints)")
 	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append.")
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
+	addOfflineCacheFlag(cmd, &offlineCache)
 	addClientLimitFlags(cmd, &sizeLimits)
 	return cmd
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -20,6 +20,15 @@ import (
 	"chainguard.dev/apko/pkg/options"
 )
 
+// addOfflineCacheFlag adds the flag naming a mirror of the raw .apk files a
+// build uses. On its own it only populates the mirror; combined with --offline it
+// becomes the sole source of packages.
+func addOfflineCacheFlag(cmd *cobra.Command, dir *string) {
+	cmd.Flags().StringVar(dir, "offline-cache", "",
+		"directory to mirror the .apk files used by this build into, as <dir>/<host>/<repo path>/<arch>/<name>-<version>.apk. "+
+			"Combined with --offline it becomes the only source of packages: no index is read and every package must be pinned to an exact version")
+}
+
 // addClientLimitFlags adds size limit flags for APK client operations (fetching indexes, expanding packages).
 func addClientLimitFlags(cmd *cobra.Command, limits *options.SizeLimits) {
 	defaults := options.DefaultSizeLimits()

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -74,6 +74,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	var includePaths []string
 	var ignoreSignatures bool
 	var cacheDir string
+	var offlineCache string
 
 	cmd := &cobra.Command{
 		Use: cmdName,
@@ -101,6 +102,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 					build.WithIncludePaths(includePaths),
 					build.WithIgnoreSignatures(ignoreSignatures),
 					build.WithCache(cacheDir, false, apk.NewCache(true)),
+					build.WithOfflineCache(offlineCache),
 				},
 			)
 		},
@@ -114,6 +116,7 @@ func lockInternal(cmdName string, extension string, deprecated string) *cobra.Co
 	cmd.Flags().StringSliceVar(&includePaths, "include-paths", []string{}, "Additional include paths where to look for input files (config, base image, etc.). By default apko will search for paths only in workdir. Include paths may be absolute, or relative. Relative paths are interpreted relative to workdir. For adding extra paths for packages, use --repository-append")
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
+	addOfflineCacheFlag(cmd, &offlineCache)
 
 	return cmd
 }

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -54,6 +54,7 @@ func publish() *cobra.Command {
 	var local bool
 	var cacheDir string
 	var offline bool
+	var offlineCache string
 	var lockfile string
 	var ignoreSignatures bool
 
@@ -119,6 +120,7 @@ in a keychain.`,
 					build.WithVCS(withVCS),
 					build.WithAnnotations(annotations),
 					build.WithCache(cacheDir, offline, apk.NewCache(true)),
+					build.WithOfflineCache(offlineCache),
 					build.WithLockFile(lockfile),
 					build.WithTempDir(tmp),
 					build.WithIgnoreSignatures(ignoreSignatures),
@@ -147,6 +149,7 @@ in a keychain.`,
 	cmd.Flags().StringSliceVarP(&extraPackages, "package-append", "p", []string{}, "extra packages to include")
 	cmd.Flags().StringSliceVar(&rawAnnotations, "annotations", []string{}, "OCI annotations to add. Separate with colon (key:value)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "directory to use for caching apk packages and indexes (default '' means to use system-defined cache directory)")
+	addOfflineCacheFlag(cmd, &offlineCache)
 	cmd.Flags().BoolVar(&offline, "offline", false, "do not use network to fetch packages (cache must be pre-populated)")
 	cmd.Flags().StringVar(&lockfile, "lockfile", "", "a path to .lock.json file (e.g. produced by apko lock) that constraints versions of packages to the listed ones (default '' means no additional constraints)")
 	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -134,6 +134,11 @@ func New(ctx context.Context, options ...Option) (*APK, error) {
 				getterOpts = append(getterOpts, withAPKDataMaxSize(opt.sizeLimits.APKDataMaxSize))
 			}
 		}
+		// Offline builds read apks from the offline cache through the ordinary
+		// installer rather than this getter, so there is nothing to populate.
+		if opt.offlineCacheDir != "" && !opt.offline {
+			getterOpts = append(getterOpts, withOfflineCacheDir(opt.offlineCacheDir))
+		}
 		packageGetter = newDefaultPackageGetter(httpClient, opt.cache, opt.auth, getterOpts...)
 	}
 

--- a/pkg/apk/apk/offline_cache.go
+++ b/pkg/apk/apk/offline_cache.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// OfflineChecksumExt is appended to a cached apk's name to form the sidecar file
+// recording the checksum that the repository index reported for it. The apk's
+// own bytes cannot serve as their own reference: the checksum is a hash of a
+// section of the apk, so recomputing it from the file proves only that the file
+// is internally consistent. The sidecar is meaningful because it was written
+// while the index was trusted.
+const OfflineChecksumExt = ".Q1"
+
+// APKURL returns the URL an apk is fetched from, given the repository it lives
+// in and a fully pinned name and version. It matches RepositoryPackage.URL() so
+// that a package located this way lands on the same offline cache path that
+// populating the cache from a normal resolve would have written.
+func APKURL(repo, arch, name, version string) string {
+	return fmt.Sprintf("%s/%s/%s-%s.apk", repo, arch, name, version)
+}
+
+// IsRemoteURL reports whether u names a package that would be fetched over the
+// network, and so is a candidate for the offline cache. Local repositories need
+// no caching.
+func IsRemoteURL(u string) bool {
+	return strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "http://")
+}
+
+// OfflineCachePath maps a remote package URL to its location beneath an offline
+// cache directory. The layout is <dir>/<host>/<path>, mirroring the repository's
+// own URL structure, so the directory can be populated from or diffed against an
+// ordinary apk mirror.
+func OfflineCachePath(dir, pkgURL string) (string, error) {
+	u, err := url.Parse(pkgURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing package url %q: %w", pkgURL, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return "", fmt.Errorf("offline cache holds only remote packages, got scheme %q in %q", u.Scheme, pkgURL)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("package url %q has no host", pkgURL)
+	}
+	if filepath.Ext(u.Path) != ".apk" {
+		return "", fmt.Errorf("package url %q does not name an .apk", pkgURL)
+	}
+	return offlineCacheJoin(dir, u.Host, u.Path)
+}
+
+// offlineCacheJoin joins elems beneath dir, refusing any result that escapes it.
+// The host and path components come from a user-supplied config and may contain
+// traversal sequences, either literally or via percent-encoding that url.Parse
+// decodes for us.
+func offlineCacheJoin(dir string, elems ...string) (string, error) {
+	if dir == "" {
+		return "", errors.New("offline cache directory is empty")
+	}
+	root := filepath.Clean(dir)
+	p := filepath.Join(append([]string{root}, elems...)...)
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return "", fmt.Errorf("offline cache path %q is not within %q: %w", p, root, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("offline cache path %q escapes %q", p, root)
+	}
+	return p, nil
+}
+
+// OfflineChecksumPath returns the path of the sidecar recording apkPath's
+// expected checksum.
+func OfflineChecksumPath(apkPath string) string {
+	return apkPath + OfflineChecksumExt
+}
+
+// ReadOfflineChecksum returns the checksum recorded alongside a cached apk, in
+// the "Q1<base64>" form that ChecksumString produces.
+func ReadOfflineChecksum(apkPath string) (string, error) {
+	p := OfflineChecksumPath(apkPath)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return "", err
+	}
+	chk := strings.TrimSpace(string(b))
+	if !strings.HasPrefix(chk, "Q1") {
+		return "", fmt.Errorf("%s: expected a Q1-prefixed checksum, got %q", p, chk)
+	}
+	return chk, nil
+}
+
+// writeOfflineChecksum records checksum for the apk at apkPath. It writes to a
+// unique temporary name and renames, so that concurrent builds sharing one cache
+// never observe a half-written sidecar.
+func writeOfflineChecksum(apkPath, checksum string) error {
+	p := OfflineChecksumPath(apkPath)
+	tmp, err := os.CreateTemp(filepath.Dir(p), filepath.Base(p)+".tmp")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString(checksum + "\n"); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), p)
+}

--- a/pkg/apk/apk/offline_cache_test.go
+++ b/pkg/apk/apk/offline_cache_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/apk/auth"
+)
+
+func TestOfflineCachePath(t *testing.T) {
+	root := filepath.Join("/tmp", "oc")
+
+	for _, tc := range []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{{
+		name: "https package",
+		url:  "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+		want: filepath.Join(root, "packages.wolfi.dev", "os", "x86_64", "busybox-1.37.0-r61.apk"),
+	}, {
+		name: "http package",
+		url:  "http://example.com/main/aarch64/foo-1.0-r0.apk",
+		want: filepath.Join(root, "example.com", "main", "aarch64", "foo-1.0-r0.apk"),
+	}, {
+		name: "host with port is kept distinct",
+		url:  "https://example.com:8443/main/x86_64/foo-1.0-r0.apk",
+		want: filepath.Join(root, "example.com:8443", "main", "x86_64", "foo-1.0-r0.apk"),
+	}, {
+		// The query string is not part of the package's identity, and including
+		// it would make the same apk cache to two different paths.
+		name: "query string is ignored",
+		url:  "https://example.com/main/x86_64/foo-1.0-r0.apk?token=abc",
+		want: filepath.Join(root, "example.com", "main", "x86_64", "foo-1.0-r0.apk"),
+	}, {
+		name:    "literal traversal in path",
+		url:     "https://example.com/../../../etc/passwd.apk",
+		wantErr: true,
+	}, {
+		// url.Parse decodes %2e and %2f, so traversal can arrive already hidden.
+		name:    "percent-encoded traversal in path",
+		url:     "https://example.com/a/%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd.apk",
+		wantErr: true,
+	}, {
+		name:    "traversal in host",
+		url:     "https://../../../etc/x86_64/foo-1.0-r0.apk",
+		wantErr: true,
+	}, {
+		name:    "file scheme is not cacheable",
+		url:     "file:///var/packages/x86_64/foo-1.0-r0.apk",
+		wantErr: true,
+	}, {
+		name:    "bare path is not cacheable",
+		url:     "/var/packages/x86_64/foo-1.0-r0.apk",
+		wantErr: true,
+	}, {
+		name:    "no host",
+		url:     "https:///main/x86_64/foo-1.0-r0.apk",
+		wantErr: true,
+	}, {
+		name:    "not an apk",
+		url:     "https://example.com/main/x86_64/APKINDEX.tar.gz",
+		wantErr: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := OfflineCachePath(root, tc.url)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestOfflineCachePathEmptyDir(t *testing.T) {
+	_, err := OfflineCachePath("", "https://example.com/main/x86_64/foo-1.0-r0.apk")
+	require.Error(t, err)
+}
+
+func TestAPKURL(t *testing.T) {
+	// Must agree with RepositoryPackage.URL(), or a package located offline would
+	// not be found at the path a populating run wrote it to.
+	repo := Repository{URI: "https://example.com/main/x86_64"}
+	pkg := NewRepositoryPackage(&testPkg, repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}}))
+	require.Equal(t, pkg.URL(), APKURL("https://example.com/main", "x86_64", testPkg.Name, testPkg.Version))
+}
+
+func TestIsRemoteURL(t *testing.T) {
+	require.True(t, IsRemoteURL("https://example.com/main"))
+	require.True(t, IsRemoteURL("http://example.com/main"))
+	require.False(t, IsRemoteURL("/var/packages"))
+	require.False(t, IsRemoteURL("file:///var/packages"))
+}
+
+func TestOfflineChecksumRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	apkPath := filepath.Join(dir, "foo-1.0-r0.apk")
+
+	_, err := ReadOfflineChecksum(apkPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	require.NoError(t, writeOfflineChecksum(apkPath, "Q1abcdef"))
+	got, err := ReadOfflineChecksum(apkPath)
+	require.NoError(t, err)
+	require.Equal(t, "Q1abcdef", got)
+
+	// Overwriting an existing record must work, since a populating run rewrites
+	// the sidecar whenever it does not match the index.
+	require.NoError(t, writeOfflineChecksum(apkPath, "Q1123456"))
+	got, err = ReadOfflineChecksum(apkPath)
+	require.NoError(t, err)
+	require.Equal(t, "Q1123456", got)
+
+	require.Equal(t, apkPath+".Q1", OfflineChecksumPath(apkPath))
+}
+
+func TestReadOfflineChecksumRejectsGarbage(t *testing.T) {
+	dir := t.TempDir()
+	apkPath := filepath.Join(dir, "foo-1.0-r0.apk")
+	require.NoError(t, os.WriteFile(OfflineChecksumPath(apkPath), []byte("not-a-checksum\n"), 0o644))
+
+	_, err := ReadOfflineChecksum(apkPath)
+	require.ErrorContains(t, err, "expected a Q1-prefixed checksum")
+}
+
+// offlineGetter builds a package getter that mirrors into offlineDir and serves
+// packages from local testdata.
+func offlineGetter(t *testing.T, offlineDir string, tr http.RoundTripper) *defaultPackageGetter {
+	t.Helper()
+	return newDefaultPackageGetter(&http.Client{Transport: tr}, &cache{
+		dir:    t.TempDir(),
+		shared: NewCache(false),
+	}, auth.DefaultAuthenticators, withOfflineCacheDir(offlineDir))
+}
+
+func TestOfflineCachePopulate(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		repo     = Repository{URI: testAlpineRepos + "/" + testArch}
+		pkg      = NewRepositoryPackage(&testPkg, repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}}))
+		offline  = t.TempDir()
+		wantPath = filepath.Join(offline, "dl-cdn.alpinelinux.org", "alpine", "v3.16", "main", testArch, testPkgFilename)
+	)
+
+	d := offlineGetter(t, offline, &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true})
+	exp, err := d.GetPackage(ctx, pkg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Close())
+
+	// The raw apk lands in the mirror, alongside the index's checksum for it.
+	require.FileExists(t, wantPath)
+	chk, err := ReadOfflineChecksum(wantPath)
+	require.NoError(t, err)
+	require.Equal(t, pkg.ChecksumString(), chk)
+
+	// Nothing is left behind at a temporary name.
+	entries, err := os.ReadDir(filepath.Dir(wantPath))
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "expected only the apk and its sidecar, got %v", entries)
+}
+
+func TestOfflineCacheServesWithoutNetwork(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		repo    = Repository{URI: testAlpineRepos + "/" + testArch}
+		pkg     = NewRepositoryPackage(&testPkg, repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}}))
+		offline = t.TempDir()
+	)
+
+	// Populate with the network available.
+	d := offlineGetter(t, offline, &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true})
+	exp, err := d.GetPackage(ctx, pkg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Close())
+
+	// A second getter whose transport always fails must still succeed, proving the
+	// apk came from the mirror rather than the network. A fresh --cache-dir is used
+	// so the expanded cache cannot be the source either.
+	d2 := offlineGetter(t, offline, &testLocalTransport{fail: true})
+	exp2, err := d2.GetPackage(ctx, pkg)
+	require.NoError(t, err)
+	require.NoError(t, exp2.Close())
+}
+
+func TestOfflineCacheDetectsDifferentContentSameName(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		repo    = Repository{URI: testAlpineRepos + "/" + testArch}
+		index   = &APKIndex{Packages: []*Package{&testPkg}}
+		pkg     = NewRepositoryPackage(&testPkg, repo.WithIndex(index))
+		offline = t.TempDir()
+	)
+
+	d := offlineGetter(t, offline, &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true})
+	exp, err := d.GetPackage(ctx, pkg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Close())
+
+	// Stand in for a repository that republished different content under the same
+	// name and version: the index now reports a checksum the cached apk does not
+	// have. Naming it separately from the fetch would let a stale apk pass, so the
+	// cached bytes must be re-checked on every run.
+	republished := testPkg
+	republished.Checksum = append([]byte(nil), testPkg.Checksum...)
+	republished.Checksum[0]++
+	changed := NewRepositoryPackage(&republished, repo.WithIndex(index))
+
+	// Forget the in-process entry, which is keyed by URL and would answer first.
+	globalApkCache.Forget(changed.URL())
+
+	d2 := offlineGetter(t, offline, &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true})
+	_, err = d2.GetPackage(ctx, changed)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "control hash mismatch")
+	require.ErrorContains(t, err, "offline cache")
+}
+
+func TestOfflineCacheRecordsChecksumForHandPlacedAPK(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		repo    = Repository{URI: testAlpineRepos + "/" + testArch}
+		pkg     = NewRepositoryPackage(&testPkg, repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}}))
+		offline = t.TempDir()
+	)
+
+	// An apk copied in from a mirror has no sidecar, so it cannot be used offline
+	// yet. Verifying it against the index is what earns it one.
+	apkPath, err := OfflineCachePath(offline, pkg.URL())
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(apkPath), 0o755))
+	contents, err := os.ReadFile(filepath.Join(testPrimaryPkgDir, testPkgFilename))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(apkPath, contents, 0o644))
+
+	_, err = ReadOfflineChecksum(apkPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	// A transport that always fails, to show the apk on disk is what was used.
+	d := offlineGetter(t, offline, &testLocalTransport{fail: true})
+	exp, err := d.GetPackage(ctx, pkg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Close())
+
+	chk, err := ReadOfflineChecksum(apkPath)
+	require.NoError(t, err)
+	require.Equal(t, pkg.ChecksumString(), chk)
+}

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -34,6 +34,7 @@ type opts struct {
 	version            string
 	cache              *cache
 	offline            bool
+	offlineCacheDir    string
 	noSignatureIndexes []string
 	auth               auth.Authenticator
 	ignoreSignatures   bool
@@ -118,6 +119,32 @@ func WithCache(cacheDir string, offline bool, shared *Cache) Option {
 			shared: shared,
 		}
 		o.offline = offline
+		return nil
+	}
+}
+
+// WithOfflineCache keeps a copy of every remote apk that is fetched under dir,
+// as the original .apk file plus a sidecar recording the checksum the repository
+// index reported for it. The layout is <dir>/<host>/<repo path>/<arch>/<name>-<version>.apk.
+//
+// An apk already present under dir is read from there instead of being
+// re-downloaded, and is verified against the index on every run, so a repository
+// that republishes different content under the same name and version is an error
+// rather than a silent mismatch between the cache and the index.
+//
+// This is distinct from WithCache, which stores apks pre-split into their
+// component sections and is not usable as a standalone apk source.
+func WithOfflineCache(dir string) Option {
+	return func(o *opts) error {
+		if dir == "" {
+			o.offlineCacheDir = ""
+			return nil
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return err
+		}
+		o.offlineCacheDir = abs
 		return nil
 	}
 }

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -117,6 +118,7 @@ type defaultPackageGetter struct {
 	auth              auth.Authenticator
 	apkControlMaxSize int64
 	apkDataMaxSize    int64
+	offlineCacheDir   string
 }
 
 // packageGetterOption is a functional option for configuring defaultPackageGetter.
@@ -133,6 +135,14 @@ func withAPKControlMaxSize(size int64) packageGetterOption {
 func withAPKDataMaxSize(size int64) packageGetterOption {
 	return func(d *defaultPackageGetter) {
 		d.apkDataMaxSize = size
+	}
+}
+
+// withOfflineCacheDir makes the getter mirror every remote apk it fetches into
+// dir, and verify any apk already there against the index's checksum.
+func withOfflineCacheDir(dir string) packageGetterOption {
+	return func(d *defaultPackageGetter) {
+		d.offlineCacheDir = dir
 	}
 }
 
@@ -189,6 +199,19 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "getPackageImpl", trace.WithAttributes(attribute.String("package", pkg.PackageName())))
 	defer span.End()
 
+	// When an offline cache is configured, every apk is read through it, so that
+	// one already sitting there is checked against the index's checksum on each
+	// run rather than only when it was first written. That means bypassing the
+	// expanded cache below, whose hit path would otherwise skip the apk entirely.
+	offlinePath := ""
+	if d.offlineCacheDir != "" && IsRemoteURL(pkg.URL()) {
+		var err error
+		offlinePath, err = OfflineCachePath(d.offlineCacheDir, pkg.URL())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	cacheDir := ""
 	if d.cache != nil {
 		var err error
@@ -197,13 +220,15 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 			return nil, err
 		}
 
-		exp, err := d.cachedPackage(ctx, pkg, cacheDir)
-		if err == nil {
-			log.Debugf("cache hit (%s)", pkg.PackageName())
-			return exp, nil
-		}
+		if offlinePath == "" {
+			exp, err := d.cachedPackage(ctx, pkg, cacheDir)
+			if err == nil {
+				log.Debugf("cache hit (%s)", pkg.PackageName())
+				return exp, nil
+			}
 
-		log.Debugf("cache miss (%s): %v", pkg.PackageName(), err)
+			log.Debugf("cache miss (%s): %v", pkg.PackageName(), err)
+		}
 
 		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 			return nil, fmt.Errorf("unable to create cache directory %q: %w", cacheDir, err)
@@ -218,7 +243,7 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 		expandOpts = append(expandOpts, expandapk.WithMaxDataSize(d.apkDataMaxSize))
 	}
 
-	exp, err := d.fetchExpandAndVerify(ctx, pkg, cacheDir, expandOpts)
+	exp, err := d.fetchExpandAndVerify(ctx, pkg, cacheDir, offlinePath, expandOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +257,7 @@ func (d *defaultPackageGetter) getPackageImpl(ctx context.Context, pkg Installab
 }
 
 // fetchExpandAndVerify fetches, expands, and verifies a package, retrying on transient errors.
-func (d *defaultPackageGetter) fetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
+func (d *defaultPackageGetter) fetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir, offlinePath string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
 	var lastErr error
 	for attempt := range maxFetchRetries + 1 {
 		if attempt > 0 {
@@ -245,7 +270,7 @@ func (d *defaultPackageGetter) fetchExpandAndVerify(ctx context.Context, pkg Ins
 			}
 		}
 
-		exp, err := d.doFetchExpandAndVerify(ctx, pkg, cacheDir, expandOpts)
+		exp, err := d.doFetchExpandAndVerify(ctx, pkg, cacheDir, offlinePath, expandOpts)
 		if err == nil {
 			return exp, nil
 		}
@@ -258,16 +283,44 @@ func (d *defaultPackageGetter) fetchExpandAndVerify(ctx context.Context, pkg Ins
 }
 
 // doFetchExpandAndVerify performs a single fetch+expand+verify cycle for a package.
-func (d *defaultPackageGetter) doFetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
-	rc, err := d.fetchPackage(ctx, pkg)
+//
+// If offlinePath is set, the apk is read from there when it already exists, and
+// otherwise downloaded to a temporary name beside it. Either way the verification
+// below runs against those exact bytes, and the apk is only published into the
+// offline cache once it has passed.
+func (d *defaultPackageGetter) doFetchExpandAndVerify(ctx context.Context, pkg InstallablePackage, cacheDir, offlinePath string, expandOpts []expandapk.Option) (*expandapk.APKExpanded, error) {
+	var (
+		rc        io.ReadCloser
+		fromCache bool
+		tmpPath   string
+		err       error
+	)
+	if offlinePath != "" {
+		rc, fromCache, tmpPath, err = d.openViaOfflineCache(ctx, pkg, offlinePath)
+	} else {
+		rc, err = d.fetchPackage(ctx, pkg)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("fetching package %q: %w", pkg.PackageName(), err)
 	}
 	defer rc.Close()
+	if tmpPath != "" {
+		// Removed unless the rename below claims it.
+		defer os.Remove(tmpPath)
+	}
+
+	// Point mismatches at the offline cache, since the fix there is to remove the
+	// stale file rather than to retry the download.
+	verifyErr := func(err error) error {
+		if !fromCache {
+			return err
+		}
+		return fmt.Errorf("%w (from offline cache %s; the repository index describes different content under this name, remove the file to re-fetch it)", err, offlinePath)
+	}
 
 	exp, err := expandapk.ExpandApkWithOptions(ctx, rc, cacheDir, expandOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("expanding %s: %w", pkg.PackageName(), err)
+		return nil, verifyErr(fmt.Errorf("expanding %s: %w", pkg.PackageName(), err))
 	}
 
 	chk := pkg.ChecksumString()
@@ -282,7 +335,7 @@ func (d *defaultPackageGetter) doFetchExpandAndVerify(ctx context.Context, pkg I
 	}
 	if !bytes.Equal(expectedControlHash, exp.ControlHash) {
 		_ = exp.Close()
-		return nil, fmt.Errorf("package %q control hash mismatch: expected %x, got %x", pkg.PackageName(), expectedControlHash, exp.ControlHash)
+		return nil, verifyErr(fmt.Errorf("package %q control hash mismatch: expected %x, got %x", pkg.PackageName(), expectedControlHash, exp.ControlHash))
 	}
 
 	pkgInfo, err := exp.PkgInfo()
@@ -297,10 +350,82 @@ func (d *defaultPackageGetter) doFetchExpandAndVerify(ctx context.Context, pkg I
 	}
 	if !bytes.Equal(expectedDataHash, exp.PackageHash) {
 		_ = exp.Close()
-		return nil, fmt.Errorf("package %q data hash mismatch: expected %x, got %x", pkg.PackageName(), expectedDataHash, exp.PackageHash)
+		return nil, verifyErr(fmt.Errorf("package %q data hash mismatch: expected %x, got %x", pkg.PackageName(), expectedDataHash, exp.PackageHash))
+	}
+
+	if offlinePath != "" {
+		if err := publishToOfflineCache(offlinePath, tmpPath, chk); err != nil {
+			_ = exp.Close()
+			return nil, fmt.Errorf("caching %s in offline cache: %w", pkg.PackageName(), err)
+		}
 	}
 
 	return exp, nil
+}
+
+// openViaOfflineCache returns a reader over the package's apk at path, which is
+// downloaded first if it is not already there. A downloaded apk is left at a
+// temporary name, reported as tmpPath, until publishToOfflineCache renames it, so
+// that bytes which fail verification are never left behind for a later run to
+// pick up. fromCache reports whether the apk was already present.
+func (d *defaultPackageGetter) openViaOfflineCache(ctx context.Context, pkg InstallablePackage, path string) (rc io.ReadCloser, fromCache bool, tmpPath string, err error) {
+	if f, err := os.Open(path); err == nil {
+		clog.FromContext(ctx).Debugf("offline cache hit (%s): %s", pkg.PackageName(), path)
+		return f, true, "", nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, false, "", fmt.Errorf("reading %s from offline cache: %w", pkg.PackageName(), err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, false, "", fmt.Errorf("creating offline cache directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp")
+	if err != nil {
+		return nil, false, "", fmt.Errorf("creating offline cache temp file: %w", err)
+	}
+	tmpPath = tmp.Name()
+
+	// Download in full before expanding, rather than teeing the body through the
+	// expander: that keeps the cached file exactly the bytes that get verified,
+	// with no dependence on the expander consuming its reader to EOF.
+	if err := func() error {
+		defer tmp.Close()
+		src, err := d.fetchPackage(ctx, pkg)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		if _, err := io.Copy(tmp, src); err != nil {
+			return err
+		}
+		return tmp.Chmod(0o644)
+	}(); err != nil {
+		os.Remove(tmpPath)
+		return nil, false, "", err
+	}
+
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		os.Remove(tmpPath)
+		return nil, false, "", err
+	}
+	return f, false, tmpPath, nil
+}
+
+// publishToOfflineCache moves a freshly downloaded apk into place, if tmpPath
+// names one, and records the checksum the index reported for it. The sidecar is
+// written even for an apk that was already cached, so that one lacking a record
+// gains one on the next populating run.
+func publishToOfflineCache(path, tmpPath, checksum string) error {
+	if tmpPath != "" {
+		if err := os.Rename(tmpPath, path); err != nil {
+			return err
+		}
+	}
+	if existing, err := ReadOfflineChecksum(path); err == nil && existing == checksum {
+		return nil
+	}
+	return writeOfflineChecksum(path, checksum)
 }
 
 // sha1File returns the SHA-1 of the file at path.

--- a/pkg/apk/apk/version.go
+++ b/pkg/apk/apk/version.go
@@ -356,6 +356,18 @@ type ParsedConstraint struct {
 	pin     string
 }
 
+// IsExactVersion reports whether the constraint pins one version, as in
+// "foo=1.2.3-r4", rather than naming a range, a tilde match, or no version.
+func (p ParsedConstraint) IsExactVersion() bool {
+	return p.dep == versionEqual && p.Version != ""
+}
+
+// Pin returns the repository tag the constraint is pinned to, as in "foo@edge",
+// or the empty string if it is not pinned to one.
+func (p ParsedConstraint) Pin() string {
+	return p.pin
+}
+
 func (p ParsedConstraint) SatisfiedBy(v Version) (bool, error) {
 	if p.Version == "" {
 		return true, nil

--- a/pkg/apk/docs/CACHE.md
+++ b/pkg/apk/docs/CACHE.md
@@ -7,7 +7,7 @@ This is completely independent of the target FS where you install the packages t
 install runs, all using similar packages. For example, if you need `busybox-1.36.2-r0.apk` for multiple installs,
 you only would need to download it once.
 
-The cache is **not** enabled by default. It only is enabled by providing the [WithCache()](./pkg/apk/options.go) option to the `New()` function.
+The cache is **not** enabled by default. It only is enabled by providing the [WithCache()](../apk/options.go) option to the `New()` function.
 
 ## Cache Location
 
@@ -50,6 +50,9 @@ Behaviour if no local etag is available depends on how it was called:
 * `.apk` files - we assume that they do not change, and thus no etag found locally means the file is accepted as is.
 
 # Offline Cache
+
+For a task-oriented guide to using this from Go, including populating a cache and
+reproducing a build from one, see [offline-cache.md](../../../docs/offline-cache.md).
 
 The cache described above stores apks pre-split into their component sections, so
 it is not usable as a standalone source of apks. The *offline cache*, enabled with

--- a/pkg/apk/docs/CACHE.md
+++ b/pkg/apk/docs/CACHE.md
@@ -48,3 +48,59 @@ Behaviour if no local etag is available depends on how it was called:
 
 * `APKINDEX.tar.gz` - we assume that it can change, and thus no etag found locally means always retrieve it.
 * `.apk` files - we assume that they do not change, and thus no etag found locally means the file is accepted as is.
+
+# Offline Cache
+
+The cache described above stores apks pre-split into their component sections, so
+it is not usable as a standalone source of apks. The *offline cache*, enabled with
+[WithOfflineCache()](../apk/options.go) or `--offline-cache`, is a separate mirror
+of the original `.apk` files, laid out the way the repository serves them:
+
+```
+<dir>/<host>/<repo path>/<arch>/<name>-<version>.apk
+<dir>/<host>/<repo path>/<arch>/<name>-<version>.apk.Q1
+<dir>/keys/<name>.rsa.pub
+```
+
+Unlike the cache above, the repository component is not URL-encoded, so the
+directory can be populated from or compared against an ordinary apk mirror. The
+scheme is dropped; a host and port are kept as-is.
+
+The `.Q1` sidecar records the checksum the repository index reported for that apk.
+It is needed because the checksum is a hash of a section *of* the apk, so
+recomputing it from the file proves only that the file is internally consistent.
+The sidecar is meaningful because it was written while the index was trusted.
+
+## Populating
+
+Given only `WithOfflineCache()`, a build resolves against the index as usual and
+mirrors each apk it uses into the directory. An apk already present is read from
+there rather than re-downloaded, and is verified against the index on every run.
+A repository that publishes different content under a name and version already in
+the cache is therefore an error rather than a silent divergence, which also makes
+this a way to detect a package rebuilt without an epoch bump.
+
+## Building offline
+
+Combined with `WithOffline()`, the directory becomes the only source of packages:
+no index is read and no network request is made. That has three consequences.
+
+* Every package must be pinned to an exact version (`name=1.2.3-r4`). Ranges,
+  tilde matches, repository pins (`@tag`) and virtuals (`so:`, `cmd:`) are all
+  refused, because resolving them needs the index.
+* There is no dependency graph, so the package list must be the **complete
+  transitive closure**. A missing dependency yields a broken image, not an error.
+* Packages are installed in the order they are listed, and that order decides
+  which package wins when two write the same path (it shows up in the mtimes
+  of shared directories and in the order of `/usr/lib/apk/db/installed`). Listing
+  a resolved closure in resolution order therefore reproduces the image an
+  ordinary build would produce, byte for byte. `/etc/apko.json` records the
+  package set sorted, as a resolving build does, rather than in the configured
+  order, so that the record does not itself introduce a difference.
+
+The guarantee an offline build gives is "these are the bytes the index vouched for
+when the cache was populated", not "these bytes are currently signed by the
+repository key": individual apk signatures are not verified against the keyring.
+
+Local (`file://` or path) repositories and base images are not supported offline,
+as both resolve packages through an index.

--- a/pkg/build/apk.go
+++ b/pkg/build/apk.go
@@ -65,8 +65,19 @@ func (bc *Context) initializeApk(ctx context.Context) error {
 
 	eg.Go(func() error {
 		keyring := sets.List(sets.New(bc.ic.Contents.Keyring...).Insert(bc.o.ExtraKeyFiles...))
+		if bc.offlineOnly() {
+			var err error
+			if keyring, err = bc.offlineKeyring(keyring); err != nil {
+				return err
+			}
+		}
 		if err := bc.apk.InitKeyring(ctx, keyring, nil); err != nil {
 			return fmt.Errorf("failed to initialize apk keyring: %w", err)
+		}
+		if bc.o.OfflineCacheDir != "" && !bc.o.Offline {
+			if err := bc.saveOfflineKeyring(ctx, keyring); err != nil {
+				return fmt.Errorf("failed to save apk keyring to offline cache: %w", err)
+			}
 		}
 		return nil
 	})

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -253,6 +253,10 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		}
 	}
 
+	if err := validateOffline(&bc.o); err != nil {
+		return nil, err
+	}
+
 	// SOURCE_DATE_EPOCH will always overwrite the build flag
 	if v, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok && len(strings.TrimSpace(v)) != 0 {
 		// The value MUST be an ASCII representation of an integer
@@ -301,6 +305,7 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 		}
 	}
 	apkOpts = append(apkOpts, apk.WithOffline(bc.o.Offline))
+	apkOpts = append(apkOpts, apk.WithOfflineCache(bc.o.OfflineCacheDir))
 
 	if bc.ic.Contents.BaseImage != nil {
 		imgPath, err := paths.ResolvePath(bc.ic.Contents.BaseImage.Image, bc.o.IncludePaths)

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/chainguard-dev/clog"
@@ -152,7 +153,18 @@ func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) 
 		pkgs []apk.InstalledDiff
 		err  error
 	)
-	if bc.o.Lockfile != "" {
+	switch {
+	case bc.offlineOnly():
+		log.Debugf("Using offline cache: %s", bc.o.OfflineCacheDir)
+		allPkgs, err := bc.offlineInstallablePackages(ctx)
+		if err != nil {
+			return nil, err
+		}
+		pkgs, err = bc.apk.InstallPackages(ctx, &bc.o.SourceDateEpoch, allPkgs)
+		if err != nil {
+			return nil, fmt.Errorf("failed installation from offline cache %s: %w", bc.o.OfflineCacheDir, err)
+		}
+	case bc.o.Lockfile != "":
 		log.Debugf("Using lockfile: %s", bc.o.Lockfile)
 		lock, err := lock.FromFile(bc.o.Lockfile)
 		if err != nil {
@@ -170,7 +182,7 @@ func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed installation from lockfile %s: %w", bc.o.Lockfile, err)
 		}
-	} else {
+	default:
 		pkgs, err = bc.apk.FixateWorld(ctx, &bc.o.SourceDateEpoch)
 		if err != nil {
 			return nil, fmt.Errorf("installing apk packages: %w", err)
@@ -280,12 +292,21 @@ func updateCache(ctx context.Context, fsys apkfs.FullFS) error {
 }
 
 func (bc *Context) WriteEtcApkoConfig(_ context.Context) error {
+	ic := bc.ic
+	if bc.offlineOnly() {
+		// A resolving build records its package set sorted (see unify), while an
+		// offline build keeps the configured order, because offline that is also the
+		// order the packages are installed in. Sort the record and not the install
+		// order, so that both kinds of build produce byte-identical images.
+		ic.Contents.Packages = slices.Sorted(slices.Values(bc.ic.Contents.Packages))
+	}
+
 	// Encode the image configuration and write it to /etc/apko.json
 	f, err := bc.fs.Create("/etc/apko.json")
 	if err != nil {
 		return fmt.Errorf("creating /etc/apko.json: %w", err)
 	}
-	if err := json.NewEncoder(f).Encode(bc.ic); err != nil {
+	if err := json.NewEncoder(f).Encode(ic); err != nil {
 		return fmt.Errorf("encoding image config: %w", err)
 	}
 	if err := f.Close(); err != nil {
@@ -319,6 +340,9 @@ func (bc *Context) BuildPackageList(ctx context.Context) (toInstall []*apk.Repos
 
 	if bc.o.Lockfile != "" {
 		return nil, nil, fmt.Errorf("assertion: cannot ResolveWorld if LockFile:%s is given", bc.o.Lockfile)
+	}
+	if bc.offlineOnly() {
+		return nil, nil, fmt.Errorf("assertion: cannot ResolveWorld with --offline and --offline-cache %s, which install without an index", bc.o.OfflineCacheDir)
 	}
 
 	if toInstall, conflicts, err = bc.apk.ResolveWorld(ctx); err != nil {

--- a/pkg/build/lock.go
+++ b/pkg/build/lock.go
@@ -51,6 +51,10 @@ func LockImageConfigurationWithPackages(ctx context.Context, ic types.ImageConfi
 		return nil, nil, nil, err
 	}
 
+	if err := validateOffline(o); err != nil {
+		return nil, nil, nil, err
+	}
+
 	input.Contents.BuildRepositories = sets.List(sets.New(input.Contents.BuildRepositories...).Insert(o.ExtraBuildRepos...))
 	input.Contents.Repositories = sets.List(sets.New(input.Contents.Repositories...).Insert(o.ExtraRepos...))
 	input.Contents.Keyring = sets.List(sets.New(input.Contents.Keyring...).Insert(o.ExtraKeyFiles...))
@@ -66,7 +70,17 @@ func LockImageConfigurationWithPackages(ctx context.Context, ic types.ImageConfi
 	var pls map[string][]string
 	var resolvedPkgs map[types.Architecture][]*apk.RepositoryPackage
 	missing := map[string][]string{}
-	if o.Lockfile == "" {
+	switch {
+	case o.Offline && o.OfflineCacheDir != "":
+		// Nothing to resolve: an offline build reads no index, so the
+		// configuration's package list is already the exact set to install. Its
+		// order is kept as written, since that is the order they are installed in.
+		pls = make(map[string][]string, len(input.Archs)+1)
+		pls["index"] = input.Contents.Packages
+		for _, arch := range input.Archs {
+			pls[arch.String()] = input.Contents.Packages
+		}
+	case o.Lockfile == "":
 		archs, pkgs, err := resolvePackageList(ctx, mc)
 		if err != nil {
 			return nil, nil, nil, err
@@ -76,7 +90,7 @@ func LockImageConfigurationWithPackages(ctx context.Context, ic types.ImageConfi
 		if err != nil {
 			return nil, missing, nil, err
 		}
-	} else {
+	default:
 		l, err := pkglock.FromFile(o.Lockfile)
 		if err != nil {
 			return nil, nil, nil, err

--- a/pkg/build/offline_cache.go
+++ b/pkg/build/offline_cache.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	"chainguard.dev/apko/pkg/options"
+)
+
+// offlineKeysDir is the subdirectory of an offline cache holding the apk signing
+// keys the configuration refers to, so that the cache is a self-contained input.
+const offlineKeysDir = "keys"
+
+// offlineOnly reports whether packages must come entirely from the offline
+// cache, with no index read and no network request.
+//
+// --offline on its own keeps its older meaning of "make no network requests,
+// satisfying the index from --cache-dir"; it is the combination with an offline
+// cache that selects the index-free path.
+func (bc *Context) offlineOnly() bool {
+	return bc.o.Offline && bc.o.OfflineCacheDir != ""
+}
+
+// validateOffline rejects combinations that would otherwise silently pick one
+// pinning mechanism and ignore the other.
+func validateOffline(o *options.Options) error {
+	if o.Offline && o.OfflineCacheDir != "" && o.Lockfile != "" {
+		return fmt.Errorf("--lockfile and --offline with --offline-cache are two ways to pin the same thing; use one or the other (lockfile %s, offline cache %s)", o.Lockfile, o.OfflineCacheDir)
+	}
+	return nil
+}
+
+// offlineRepositories returns the repositories to search for packages, in the
+// order they were configured. Unlike the resolving path, which sorts them, order
+// is meaningful here: it decides which repository wins when more than one holds
+// the same name and version.
+func (bc *Context) offlineRepositories() ([]string, error) {
+	var repos []string
+	seen := sets.New[string]()
+	for _, group := range [][]string{
+		bc.ic.Contents.BuildRepositories,
+		bc.ic.Contents.Repositories,
+		bc.o.ExtraBuildRepos,
+		bc.o.ExtraRepos,
+	} {
+		for _, repo := range group {
+			repo = strings.TrimSuffix(repo, "/")
+			if repo == "" || seen.Has(repo) {
+				continue
+			}
+			seen.Insert(repo)
+			if !apk.IsRemoteURL(repo) {
+				return nil, fmt.Errorf("offline builds cannot use the local repository %q: only http(s) repositories are mirrored into an offline cache", repo)
+			}
+			repos = append(repos, repo)
+		}
+	}
+	if len(repos) == 0 {
+		return nil, errors.New("no repositories configured")
+	}
+	return repos, nil
+}
+
+// offlineInstallablePackages locates every package the configuration asks for in
+// the offline cache.
+//
+// There is no index to resolve against, so the configuration's package list is
+// taken as the complete set to install: it must name exact versions and must
+// already include every transitive dependency.
+func (bc *Context) offlineInstallablePackages(ctx context.Context) ([]apk.InstallablePackage, error) {
+	log := clog.FromContext(ctx)
+
+	if bc.baseimg != nil {
+		return nil, errors.New("offline builds do not support a base image, whose packages are resolved from its own index")
+	}
+
+	if fi, err := os.Stat(bc.o.OfflineCacheDir); err != nil {
+		return nil, fmt.Errorf("offline cache %s: %w", bc.o.OfflineCacheDir, err)
+	} else if !fi.IsDir() {
+		return nil, fmt.Errorf("offline cache %s is not a directory", bc.o.OfflineCacheDir)
+	}
+
+	repos, err := bc.offlineRepositories()
+	if err != nil {
+		return nil, err
+	}
+
+	arch := bc.Arch().ToAPK()
+
+	// Order is preserved rather than sorted, because with no index there is no
+	// dependency graph to install in the order of: packages are installed in the
+	// order listed, and that order decides which package wins when two write the
+	// same path. Listing a resolved closure in resolution order reproduces the
+	// image an ordinary build would have produced.
+	want := make([]string, 0, len(bc.ic.Contents.Packages)+len(bc.o.ExtraPackages))
+	seen := sets.New[string]()
+	for _, spec := range append(append([]string{}, bc.ic.Contents.Packages...), bc.o.ExtraPackages...) {
+		if spec == "" || seen.Has(spec) {
+			continue
+		}
+		seen.Insert(spec)
+		want = append(want, spec)
+	}
+
+	constraints := make([]apk.ParsedConstraint, 0, len(want))
+	var unpinned []string
+	for _, spec := range want {
+		c := apk.ResolvePackageNameVersionPin(spec)
+		switch {
+		case !c.IsExactVersion():
+			unpinned = append(unpinned, spec)
+		case c.Pin() != "":
+			unpinned = append(unpinned, fmt.Sprintf("%s (repository pins are not supported offline)", spec))
+		case strings.Contains(c.Name, ":"):
+			// so:, cmd: and friends name something a package provides. Resolving
+			// them needs the index's provides data.
+			unpinned = append(unpinned, fmt.Sprintf("%s (virtual packages cannot be resolved offline)", spec))
+		default:
+			constraints = append(constraints, c)
+		}
+	}
+	if len(unpinned) > 0 {
+		return nil, fmt.Errorf("offline builds require every package to be pinned to an exact version (name=version); these are not:\n  %s", strings.Join(unpinned, "\n  "))
+	}
+
+	pkgs := make([]apk.InstallablePackage, 0, len(constraints))
+	var problems []string
+	for _, c := range constraints {
+		pkg, err := bc.locateOfflinePackage(c, repos, arch)
+		if err != nil {
+			problems = append(problems, err.Error())
+			continue
+		}
+		log.Debugf("offline cache: %s-%s from %s", c.Name, c.Version, pkg.URL())
+		pkgs = append(pkgs, pkg)
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return nil, fmt.Errorf("%d package(s) could not be taken from the offline cache %s:\n  %s",
+			len(problems), bc.o.OfflineCacheDir, strings.Join(problems, "\n  "))
+	}
+
+	return pkgs, nil
+}
+
+// locateOfflinePackage finds one pinned package in the offline cache, taking the
+// first repository that holds it.
+func (bc *Context) locateOfflinePackage(c apk.ParsedConstraint, repos []string, arch string) (apk.InstallablePackage, error) {
+	tried := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		path, err := apk.OfflineCachePath(bc.o.OfflineCacheDir, apk.APKURL(repo, arch, c.Name, c.Version))
+		if err != nil {
+			return nil, err
+		}
+		if _, err := os.Stat(path); err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return nil, fmt.Errorf("%s-%s: %w", c.Name, c.Version, err)
+			}
+			tried = append(tried, path)
+			continue
+		}
+		checksum, err := apk.ReadOfflineChecksum(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, fmt.Errorf("%s-%s: %s has no recorded checksum at %s; re-populate the cache rather than adding the apk by hand",
+					c.Name, c.Version, path, apk.OfflineChecksumPath(path))
+			}
+			return nil, fmt.Errorf("%s-%s: %w", c.Name, c.Version, err)
+		}
+		return installablePackage{name: c.Name, url: path, checksum: checksum}, nil
+	}
+	return nil, fmt.Errorf("%s-%s: not in the cache; looked for %s", c.Name, c.Version, strings.Join(tried, ", "))
+}
+
+// offlineKeyring rewrites remote keyring entries to the copies held in the
+// offline cache, since fetching them is not possible with the network closed.
+// Local paths are left alone.
+func (bc *Context) offlineKeyring(keyring []string) ([]string, error) {
+	out := make([]string, 0, len(keyring))
+	var missing []string
+	for _, key := range keyring {
+		if !apk.IsRemoteURL(key) {
+			out = append(out, key)
+			continue
+		}
+		path := filepath.Join(bc.o.OfflineCacheDir, offlineKeysDir, filepath.Base(key))
+		if _, err := os.Stat(path); err != nil {
+			missing = append(missing, fmt.Sprintf("%s (expected at %s)", key, path))
+			continue
+		}
+		out = append(out, path)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("offline builds need the apk signing keys in the cache; these are missing:\n  %s", strings.Join(missing, "\n  "))
+	}
+	return out, nil
+}
+
+// saveOfflineKeyring copies the keys a build just installed into the offline
+// cache, so that a later offline build has them without reaching the network.
+// The keys have already been written into the image, so they are read back from
+// there rather than fetched again.
+func (bc *Context) saveOfflineKeyring(ctx context.Context, keyring []string) error {
+	log := clog.FromContext(ctx)
+
+	dir := filepath.Join(bc.o.OfflineCacheDir, offlineKeysDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	for _, key := range keyring {
+		if !apk.IsRemoteURL(key) {
+			continue
+		}
+		base := filepath.Base(key)
+		data, err := fs.ReadFile(bc.fs, filepath.Join("etc", "apk", "keys", base))
+		if err != nil {
+			return fmt.Errorf("reading installed apk key %s: %w", base, err)
+		}
+		dst := filepath.Join(dir, base)
+		// #nosec G306 -- apk keyring must be publicly readable
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("writing apk key to offline cache: %w", err)
+		}
+		log.Debugf("offline cache: saved key %s", dst)
+	}
+	return nil
+}

--- a/pkg/build/offline_cache_docs_test.go
+++ b/pkg/build/offline_cache_docs_test.go
@@ -1,0 +1,99 @@
+package build_test
+
+// The snippets in docs/offline-cache.md, compiled and run against the local
+// testdata repository so that the documented flow cannot drift from the API.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+func docFlow(ctx context.Context, ic types.ImageConfiguration, offlineDir, cacheDir string) error {
+	// --- Reproducing a build byte for byte ---
+	configs, _, err := build.LockImageConfiguration(ctx, ic,
+		build.WithOfflineCache(offlineDir),
+	)
+	if err != nil {
+		return err
+	}
+	resolved, ok := configs["amd64"] // keyed by types.Architecture.String(), plus "index"
+	if !ok {
+		return fmt.Errorf("no resolved config for amd64")
+	}
+
+	// --- Populating a cache ---
+	bc, err := build.New(ctx, apkfs.NewMemFS(),
+		build.WithImageConfiguration(*resolved),
+		build.WithArch(types.ParseArchitecture("amd64")),
+		build.WithCache(cacheDir, false, apk.NewCache(true)),
+		build.WithOfflineCache(offlineDir),
+	)
+	if err != nil {
+		return err
+	}
+	if _, _, err := bc.BuildLayer(ctx); err != nil {
+		return err
+	}
+
+	// --- Capturing the pinned closure ---
+	installed, err := bc.InstalledPackages()
+	if err != nil {
+		return err
+	}
+	pinned := make([]string, 0, len(installed))
+	for _, p := range installed {
+		pinned = append(pinned, p.Name+"="+p.Version)
+	}
+
+	// --- Building offline ---
+	offlineIC := *resolved
+	offlineIC.Contents.Packages = pinned
+
+	obc, err := build.New(ctx, apkfs.NewMemFS(),
+		build.WithImageConfiguration(offlineIC),
+		build.WithArch(types.ParseArchitecture("amd64")),
+		build.WithOffline(true),
+		build.WithOfflineCache(offlineDir),
+	)
+	if err != nil {
+		return err
+	}
+	if _, _, err := obc.BuildLayer(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func docAPKLayer(offlineDir, repo, arch, name, version string) error {
+	path, err := apk.OfflineCachePath(offlineDir, apk.APKURL(repo, arch, name, version))
+	if err != nil {
+		return err
+	}
+	checksum, err := apk.ReadOfflineChecksum(path)
+	if err != nil {
+		return err
+	}
+	_ = checksum
+	return nil
+}
+
+func TestOfflineCacheDocumentedFlow(t *testing.T) {
+	srv := httptest.NewServer(http.FileServer(http.Dir("testdata/packages")))
+	defer srv.Close()
+
+	offlineDir, cacheDir := t.TempDir(), t.TempDir()
+	ic := offlineImageConfig(srv.URL, "pretend-baselayout", "replayout", "custom-ca-certs-1")
+
+	require.NoError(t, docFlow(t.Context(), ic, offlineDir, cacheDir))
+	require.NoError(t, docAPKLayer(offlineDir, srv.URL, "x86_64", "pretend-baselayout", "1.0.0-r0"))
+}

--- a/pkg/build/offline_cache_e2e_test.go
+++ b/pkg/build/offline_cache_e2e_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build_test
+
+import (
+	"crypto/sha1" //nolint:gosec // this is what apk tools is using
+	"encoding/base64"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+// offlineImageConfig describes an image built from the local testdata repository
+// served at repoURL.
+func offlineImageConfig(repoURL string, packages ...string) types.ImageConfiguration {
+	return types.ImageConfiguration{
+		Contents: types.ImageContents{
+			Repositories: []string{repoURL},
+			Keyring:      []string{repoURL + "/melange.rsa.pub"},
+			Packages:     packages,
+		},
+		Archs: []types.Architecture{types.ParseArchitecture("amd64")},
+	}
+}
+
+// TestOfflineCacheEndToEnd populates an offline cache from a served repository,
+// then rebuilds the same image with that server shut down, which proves the
+// second build reads neither the index nor the network.
+func TestOfflineCacheEndToEnd(t *testing.T) {
+	ctx := t.Context()
+	offlineDir := t.TempDir()
+
+	srv := httptest.NewServer(http.FileServer(http.Dir("testdata/packages")))
+	repoURL := srv.URL
+
+	// Resolve the unpinned request the way the CLI does, so the reference build
+	// records the same pinned package set an offline build will be given. Without
+	// this the two configs genuinely differ and /etc/apko.json would too.
+	configs, _, err := build.LockImageConfiguration(ctx,
+		offlineImageConfig(repoURL, "pretend-baselayout", "replayout", "custom-ca-certs-1"),
+		build.WithOfflineCache(offlineDir),
+	)
+	require.NoError(t, err)
+	resolved, ok := configs["amd64"]
+	require.True(t, ok, "expected a resolved config for amd64, got %v", configs)
+
+	// The reference build, which resolves and populates the cache as it goes.
+	bc, err := build.New(ctx, apkfs.NewMemFS(),
+		build.WithImageConfiguration(*resolved),
+		build.WithArch(types.ParseArchitecture("amd64")),
+		build.WithOfflineCache(offlineDir),
+	)
+	require.NoError(t, err)
+
+	_, onlineLayer, err := bc.BuildLayer(ctx)
+	require.NoError(t, err)
+	onlineDiffID, err := onlineLayer.DiffID()
+	require.NoError(t, err)
+
+	// InstalledPackages reports them in the order they were installed, which is the
+	// order an offline build has to be given to reproduce this image.
+	installed, err := bc.InstalledPackages()
+	require.NoError(t, err)
+	require.NotEmpty(t, installed)
+
+	// Every installed package is mirrored, with its checksum recorded, and the
+	// signing key is copied in so the cache stands alone.
+	host, err := url.Parse(repoURL)
+	require.NoError(t, err)
+	pinned := make([]string, 0, len(installed))
+	for _, p := range installed {
+		apkPath := filepath.Join(offlineDir, host.Host, "x86_64", p.Name+"-"+p.Version+".apk")
+		require.FileExists(t, apkPath)
+
+		chk, err := apk.ReadOfflineChecksum(apkPath)
+		require.NoError(t, err)
+		require.Equal(t, p.ChecksumString(), chk, "recorded checksum should be the one the index reported")
+
+		pinned = append(pinned, p.Name+"="+p.Version)
+	}
+	require.FileExists(t, filepath.Join(offlineDir, "keys", "melange.rsa.pub"))
+
+	// Take the network away entirely. The URLs in the config stay the same, so the
+	// only way the next build can succeed is from the offline cache.
+	srv.Close()
+
+	t.Run("resolution is skipped", func(t *testing.T) {
+		// Would need the index, which is now unreachable.
+		_, _, err := build.LockImageConfiguration(ctx, offlineImageConfig(repoURL, pinned...),
+			build.WithOffline(true),
+			build.WithOfflineCache(offlineDir),
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("image is byte-identical to the resolved build", func(t *testing.T) {
+		obc, err := build.New(ctx, apkfs.NewMemFS(),
+			build.WithImageConfiguration(offlineImageConfig(repoURL, pinned...)),
+			build.WithArch(types.ParseArchitecture("amd64")),
+			build.WithOffline(true),
+			build.WithOfflineCache(offlineDir),
+		)
+		require.NoError(t, err)
+
+		_, offlineLayer, err := obc.BuildLayer(ctx)
+		require.NoError(t, err)
+		offlineDiffID, err := offlineLayer.DiffID()
+		require.NoError(t, err)
+
+		// The whole point: given the same closure in install order, an offline build
+		// reproduces the resolved build exactly, down to the layer bytes. This
+		// fixture's install order happens to match sorted order, so the sibling
+		// subtest below is what covers the two being handled differently.
+		require.Equal(t, onlineDiffID, offlineDiffID)
+
+		offlineInstalled, err := obc.InstalledPackages()
+		require.NoError(t, err)
+		require.Len(t, offlineInstalled, len(installed))
+		for i := range installed {
+			require.Equal(t, installed[i].Name, offlineInstalled[i].Name)
+			require.Equal(t, installed[i].Version, offlineInstalled[i].Version)
+		}
+	})
+
+	t.Run("recorded config is sorted while install order is as given", func(t *testing.T) {
+		// Deliberately not in sorted order. /etc/apko.json must still record the
+		// sorted set, matching what a resolving build records, or the two builds
+		// would differ in that one file. The install order must follow the config.
+		reversed := slices.Clone(pinned)
+		slices.Reverse(reversed)
+		sorted := slices.Sorted(slices.Values(pinned))
+		require.NotEqual(t, sorted, reversed, "fixture cannot distinguish sorted from configured order")
+
+		memfs := apkfs.NewMemFS()
+		obc, err := build.New(ctx, memfs,
+			build.WithImageConfiguration(offlineImageConfig(repoURL, reversed...)),
+			build.WithArch(types.ParseArchitecture("amd64")),
+			build.WithOffline(true),
+			build.WithOfflineCache(offlineDir),
+		)
+		require.NoError(t, err)
+		require.NoError(t, obc.BuildImage(ctx))
+
+		b, err := fs.ReadFile(memfs, "etc/apko.json")
+		require.NoError(t, err)
+		var recorded types.ImageConfiguration
+		require.NoError(t, json.Unmarshal(b, &recorded))
+		require.Equal(t, sorted, recorded.Contents.Packages)
+
+		// Installed in the order the config listed them, not the recorded order.
+		installedNames := make([]string, 0, len(reversed))
+		offlineInstalled, err := obc.InstalledPackages()
+		require.NoError(t, err)
+		for _, p := range offlineInstalled {
+			installedNames = append(installedNames, p.Name+"="+p.Version)
+		}
+		require.Equal(t, reversed, installedNames)
+	})
+
+	t.Run("unpinned package is refused", func(t *testing.T) {
+		obc, err := build.New(ctx, apkfs.NewMemFS(),
+			build.WithImageConfiguration(offlineImageConfig(repoURL, "pretend-baselayout")),
+			build.WithArch(types.ParseArchitecture("amd64")),
+			build.WithOffline(true),
+			build.WithOfflineCache(offlineDir),
+		)
+		require.NoError(t, err)
+
+		err = obc.BuildImage(ctx)
+		require.ErrorContains(t, err, "pinned to an exact version")
+	})
+
+	t.Run("package missing from the cache is refused", func(t *testing.T) {
+		obc, err := build.New(ctx, apkfs.NewMemFS(),
+			build.WithImageConfiguration(offlineImageConfig(repoURL, "no-such-package=1.0.0-r0")),
+			build.WithArch(types.ParseArchitecture("amd64")),
+			build.WithOffline(true),
+			build.WithOfflineCache(offlineDir),
+		)
+		require.NoError(t, err)
+
+		err = obc.BuildImage(ctx)
+		require.ErrorContains(t, err, "not in the cache")
+	})
+
+	t.Run("apk whose recorded checksum was tampered with is refused", func(t *testing.T) {
+		// Copy the cache so the tampering does not affect the other subtests.
+		tampered := t.TempDir()
+		require.NoError(t, os.CopyFS(tampered, os.DirFS(offlineDir)))
+
+		apkPath := filepath.Join(tampered, host.Host, "x86_64", installed[0].Name+"-"+installed[0].Version+".apk")
+		// A well-formed but wrong checksum: the base64 of an all-zero SHA-1.
+		wrong := "Q1" + base64.StdEncoding.EncodeToString(make([]byte, sha1.Size))
+		require.NoError(t, os.WriteFile(apk.OfflineChecksumPath(apkPath), []byte(wrong+"\n"), 0o644))
+
+		obc, err := build.New(ctx, apkfs.NewMemFS(),
+			build.WithImageConfiguration(offlineImageConfig(repoURL, pinned...)),
+			build.WithArch(types.ParseArchitecture("amd64")),
+			build.WithOffline(true),
+			build.WithOfflineCache(tampered),
+		)
+		require.NoError(t, err)
+
+		err = obc.BuildImage(ctx)
+		require.ErrorContains(t, err, "control hash mismatch")
+	})
+}

--- a/pkg/build/offline_cache_test.go
+++ b/pkg/build/offline_cache_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/options"
+)
+
+const testOfflineRepo = "https://packages.wolfi.dev/os"
+
+// offlineCtx builds a Context wired for an offline build from dir.
+func offlineCtx(dir string, pkgs []string, repos ...string) *Context {
+	if len(repos) == 0 {
+		repos = []string{testOfflineRepo}
+	}
+	return &Context{
+		ic: types.ImageConfiguration{
+			Contents: types.ImageContents{
+				Repositories: repos,
+				Packages:     pkgs,
+			},
+		},
+		o: options.Options{
+			Arch:            types.ParseArchitecture("x86_64"),
+			Offline:         true,
+			OfflineCacheDir: dir,
+		},
+	}
+}
+
+// seedOfflineAPK writes a stand-in apk and its checksum sidecar where an offline
+// build will look for it. The bytes are never expanded by these tests, which stop
+// at locating the package.
+func seedOfflineAPK(t *testing.T, dir, repo, name, version, checksum string) string {
+	t.Helper()
+	path, err := apk.OfflineCachePath(dir, apk.APKURL(repo, "x86_64", name, version))
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("not-a-real-apk"), 0o644))
+	if checksum != "" {
+		require.NoError(t, os.WriteFile(apk.OfflineChecksumPath(path), []byte(checksum+"\n"), 0o644))
+	}
+	return path
+}
+
+func TestOfflineOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	// --offline alone keeps its older meaning and must not select the index-free path.
+	bc := offlineCtx(dir, nil)
+	bc.o.OfflineCacheDir = ""
+	require.False(t, bc.offlineOnly())
+
+	// --offline-cache alone only populates.
+	bc = offlineCtx(dir, nil)
+	bc.o.Offline = false
+	require.False(t, bc.offlineOnly())
+
+	require.True(t, offlineCtx(dir, nil).offlineOnly())
+}
+
+func TestOfflineRepositories(t *testing.T) {
+	t.Run("configured order is preserved and duplicates dropped", func(t *testing.T) {
+		bc := offlineCtx(t.TempDir(), nil)
+		bc.ic.Contents.BuildRepositories = []string{"https://b.example.com/os"}
+		bc.ic.Contents.Repositories = []string{"https://a.example.com/os", "https://b.example.com/os/"}
+		bc.o.ExtraRepos = []string{"https://c.example.com/os"}
+
+		repos, err := bc.offlineRepositories()
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"https://b.example.com/os",
+			"https://a.example.com/os",
+			"https://c.example.com/os",
+		}, repos)
+	})
+
+	t.Run("runtime-only repositories are excluded", func(t *testing.T) {
+		bc := offlineCtx(t.TempDir(), nil)
+		bc.ic.Contents.RuntimeOnlyRepositories = []string{"https://runtime.example.com/os"}
+		repos, err := bc.offlineRepositories()
+		require.NoError(t, err)
+		require.Equal(t, []string{testOfflineRepo}, repos)
+	})
+
+	t.Run("local repositories are rejected", func(t *testing.T) {
+		bc := offlineCtx(t.TempDir(), nil, "/var/packages")
+		_, err := bc.offlineRepositories()
+		require.ErrorContains(t, err, "local repository")
+	})
+
+	t.Run("no repositories", func(t *testing.T) {
+		bc := offlineCtx(t.TempDir(), nil)
+		bc.ic.Contents.Repositories = nil
+		_, err := bc.offlineRepositories()
+		require.ErrorContains(t, err, "no repositories")
+	})
+}
+
+func TestOfflineInstallablePackagesRequiresExactPins(t *testing.T) {
+	dir := t.TempDir()
+	bc := offlineCtx(dir, []string{
+		"busybox",           // name only
+		"glibc>2.0",         // range
+		"libgcc~16.1",       // tilde
+		"openssl@edge",      // repository pin
+		"so:libc.so.6=2.43", // virtual
+		"wolfi-base=1.0-r0", // fine
+	})
+
+	_, err := bc.offlineInstallablePackages(context.Background())
+	require.Error(t, err)
+	// Every offender is reported at once, so one run tells you the whole story.
+	for _, want := range []string{"busybox", "glibc>2.0", "libgcc~16.1", "openssl@edge", "so:libc.so.6"} {
+		require.ErrorContains(t, err, want)
+	}
+	require.NotContains(t, err.Error(), "wolfi-base=1.0-r0")
+}
+
+func TestOfflineInstallablePackagesPreservesOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	// Deliberately not in sorted order: this is the order they get installed in,
+	// which decides which package wins when two write the same path.
+	order := []string{"wolfi-baselayout=20230201-r29", "libgcc=16.1.0-r4", "busybox=1.37.0-r61"}
+	for i, spec := range order {
+		name, version, _ := splitSpec(spec)
+		seedOfflineAPK(t, dir, testOfflineRepo, name, version, "Q1seed"+string(rune('a'+i)))
+	}
+
+	bc := offlineCtx(dir, order)
+	pkgs, err := bc.offlineInstallablePackages(context.Background())
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		got = append(got, p.PackageName())
+	}
+	require.Equal(t, []string{"wolfi-baselayout", "libgcc", "busybox"}, got)
+
+	// The recorded checksum, not a hash of the file, is what gets installed against.
+	require.Equal(t, "Q1seeda", pkgs[0].ChecksumString())
+}
+
+func TestOfflineInstallablePackagesFirstRepositoryWins(t *testing.T) {
+	dir := t.TempDir()
+	const first, second = "https://first.example.com/os", "https://second.example.com/os"
+
+	seedOfflineAPK(t, dir, first, "busybox", "1.37.0-r61", "Q1first")
+	seedOfflineAPK(t, dir, second, "busybox", "1.37.0-r61", "Q1second")
+
+	bc := offlineCtx(dir, []string{"busybox=1.37.0-r61"}, first, second)
+	pkgs, err := bc.offlineInstallablePackages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.Equal(t, "Q1first", pkgs[0].ChecksumString())
+	require.Contains(t, pkgs[0].URL(), "first.example.com")
+
+	// With the order flipped, the other one wins.
+	bc = offlineCtx(dir, []string{"busybox=1.37.0-r61"}, second, first)
+	pkgs, err = bc.offlineInstallablePackages(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Q1second", pkgs[0].ChecksumString())
+}
+
+func TestOfflineInstallablePackagesMissing(t *testing.T) {
+	dir := t.TempDir()
+	seedOfflineAPK(t, dir, testOfflineRepo, "busybox", "1.37.0-r61", "Q1seed")
+
+	t.Run("apk absent", func(t *testing.T) {
+		bc := offlineCtx(dir, []string{"busybox=1.37.0-r61", "glibc=2.43-r11"})
+		_, err := bc.offlineInstallablePackages(context.Background())
+		require.ErrorContains(t, err, "glibc-2.43-r11: not in the cache")
+		// The path it looked in is named, so the fix is obvious.
+		require.ErrorContains(t, err, filepath.Join("packages.wolfi.dev", "os", "x86_64", "glibc-2.43-r11.apk"))
+	})
+
+	t.Run("wrong arch", func(t *testing.T) {
+		bc := offlineCtx(dir, []string{"busybox=1.37.0-r61"})
+		bc.o.Arch = types.ParseArchitecture("aarch64")
+		_, err := bc.offlineInstallablePackages(context.Background())
+		require.ErrorContains(t, err, "not in the cache")
+	})
+
+	t.Run("apk present but no recorded checksum", func(t *testing.T) {
+		unrecorded := t.TempDir()
+		seedOfflineAPK(t, unrecorded, testOfflineRepo, "busybox", "1.37.0-r61", "")
+
+		bc := offlineCtx(unrecorded, []string{"busybox=1.37.0-r61"})
+		_, err := bc.offlineInstallablePackages(context.Background())
+		require.ErrorContains(t, err, "no recorded checksum")
+	})
+
+	t.Run("cache directory does not exist", func(t *testing.T) {
+		bc := offlineCtx(filepath.Join(t.TempDir(), "nope"), []string{"busybox=1.37.0-r61"})
+		_, err := bc.offlineInstallablePackages(context.Background())
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestOfflineKeyring(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, offlineKeysDir)
+	require.NoError(t, os.MkdirAll(keysDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "wolfi-signing.rsa.pub"), []byte("key"), 0o644))
+
+	bc := offlineCtx(dir, nil)
+
+	t.Run("remote keys are redirected to the cache", func(t *testing.T) {
+		got, err := bc.offlineKeyring([]string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"})
+		require.NoError(t, err)
+		require.Equal(t, []string{filepath.Join(keysDir, "wolfi-signing.rsa.pub")}, got)
+	})
+
+	t.Run("local keys are left alone", func(t *testing.T) {
+		got, err := bc.offlineKeyring([]string{"/etc/apk/keys/local.rsa.pub"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"/etc/apk/keys/local.rsa.pub"}, got)
+	})
+
+	t.Run("missing key is an error naming where it was expected", func(t *testing.T) {
+		_, err := bc.offlineKeyring([]string{"https://packages.wolfi.dev/os/other-signing.rsa.pub"})
+		require.ErrorContains(t, err, "other-signing.rsa.pub")
+		require.ErrorContains(t, err, keysDir)
+	})
+}
+
+// splitSpec splits "name=version" for test setup.
+func splitSpec(spec string) (name, version string, ok bool) {
+	c := apk.ResolvePackageNameVersionPin(spec)
+	return c.Name, c.Version, c.IsExactVersion()
+}
+
+func TestValidateOffline(t *testing.T) {
+	dir := t.TempDir()
+
+	// A lockfile and an offline cache are two ways to pin the same thing, so
+	// silently honouring one and ignoring the other would be misleading.
+	bc := offlineCtx(dir, nil)
+	bc.o.Lockfile = "apko.lock.json"
+	require.ErrorContains(t, validateOffline(&bc.o), "two ways to pin")
+
+	// A lockfile with only a populating offline cache is fine.
+	bc = offlineCtx(dir, nil)
+	bc.o.Offline = false
+	bc.o.Lockfile = "apko.lock.json"
+	require.NoError(t, validateOffline(&bc.o))
+
+	require.NoError(t, validateOffline(&offlineCtx(dir, nil).o))
+}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"chainguard.dev/apko/pkg/apk/apk"
@@ -219,6 +220,30 @@ func WithCache(cacheDir string, offline bool, shared *apk.Cache) Option {
 func WithOffline(offline bool) Option {
 	return func(bc *Context) error {
 		bc.o.Offline = offline
+		return nil
+	}
+}
+
+// WithOfflineCache keeps a mirror of the raw .apk files a build uses in dir, as
+// <dir>/<host>/<repo path>/<arch>/<name>-<version>.apk plus a sidecar recording
+// the checksum the repository index reported for each one.
+//
+// Combined with WithOffline, dir becomes the only source of packages: no index
+// is read and no network request is made, which requires that every package in
+// the configuration be pinned to an exact version.
+func WithOfflineCache(dir string) Option {
+	return func(bc *Context) error {
+		if dir == "" {
+			bc.o.OfflineCacheDir = ""
+			return nil
+		}
+		// Absolutized to match apk.WithOfflineCache, so both layers agree on the
+		// path even if the working directory changes (apko -C).
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return err
+		}
+		bc.o.OfflineCacheDir = abs
 		return nil
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -78,6 +78,7 @@ type Options struct {
 	CacheDir                string                `json:"cacheDir,omitempty"`
 	DiskCacheEnabled        bool                  `json:"-"`
 	Offline                 bool                  `json:"offline,omitempty"`
+	OfflineCacheDir         string                `json:"offlineCacheDir,omitempty"`
 	SharedCache             *apk.Cache            `json:"-"`
 	Lockfile                string                `json:"lockfile,omitempty"`
 	Auth                    auth.Authenticator    `json:"-"`


### PR DESCRIPTION
This adds an offline apk cache that can be populated with a apko build using `--offline-cache=dir`.
Subsequent builds using `--offline-cache=dir` and `--offline` will _only_ use the cache.