### PR TITLE
Bump go-erofs import to current main.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	chainguard.dev/sdk v0.1.197
 	github.com/chainguard-dev/clog v1.8.1
 	github.com/charmbracelet/log v1.0.0
-	github.com/erofs/go-erofs v0.3.1
+	github.com/erofs/go-erofs v0.3.2-0.20260804074615-52cc42c5291c
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.9

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/erofs/go-erofs v0.3.1 h1:Sux82Jq9yvyYhIoLgSHDp741p/+370HsOj9dAh1+VVs=
-github.com/erofs/go-erofs v0.3.1/go.mod h1:XkSeN9MHszGd4+3gcEjadJLYHCQpWzJ7/8yznzMuzJs=
+github.com/erofs/go-erofs v0.3.2-0.20260804074615-52cc42c5291c h1:l2NcPw9ioT/HNi0J3L4wiU2BcoYxiVx0xwWilF8S4p8=
+github.com/erofs/go-erofs v0.3.2-0.20260804074615-52cc42c5291c/go.mod h1:XkSeN9MHszGd4+3gcEjadJLYHCQpWzJ7/8yznzMuzJs=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=


### PR DESCRIPTION
The big thing was to pick up
https://github.com/erofs/go-erofs/pull/41

    52cc42c Add RemoveAll for recursive removal
    112653e Add remove function for merging overlays
    ba68dad Add hardlink support in the writer
    44d5e74 Fix FileInfo.Mode() dropping setuid/setgid/sticky on the read path
    0746254 Preserve setuid/setgid/sticky bits in Writer.Mkdir
    622ddde Fix chunk-index map alignment for inodes with xattrs