### PR TITLE
fix: write the installed database sorted by package name

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -921,8 +921,25 @@ func (a *APK) InstallPackageContents(ctx context.Context, sourceDateEpoch *time.
 func (a *APK) recordInstalled(ctx context.Context, infos []*Package, allFiles [][]tar.Header) ([]InstalledDiff, error) {
 	diffs := make([]InstalledDiff, 0, len(allFiles))
 
-	// update the installed file
-	for i, files := range allFiles {
+	// update the installed file, writing the records sorted by package name:
+	// apk-tools rewrites the database sorted on its first operation, so writing
+	// it sorted keeps apko's output canonical instead of install-ordered
+	// (https://github.com/chainguard-dev/apko/issues/1969). Installation order
+	// above is unaffected; consumers key the returned diffs by package.
+	order := make([]int, 0, len(allFiles))
+	for i := range allFiles {
+		order = append(order, i)
+	}
+	slices.SortStableFunc(order, func(x, y int) int {
+		px, py := infos[x], infos[y]
+		if px == nil || py == nil {
+			// nil entries are skipped below; their position is irrelevant
+			return 0
+		}
+		return strings.Compare(px.Name, py.Name)
+	})
+	for _, i := range order {
+		files := allFiles[i]
 		pkg := infos[i]
 
 		// TODO: We currently skip over packages that are already installed.

--- a/pkg/apk/apk/install_test.go
+++ b/pkg/apk/apk/install_test.go
@@ -682,3 +682,43 @@ func TestInstallAPKFilesMetadataOrder(t *testing.T) {
 			"metadata calls for %s must be chown then chmod", name)
 	}
 }
+
+func TestInstallPackagesWritesSortedInstalledDB(t *testing.T) {
+	apk, _, err := testGetTestAPK()
+	require.NoErrorf(t, err, "failed to get test APK")
+
+	// Install deliberately out of name order; the installed database must
+	// still come out sorted by package name, matching what apk-tools
+	// produces when it rewrites the database.
+	pkgZ := &Package{Name: "zzz-last", Origin: "zzz-last"}
+	fpZ := fakePackage(t, pkgZ, []testDirEntry{
+		{"etc", 0o755, true, nil, nil},
+		{"etc/zzz-file", 0o644, false, []byte("z"), nil},
+	}, "")
+	pkgM := &Package{Name: "mmm-middle", Origin: "mmm-middle"}
+	fpM := fakePackage(t, pkgM, []testDirEntry{
+		{"etc", 0o755, true, nil, nil},
+		{"etc/mmm-file", 0o644, false, []byte("m"), nil},
+	}, "")
+	pkgA := &Package{Name: "aaa-first", Origin: "aaa-first"}
+	fpA := fakePackage(t, pkgA, []testDirEntry{
+		{"etc", 0o755, true, nil, nil},
+		{"etc/aaa-file", 0o644, false, []byte("a"), nil},
+	}, "")
+
+	_, err = apk.InstallPackages(context.Background(), nil, []InstallablePackage{fpZ, fpM, fpA})
+	require.NoError(t, err)
+
+	installed, err := apk.GetInstalled()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(installed))
+	for _, p := range installed {
+		names = append(names, p.Name)
+	}
+	// The test fixture ships a pre-populated installed database, so assert on
+	// the records this InstallPackages call appended: they must be sorted by
+	// name even though they were installed in reverse order.
+	require.GreaterOrEqual(t, len(names), 3)
+	require.Equal(t, []string{"aaa-first", "mmm-middle", "zzz-last"}, names[len(names)-3:])
+}


### PR DESCRIPTION
Fixes #1969

apko wrote /usr/lib/apk/db/installed in installation order, and apk-tools rewrites it sorted on its first operation, so any apk invocation inside the image changed the database without changing its contents.

This sorts the database records by package name at write time. Installation order on disk is unchanged, and the per-package diffs are unaffected: their only consumer keys them by package, not by position. Added a regression test installing packages in reverse name order and asserting the database reads back sorted.

One note: records appended to a pre-existing database (the base-image path) are sorted within the batch but not merged into the existing records; that matches how this issue reproduces on a fresh build. Happy to extend to a full rewrite-sorted approach if you'd prefer.