### PR TITLE
erofs: first batch of #2408 follow-ups

### DIFF
--- a/docs/erofs.md
+++ b/docs/erofs.md
@@ -165,7 +165,12 @@ apko erofs ls out/blobs/sha256/$LAYER | head
 apko erofs ls out/      # works against the whole OCI image too
 ```
 
-For multi-layer images, `ls` applies overlay semantics in user space to present the merged view the kernel would assemble. It uses the overlayfs-native deletion encoding the spec mandates (§3.6) — a whiteout is a character device with rdev 0, an opaque directory sets `trusted.overlay.opaque="y"` — not the `.wh.` filename convention of tar layers, which §8.1 forbids in EROFS images. A single-layer image is listed as-is: the kernel would mount it directly, applying no overlay semantics, so neither does `ls`.
+For multi-layer images, `ls` applies overlay semantics in user space. It uses the overlayfs-native deletion encoding the spec mandates (§3.6) — a whiteout is a character device with rdev 0, an opaque directory sets `trusted.overlay.opaque="y"` — not the `.wh.` filename convention of tar layers, which §8.1 forbids in EROFS images. A single-layer image is listed as-is: the kernel would mount it directly, applying no overlay semantics, so neither does `ls`.
+
+The merge approximates what the kernel would assemble, and diverges in two corners (see [#2408](https://github.com/chainguard-dev/apko/issues/2408)), both of which need two or more layers:
+
+- A whiteout — or a plain file — at a directory's own name in a middle layer does not cut off lower layers when a higher layer recreates that directory. `ls` shows the union of the recreated directory and the layers below the whiteout; the kernel shows only the recreated directory.
+- Opacity is not inherited by descendant directories. Marking `a` opaque hides lower layers' children of `a`, but not lower layers' children of `a/b`; the kernel's cut covers the whole subtree.
 
 ## Mount the layer
 
@@ -250,7 +255,7 @@ For inspection, apko *does* expose a focused leaf library — see `chainguard.de
 - **No dm-verity.** The spec's verified-mount path (§3.5) is not produced.
 - **No chunk index.** Lazy-loading runtimes (per spec §3.4) won't get an index; reads are sequential.
 - **No `overlay-data` or `device` roles.** apko emits one unannotated EROFS layer; `org.erofs.role` is never set.
-- **Hardlinks become independent copies.** go-erofs has no API to point two names at one inode, so each link costs another full copy of the file's data (rounded up to the block size) and `st_nlink`/`st_ino` identity is lost. Spec §3.7 allows this — a producer must either materialize links or fail — but a hardlink-heavy image will be larger as EROFS than as tar, where extra links are zero-byte entries.
+- **Hardlinks become independent copies.** go-erofs has no API to point two names at one inode, so each link costs another full copy of the file's data (rounded up to the block size) and `st_nlink`/`st_ino` identity is lost. Spec §3.7's materialize-or-fail rule covers *cross-layer* hardlinks; within a single layer the spec is silent, so this is conformant but not blessed by that section. Either way, a hardlink-heavy image will be larger as EROFS than as tar, where extra links are zero-byte entries.
 - **Spec is draft.** Media-type strings and annotation keys may change before the spec stabilizes. Treat any image built today as experimental.
 
 If you need any of the above, please open an issue.

--- a/pkg/build/erofs.go
+++ b/pkg/build/erofs.go
@@ -158,8 +158,9 @@ func emitErofsEntry(w *erofs.Writer, absPath, fsysPath string, info fs.FileInfo,
 		// reported link count but does not share the inode, so it would only
 		// make the metadata lie.) Every link therefore costs another full copy
 		// of the data, rounded up to the block size, and st_nlink/st_ino
-		// identity is lost. Spec §3.7 permits materializing links -- a producer
-		// must either materialize or fail -- so this is conformant, not a bug.
+		// identity is lost. Spec §3.7's materialize-or-fail rule governs
+		// cross-layer links; for links within one layer the spec says nothing,
+		// so materializing is conformant but not something §3.7 blesses.
 		fout, err := w.Create(absPath)
 		if err != nil {
 			return fmt.Errorf("create %s: %w", absPath, err)

--- a/pkg/build/oci/index_test.go
+++ b/pkg/build/oci/index_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
@@ -75,6 +76,40 @@ func TestGenerateIndex_PropagatesOSFeatures(t *testing.T) {
 	// A tar build must not gain the feature, and the propagation must not
 	// invent an empty OSFeatures slice where the config has none.
 	tarImg := buildImage(t, types.ImageConfiguration{}, ggcrtypes.OCILayer)
-	require.Empty(t, platformOf(t, tarImg).OSFeatures,
+	require.Nil(t, platformOf(t, tarImg).OSFeatures,
 		"tar-format builds must not declare os.features on the index descriptor")
+}
+
+// The propagation reads whatever os.features the finished config carries, and
+// BuildImageFromLayers DeepCopies the base image's config -- so a base image
+// that already declares features surfaces them on the index platform
+// descriptor, for a tar build as much as an EROFS one. That is what §5.4 asks
+// for (the descriptor should describe the image), and it changes the index
+// digest for such builds, so pin it rather than leave it to be rediscovered.
+func TestGenerateIndex_PropagatesOSFeaturesFromBaseImage(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	arch := types.ParseArchitecture("amd64")
+
+	base, err := mutate.ConfigFile(empty.Image, &v1.ConfigFile{
+		OSFeatures: []string{"example-feature"},
+	})
+	require.NoError(t, err)
+
+	img, err := BuildImageFromLayer(ctx, base, static.NewLayer([]byte("hello"), ggcrtypes.OCILayer), types.ImageConfiguration{}, now, arch)
+	require.NoError(t, err)
+
+	cfg, err := img.ConfigFile()
+	require.NoError(t, err)
+	require.Equal(t, []string{"example-feature"}, cfg.OSFeatures,
+		"the base image's os.features must survive into the built config")
+
+	_, idx, err := GenerateIndex(ctx, types.ImageConfiguration{}, map[types.Architecture]v1.Image{arch: img}, now)
+	require.NoError(t, err)
+	mf, err := idx.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, mf.Manifests, 1)
+	require.NotNil(t, mf.Manifests[0].Platform, "index descriptor has no platform")
+	require.Equal(t, []string{"example-feature"}, mf.Manifests[0].Platform.OSFeatures,
+		"a base image's os.features must reach the index platform descriptor")
 }

--- a/pkg/erofsmount/oci.go
+++ b/pkg/erofsmount/oci.go
@@ -77,8 +77,15 @@ func ReadOCILayers(ociDir, tag, arch string) ([]LayerRef, error) {
 
 	refs := make([]LayerRef, 0, len(manifest.Layers))
 	for i, desc := range manifest.Layers {
-		if string(desc.MediaType) != types.ErofsLayerMediaType {
-			return nil, fmt.Errorf("layer %d has mediaType %q; expected %q (this command only handles EROFS images)", i, desc.MediaType, types.ErofsLayerMediaType)
+		if mt := string(desc.MediaType); mt != types.ErofsLayerMediaType {
+			// A "+codec" suffix names an externally compressed EROFS layer:
+			// really an EROFS image, just not one we can read without
+			// decompressing it first. Saying "not an EROFS image" would be
+			// wrong and unhelpful.
+			if codec, ok := strings.CutPrefix(mt, types.ErofsLayerMediaType+"+"); ok && codec != "" {
+				return nil, fmt.Errorf("layer %d is a %s-compressed EROFS layer (mediaType %q), which apko cannot read yet; see https://github.com/chainguard-dev/apko/pull/2406", i, codec, mt)
+			}
+			return nil, fmt.Errorf("layer %d has mediaType %q; expected %q (this command only handles EROFS images)", i, mt, types.ErofsLayerMediaType)
 		}
 		// org.erofs.role is OPTIONAL on any layer (spec §2.3), and §7 step 1
 		// classifies both "overlay-lower" and an absent role as overlay lowers

--- a/pkg/erofsmount/oci_test.go
+++ b/pkg/erofsmount/oci_test.go
@@ -187,6 +187,27 @@ func TestReadOCILayers_WrongMediaType(t *testing.T) {
 	}
 }
 
+// An externally compressed layer is a real EROFS image apko cannot read yet,
+// not a foreign layer, so the error must not tell the user it isn't EROFS.
+func TestReadOCILayers_CompressedMediaType(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeOCILayout(t, dir, []fakeLayer{
+		{body: []byte("compressed-erofs"), mediaType: types.ErofsLayerMediaType + "+zstd"},
+	})
+	_, err := ReadOCILayers(dir, "", "amd64")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"zstd", "2406"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "only handles EROFS images") {
+		t.Errorf("error %q calls a compressed EROFS layer non-EROFS", err)
+	}
+}
+
 // org.erofs.role is OPTIONAL on any layer (§2.3), and §3.8 rule 1 allows the
 // final layer's role to be absent *or* overlay-lower, so neither an
 // unannotated non-final layer nor an overlay-lower final layer is an error.

--- a/pkg/erofsmount/stack.go
+++ b/pkg/erofsmount/stack.go
@@ -15,6 +15,8 @@
 package erofsmount
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"path"
@@ -222,7 +224,11 @@ func (s *Stack) lookup(name string) (int, error) {
 		}
 		// Not in this layer. If this layer's copy of the parent directory is
 		// opaque, it hides everything below.
-		if s.isOpaqueDir(layer, parent) {
+		opaque, err := s.isOpaqueDir(layer, parent)
+		if err != nil {
+			return -1, err
+		}
+		if opaque {
 			return -1, fs.ErrNotExist
 		}
 	}
@@ -256,7 +262,11 @@ func (s *Stack) mergeDir(name string) ([]fs.DirEntry, error) {
 		}
 		// This layer's own entries are already in; an opaque directory hides
 		// only what lies below it.
-		if s.isOpaqueDir(layer, name) {
+		opaque, err := s.isOpaqueDir(layer, name)
+		if err != nil {
+			return nil, err
+		}
+		if opaque {
 			break
 		}
 	}
@@ -288,22 +298,33 @@ func (s *Stack) isWhiteout(e fs.DirEntry) bool {
 // isOpaqueDir reports whether fsys's copy of dir is an opaque directory --
 // `trusted.overlay.opaque` set to "y", per spec §3.6 -- which hides every
 // lower layer's children of that directory.
-func (s *Stack) isOpaqueDir(fsys fs.FS, dir string) bool {
+//
+// A stat failure is reported, not swallowed: opacity hides content, so
+// answering "not opaque" for a layer we could not read would silently un-hide
+// whatever the image meant to hide. dir being absent from this layer is the one
+// benign case, and means exactly "not opaque here".
+func (s *Stack) isOpaqueDir(fsys fs.FS, dir string) (bool, error) {
 	if !s.whiteouts {
-		return false
+		return false, nil
 	}
 	info, err := statOn(fsys, dir)
-	if err != nil || !info.IsDir() {
-		return false
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s to check for %s: %w", dir, overlayOpaqueXattr, err)
+	}
+	if !info.IsDir() {
+		return false, nil
 	}
 	gx, ok := info.(interface {
 		GetXattr(string) (string, bool)
 	})
 	if !ok {
-		return false
+		return false, nil
 	}
 	v, _ := gx.GetXattr(overlayOpaqueXattr)
-	return v == "y"
+	return v == "y", nil
 }
 
 // rootInfo returns FileInfo for ".". The topmost layer that has a root wins

--- a/pkg/erofsmount/stack.go
+++ b/pkg/erofsmount/stack.go
@@ -215,7 +215,11 @@ func (s *Stack) lookup(name string) (int, error) {
 			if e.Name() != base {
 				continue
 			}
-			if s.isWhiteout(e) {
+			white, err := s.isWhiteout(e)
+			if err != nil {
+				return -1, err
+			}
+			if white {
 				// A whiteout hides every lower layer's entry, and is not
 				// itself part of the merged view.
 				return -1, fs.ErrNotExist
@@ -255,7 +259,11 @@ func (s *Stack) mergeDir(name string) ([]fs.DirEntry, error) {
 				continue
 			}
 			seen[n] = true
-			if s.isWhiteout(e) {
+			white, err := s.isWhiteout(e)
+			if err != nil {
+				return nil, err
+			}
+			if white {
 				continue // tombstone: shadows lower layers, never listed
 			}
 			out = append(out, e)
@@ -280,19 +288,22 @@ func (s *Stack) mergeDir(name string) ([]fs.DirEntry, error) {
 //
 // The cheap Type() check comes first so the common case costs nothing: only a
 // char device is worth an Info() call, which for a real EROFS layer reads the
-// inode.
-func (s *Stack) isWhiteout(e fs.DirEntry) bool {
+// inode. That call's failure is reported rather than swallowed, for the same
+// reason as isOpaqueDir: whether the entry is a tombstone decides what the
+// merged view shows, and answering it from an inode we could not read is a
+// guess either way.
+func (s *Stack) isWhiteout(e fs.DirEntry) (bool, error) {
 	if !s.whiteouts || e.Type()&fs.ModeCharDevice == 0 {
-		return false
+		return false, nil
 	}
 	info, err := e.Info()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("stat %s to check for whiteout: %w", e.Name(), err)
 	}
 	// go-erofs advertises Rdev() on the FileInfo it returns; an fs.FS with no
 	// notion of device numbers cannot express a whiteout at all.
 	rd, ok := info.(interface{ Rdev() uint64 })
-	return ok && rd.Rdev() == 0
+	return ok && rd.Rdev() == 0, nil
 }
 
 // isOpaqueDir reports whether fsys's copy of dir is an opaque directory --

--- a/pkg/erofsmount/stack_test.go
+++ b/pkg/erofsmount/stack_test.go
@@ -477,6 +477,66 @@ func TestStack_OpaqueDir_KeepsOwnChildren(t *testing.T) {
 	}
 }
 
+// errCorruptXattr stands in for whatever a layer with a damaged xattr region
+// makes go-erofs return. The only property that matters is that it is not
+// fs.ErrNotExist.
+var errCorruptXattr = errors.New("simulated corrupt xattr region")
+
+// brokenStatFS fails Stat for named paths while ReadDir keeps working, which is
+// how an unreadable inode presents: the parent directory still lists it.
+type brokenStatFS struct {
+	overlayFS
+	statErr map[string]error
+}
+
+func (b brokenStatFS) Stat(name string) (fs.FileInfo, error) {
+	if err := b.statErr[name]; err != nil {
+		return nil, err
+	}
+	return b.overlayFS.Stat(name)
+}
+
+// A layer we cannot stat is a layer whose opacity we cannot determine. Treating
+// that as "not opaque" would un-hide the lower layers it may have been hiding,
+// so both callers must surface the error instead.
+//
+// The middle layer is the broken one on purpose: it is the only position where
+// isOpaqueDir is the first thing to fail. If the top layer were broken, the
+// ancestor stat in lookup would raise first and the fixture would pass without
+// isOpaqueDir being consulted at all.
+func TestStack_OpaqueDir_StatErrorIsNotSilentlyPermissive(t *testing.T) {
+	lower := fstest.MapFS{
+		"etc":        {Mode: fs.ModeDir | 0o755},
+		"etc/secret": {Data: []byte("hidden"), Mode: 0o644},
+	}
+	middle := brokenStatFS{
+		overlayFS: overlayFS{MapFS: fstest.MapFS{
+			"etc": {Mode: fs.ModeDir | 0o755},
+		}},
+		statErr: map[string]error{"etc": errCorruptXattr},
+	}
+	top := overlayFS{MapFS: fstest.MapFS{
+		"etc":     {Mode: fs.ModeDir | 0o755},
+		"etc/foo": {Data: []byte("F"), Mode: 0o644},
+	}}
+	s := NewStack(lower, middle, top)
+
+	// mergeDir: the union must not quietly include etc/secret.
+	if ents, err := fs.ReadDir(s, "etc"); !errors.Is(err, errCorruptXattr) {
+		names := make([]string, 0, len(ents))
+		for _, e := range ents {
+			names = append(names, e.Name())
+		}
+		t.Errorf("ReadDir(etc) = %v, %v; want error wrapping %v", names, err, errCorruptXattr)
+	}
+
+	// lookup: reaching an entry only the bottom layer has must not quietly
+	// succeed either.
+	if _, err := fs.Stat(s, "etc/secret"); !errors.Is(err, errCorruptXattr) {
+		t.Errorf("Stat(etc/secret) err = %v; want error wrapping %v", err, errCorruptXattr)
+	}
+}
+
 func TestStack_SingleLayer(t *testing.T) {
 	only := fstest.MapFS{
 		"etc/foo": {Data: []byte("X"), Mode: 0o644},

--- a/pkg/erofsmount/stack_test.go
+++ b/pkg/erofsmount/stack_test.go
@@ -45,8 +45,9 @@ func (n nakedFS) Open(name string) (fs.File, error) { return n.inner.Open(name) 
 // (rdev 0). A real device names its rdev explicitly.
 type overlayFS struct {
 	fstest.MapFS
-	rdev   map[string]uint64 // char-device path -> device number; absent means 0
-	opaque map[string]bool   // directory paths carrying trusted.overlay.opaque=y
+	rdev    map[string]uint64 // char-device path -> device number; absent means 0
+	opaque  map[string]bool   // directory paths carrying trusted.overlay.opaque=y
+	infoErr map[string]error  // paths whose DirEntry.Info() fails
 }
 
 func (o overlayFS) wrap(p string, fi fs.FileInfo) fs.FileInfo {
@@ -80,6 +81,9 @@ type overlayEntry struct {
 }
 
 func (e overlayEntry) Info() (fs.FileInfo, error) {
+	if err := e.fsys.infoErr[e.path]; err != nil {
+		return nil, err
+	}
 	fi, err := e.DirEntry.Info()
 	if err != nil {
 		return nil, err
@@ -534,6 +538,44 @@ func TestStack_OpaqueDir_StatErrorIsNotSilentlyPermissive(t *testing.T) {
 	// succeed either.
 	if _, err := fs.Stat(s, "etc/secret"); !errors.Is(err, errCorruptXattr) {
 		t.Errorf("Stat(etc/secret) err = %v; want error wrapping %v", err, errCorruptXattr)
+	}
+}
+
+// errCorruptInode stands in for whatever go-erofs returns for an inode it
+// cannot read. Like errCorruptXattr, the only property that matters is that it
+// is not fs.ErrNotExist.
+var errCorruptInode = errors.New("simulated unreadable inode")
+
+// A char device whose inode we cannot read may or may not be a whiteout, and
+// both answers change the merged view. Surface the error instead of picking one,
+// matching isOpaqueDir.
+func TestStack_Whiteout_InfoErrorIsNotSilentlyPermissive(t *testing.T) {
+	lower := fstest.MapFS{
+		"etc":        {Mode: fs.ModeDir | 0o755},
+		"etc/secret": {Data: []byte("hidden"), Mode: 0o644},
+	}
+	top := overlayFS{
+		MapFS: fstest.MapFS{
+			"etc":        {Mode: fs.ModeDir | 0o755},
+			"etc/secret": whiteout(),
+		},
+		infoErr: map[string]error{"etc/secret": errCorruptInode},
+	}
+	s := NewStack(lower, top)
+
+	// mergeDir: neither the tombstone nor the entry it may delete may be
+	// listed on a guess.
+	if ents, err := fs.ReadDir(s, "etc"); !errors.Is(err, errCorruptInode) {
+		names := make([]string, 0, len(ents))
+		for _, e := range ents {
+			names = append(names, e.Name())
+		}
+		t.Errorf("ReadDir(etc) = %v, %v; want error wrapping %v", names, err, errCorruptInode)
+	}
+
+	// lookup: same for resolving the name directly.
+	if _, err := fs.Stat(s, "etc/secret"); !errors.Is(err, errCorruptInode) {
+		t.Errorf("Stat(etc/secret) err = %v; want error wrapping %v", err, errCorruptInode)
 	}
 }
 


### PR DESCRIPTION
First batch of the EROFS follow-ups from #2408 — the items that touch merged
`main` only, so none of them wait on the descoped mount/umount or layering code
coming back. One real behavior change, two tests, two rewords.

### `isOpaqueDir` fails closed on an unreadable layer

`isOpaqueDir` returned `false` whenever `statOn` failed, so a layer whose xattr
region could not be read was treated as one that hides nothing. That fails
*open*: the entries an opaque directory was meant to hide from lower layers get
listed anyway, and nothing tells the caller the answer was a guess. Layers come
from an OCI image that may be untrusted, so a damaged or hostile one should not
be able to widen the merged view by being unreadable.

It now returns `(bool, error)` and propagates anything that is not
`fs.ErrNotExist` — absent is the one benign case, since a layer that lacks the
directory genuinely is not opaque there. Both callers (`lookup`, `mergeDir`)
already returned errors.

The test puts the unreadable layer in the *middle* of three on purpose: that is
the only position where `isOpaqueDir` is the first thing to fail. With the
broken layer on top, `lookup`'s ancestor stat raises first and the fixture would
pass either way. Against the old code it reports
`ReadDir(etc) = [foo secret], <nil>` — the lower layer's `secret` leaking into
the merged view.

### `application/vnd.erofs+zstd` gets an accurate error

A compressed layer is a spec-legal EROFS image apko cannot read yet, but it hit
the mediaType check and was told the command "only handles EROFS images". Now
any `application/vnd.erofs+<codec>` names its codec and points at #2406.

Matching on the suffix rather than adding a media-type constant is deliberate:
the draft spec's set of codecs isn't something apko should pin down in
`pkg/build/types` to produce one error message.

### `os.features` propagation from a base image config, pinned

`generateIndexWithMediaType` copies the finished config's `os.features` onto the
index platform descriptor for every format, and `BuildImageFromLayers`
DeepCopies the base image's config. So a plain **tar** build on a base image
that already declares `os.features` surfaces them on the index descriptor,
changing that index's digest. Spec §5.4 asks for this and #2249's squash message
calls it out, but the test added there covered only the empty-base case.

Also `require.Empty` → `require.Nil` for the "tar builds declare nothing"
assertion, which is what it means to check — that the propagation doesn't invent
an empty slice. Harmless either way: `os.features` carries `omitempty` in
go-containerregistry, so an empty-but-present slice can't change a digest.

### Two claims softened to match reality

- **§3.7 was cited too strongly.** Its materialize-or-fail rule governs
  *cross-layer* hardlinks; for links within one layer the spec is silent, so
  apko materializing them is conformant but not blessed by that section. #2249's
  squash message has this right; `pkg/build/erofs.go` and `docs/erofs.md` did
  not.
- **`docs/erofs.md` promised kernel parity for `apko erofs ls`** ("the merged
  view the kernel would assemble"). It approximates it, and diverges in two
  corners: a middle-layer whiteout at a directory's own name doesn't cut off
  lower layers when a higher layer recreates the directory, and opacity isn't
  inherited by descendant directories. Both need 2+ layers, so neither is
  reachable for an image apko produces today. The doc now names them and links
  #2408, where the algorithm fix (a per-directory layer horizon) is tracked.

### Verification

`go test ./...` passes, `golangci-lint run -n` reports 0 issues, `gofmt -l` is
clean.

Unrelated note found along the way: `make lint` is currently broken on `main` —
its target installs
`github.com/golangci/golangci-lint/cmd/golangci-lint/v2@v2.2.1`, which no longer
resolves (`invalid version: unknown revision cmd/golangci-lint/v2.2.1`). CI
isn't affected, since `verify.yaml` uses `golangci-lint-action`. Left alone
here; happy to fix it separately.

### Not in this PR

The rest of #2408: restoring mount/umount (with state-file containment,
partial-unmount recovery, a read-only default and a `Driver` test seam),
restoring multi-layer splitting, the layer-horizon fix, and the go-erofs bump.
The pre-descope tree those two build on is preserved at
https://github.com/smoser/apko/tree/feat/apko-erofs-full.

Refs #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)
