### PR TITLE
apk: refuse to record a package with an empty name

### DIFF
--- a/pkg/apk/apk/empty_package_name_test.go
+++ b/pkg/apk/apk/empty_package_name_test.go
@@ -1,0 +1,73 @@
+package apk
+
+import (
+	"archive/tar"
+	"strings"
+	"testing"
+)
+
+// A package whose name is empty renders a "P:" line with no value.
+// ParseInstalled gates on pkg.Name != "" and so drops the entire record at the
+// blank line, which means the package's files are present in the image while
+// belonging to no package, and absent from anything derived from the database.
+// Writing a record that cannot be read back is never useful.
+func TestAddInstalledPackageRejectsEmptyPackageName(t *testing.T) {
+	a, _, err := testGetTestAPK()
+	if err != nil {
+		t.Fatalf("testGetTestAPK: %v", err)
+	}
+	before, err := a.GetInstalled()
+	if err != nil {
+		t.Fatalf("GetInstalled: %v", err)
+	}
+
+	files := []tar.Header{
+		{Name: "usr", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/bin", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/bin/thing", Typeflag: tar.TypeReg, Size: 5, Mode: 0o755},
+	}
+
+	_, err = a.AddInstalledPackage(&Package{Name: "", Version: "1.0", Arch: "x86_64"}, files)
+	if err == nil {
+		t.Fatal("AddInstalledPackage accepted a package with an empty name, want rejection")
+	}
+	if !strings.Contains(err.Error(), "empty name") {
+		t.Errorf("error = %q, want it to mention the empty name", err.Error())
+	}
+
+	after, err := a.GetInstalled()
+	if err != nil {
+		t.Fatalf("GetInstalled after rejection: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("installed package count went %d -> %d after a rejected write", len(before), len(after))
+	}
+}
+
+// The rejection must not cost a legitimate package: a name is the only thing
+// required here, and everything else may be empty.
+func TestAddInstalledPackageAcceptsMinimalPackage(t *testing.T) {
+	a, _, err := testGetTestAPK()
+	if err != nil {
+		t.Fatalf("testGetTestAPK: %v", err)
+	}
+	before, err := a.GetInstalled()
+	if err != nil {
+		t.Fatalf("GetInstalled: %v", err)
+	}
+
+	if _, err := a.AddInstalledPackage(&Package{Name: "minimal"}, nil); err != nil {
+		t.Fatalf("AddInstalledPackage(minimal) = %v, want success", err)
+	}
+
+	after, err := a.GetInstalled()
+	if err != nil {
+		t.Fatalf("GetInstalled after add: %v", err)
+	}
+	if len(after) != len(before)+1 {
+		t.Fatalf("installed count = %d, want %d", len(after), len(before)+1)
+	}
+	if got := after[len(after)-1].Name; got != "minimal" {
+		t.Errorf("added package name = %q, want %q", got, "minimal")
+	}
+}

--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -48,6 +48,17 @@ func (a *APK) GetInstalled() ([]*InstalledPackage, error) {
 // AddInstalledPackage add a package to the list of installed packages and returns
 // the _incremental_ diff installing the package had on the idb file.
 func (a *APK) AddInstalledPackage(pkg *Package, files []tar.Header) ([]byte, error) {
+	// A record with an empty P: value is written without complaint and then
+	// discarded wholesale by ParseInstalled, which gates on pkg.Name != "". The
+	// package's files are left in the image belonging to no package at all, and
+	// absent from the generated SBOM. Refuse to write a record we cannot read
+	// back: at best it vanishes silently, and nothing downstream can tell that
+	// from a package that was never installed.
+	if pkg.Name == "" {
+		return nil, fmt.Errorf("refusing to add a package with an empty name: the record " +
+			"would be silently discarded when the installed database is read back")
+	}
+
 	// be sure to open the file in append mode so we add to the end
 	installedFile, err := a.fs.OpenFile(installedFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {


### PR DESCRIPTION
`AddInstalledPackage` writes a package's name into the installed database as a `P:` line, and `ParseInstalled` gates every record on `pkg.Name != ""`.

A package whose name is empty is therefore written without complaint and then discarded wholesale on read-back, together with every `F:` and `R:` line it contributed. Its files remain in the image while belonging to no package at all, and it is absent from anything derived from the database, including the generated SBOM. Nothing downstream can distinguish that from a package that was never installed.

Verified — the record and its file entries are dropped together, so a following record is unaffected:

```
db:     P:\nV:1.0\nF:usr\nF:usr/bin\nR:orphaned-thing\n\n
        P:next-package\nV:2.0\nF:etc\nR:its-own-file\n\n

parsed: package "next-package" files=[etc etc/its-own-file]
        packages parsed: 1
```

## The change

Reject an empty name up front, before the database file is opened. Writing a record that cannot be read back is never the useful outcome: the write appears to succeed, and the loss is silent at every later step.

Only the name is required. A package with no version, arch or files still records correctly, and a test pins that so the check cannot drift into demanding more than the format does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)