### PR TITLE
Makefile: fix `make lint`, reading its version from CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,18 @@ install: $(SRCS) ## Builds and moves apko into BINDIR (default /usr/bin)
 
 GOLANGCI_LINT_DIR = $(shell pwd)/bin
 GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
+LINT_WORKFLOW = .github/workflows/verify.yaml
+# Read the version out of the workflow rather than pinning it again here, so
+# `make lint` cannot drift from CI. go install takes "v2.11" as a prefix query
+# and picks the highest v2.11.x, which is what golangci-lint-action does too.
+GOLANGCI_LINT_VERSION = $(shell sed -n '/golangci-lint-action/,/version:/s/^[[:space:]]*version:[[:space:]]*//p' $(LINT_WORKFLOW))
 
 .PHONY: golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint/v2@v2.2.1 ;\
+	test -n "$(GOLANGCI_LINT_VERSION)" || { echo "no golangci-lint version found in $(LINT_WORKFLOW)" >&2; exit 1; } ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) ;\
 
 .PHONY: fmt
 fmt: ## Format all go files


### PR DESCRIPTION
`make lint` fails at the install step, and has since `4a12efd7` (#1736, "upgrade
golangci-lint to v2", July 2025):

```
go: github.com/golangci/golangci-lint/cmd/golangci-lint/v2@v2.2.1:
    invalid version: unknown revision cmd/golangci-lint/v2.2.1
```

The major-version suffix belongs on the *module* path, not after the package
path. The module is `github.com/golangci/golangci-lint/v2`, so the binary lives
at `.../v2/cmd/golangci-lint`. As written, `go` read the trailing `/v2` as part
of the package path and went looking for a `cmd/golangci-lint/v2.2.1` tag, which
doesn't exist.

CI never caught this: the lint job uses `golangci-lint-action` directly, and no
workflow invokes `make lint`, `make golangci-lint` or `checkfmt`. So only local
linting was broken, which is presumably how it went unnoticed for thirteen
months.

### Not pinning the version twice

The obvious fix is `.../v2/cmd/golangci-lint@v2.2.1`, which does install. But
`v2.2.1` is nine minor releases behind the `v2.11` CI pins, so a working
`make lint` would then quietly run a different check set than CI — and pinning
`v2.11.4` here instead just moves the problem to the next bump, where the two
drift silently rather than failing loudly.

So this reads the version out of the workflow:

```make
GOLANGCI_LINT_VERSION = $(shell sed -n '/golangci-lint-action/,/version:/s/^[[:space:]]*version:[[:space:]]*//p' $(LINT_WORKFLOW))
```

`go install` accepts `v2.11` as a prefix query and resolves it to the highest
`v2.11.x` — exactly what `golangci-lint-action` does with that same string — so
the two agree by construction and a CI bump needs no Makefile change. The recipe
guards the extraction, so if the workflow is renamed or restructured it says

```
no golangci-lint version found in .github/workflows/verify.yaml
```

rather than running `go install ...@` and failing obscurely.

### Verification

From a clean tree with no `bin/`:

```
$ make lint
...
GOBIN=.../bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11
.../bin/golangci-lint run -n
0 issues.

$ ./bin/golangci-lint --version
golangci-lint has version 2.11.4 ...
```

And the guard: `make golangci-lint LINT_WORKFLOW=/dev/null` exits 2 with the
message above.

Found while working on #2408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
