### PR TITLE
build: make WithAnnotations and WithFormat order-independent

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -60,6 +60,11 @@ type Context struct {
 	ic types.ImageConfiguration
 	o  options.Options
 
+	// formatOverride is the layer format an explicit WithFormat asked for. It
+	// is held here rather than written straight to ic, and resolved onto ic by
+	// resolveImageConfiguration once every Option has been applied.
+	formatOverride types.LayerFormat
+
 	s6      *s6.Context
 	fs      apkfs.FullFS
 	apk     *apk.APK
@@ -239,6 +244,16 @@ func (bc *Context) checkPaths(ctx context.Context) error {
 	return nil
 }
 
+// resolveImageConfiguration applies the overrides recorded by the field-level
+// Options onto ic. It runs after every Option has been applied, so that an
+// Option which replaces ic wholesale -- WithImageConfiguration, WithConfig --
+// cannot discard them by appearing later in the slice.
+func (bc *Context) resolveImageConfiguration() {
+	if bc.formatOverride != "" {
+		bc.ic.Format = bc.formatOverride
+	}
+}
+
 // NewOptions evaluates the build.Options in the same way as New().
 func NewOptions(opts ...Option) (*options.Options, *types.ImageConfiguration, error) {
 	bc := Context{
@@ -250,6 +265,7 @@ func NewOptions(opts ...Option) (*options.Options, *types.ImageConfiguration, er
 			return nil, nil, err
 		}
 	}
+	bc.resolveImageConfiguration()
 
 	return &bc.o, &bc.ic, nil
 }
@@ -273,6 +289,7 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 			return nil, err
 		}
 	}
+	bc.resolveImageConfiguration()
 
 	// SOURCE_DATE_EPOCH will always overwrite the build flag
 	if v, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok && len(strings.TrimSpace(v)) != 0 {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,10 +61,12 @@ type Context struct {
 	ic types.ImageConfiguration
 	o  options.Options
 
-	// formatOverride is the layer format an explicit WithFormat asked for. It
-	// is held here rather than written straight to ic, and resolved onto ic by
-	// resolveImageConfiguration once every Option has been applied.
-	formatOverride types.LayerFormat
+	// formatOverride and annotationOverrides are what the field-level Options
+	// asked for. They are held here rather than written straight to ic, and
+	// resolved onto ic by resolveImageConfiguration once every Option has been
+	// applied.
+	formatOverride      types.LayerFormat
+	annotationOverrides map[string]string
 
 	s6      *s6.Context
 	fs      apkfs.FullFS
@@ -251,6 +254,15 @@ func (bc *Context) checkPaths(ctx context.Context) error {
 func (bc *Context) resolveImageConfiguration() {
 	if bc.formatOverride != "" {
 		bc.ic.Format = bc.formatOverride
+	}
+	if len(bc.annotationOverrides) > 0 {
+		// Clone: ic.Annotations may still be the caller's map.
+		m := maps.Clone(bc.ic.Annotations)
+		if m == nil {
+			m = make(map[string]string, len(bc.annotationOverrides))
+		}
+		maps.Copy(m, bc.annotationOverrides)
+		bc.ic.Annotations = m
 	}
 }
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -256,13 +256,13 @@ func (bc *Context) resolveImageConfiguration() {
 		bc.ic.Format = bc.formatOverride
 	}
 	if len(bc.annotationOverrides) > 0 {
-		// Clone: ic.Annotations may still be the caller's map.
-		m := maps.Clone(bc.ic.Annotations)
-		if m == nil {
-			m = make(map[string]string, len(bc.annotationOverrides))
-		}
-		maps.Copy(m, bc.annotationOverrides)
-		bc.ic.Annotations = m
+		// Merge onto the configured annotations, overrides winning per key. A
+		// new map rather than a write in place: bc.ic.Annotations may still be
+		// the map the caller passed to WithImageConfiguration.
+		merged := make(map[string]string, len(bc.ic.Annotations)+len(bc.annotationOverrides))
+		maps.Copy(merged, bc.ic.Annotations)
+		maps.Copy(merged, bc.annotationOverrides)
+		bc.ic.Annotations = merged
 	}
 }
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -36,7 +36,9 @@ import (
 type Option func(*Context) error
 
 // WithConfig sets the image configuration for the build context.
-// The image configuration is parsed from given config file.
+// The image configuration is parsed from given config file. Like
+// WithImageConfiguration it replaces the configuration rather than merging into
+// it.
 // TODO(jason): Remove this.
 func WithConfig(configFile string, includePaths []string) Option {
 	return func(bc *Context) error {
@@ -75,8 +77,9 @@ func WithTarball(path string) Option {
 }
 
 // WithFormat sets the layer payload format ("tar" or "erofs"). The value
-// overrides any format declared in the image configuration. Empty means
-// "leave the configured value alone".
+// overrides any format declared in the image configuration, wherever this
+// Option appears in the slice relative to WithImageConfiguration or
+// WithConfig. Empty means "leave the configured value alone".
 func WithFormat(format string) Option {
 	return func(bc *Context) error {
 		if format == "" {
@@ -86,7 +89,7 @@ func WithFormat(format string) Option {
 		if !f.Valid() {
 			return fmt.Errorf("invalid --format %q (must be %q or %q)", format, types.LayerFormatTar, types.LayerFormatErofs)
 		}
-		bc.ic.Format = f
+		bc.formatOverride = f
 		return nil
 	}
 }
@@ -183,7 +186,10 @@ func WithIncludePaths(includePaths []string) Option {
 }
 
 // WithImageConfiguration sets the ImageConfiguration object
-// to use when building.
+// to use when building. It replaces the configuration rather than merging into
+// it, so any earlier Option that set one of its fields directly is discarded.
+// The field-level Options (WithFormat) are exempt: they are resolved after
+// every Option has been applied.
 func WithImageConfiguration(ic types.ImageConfiguration) Option {
 	return func(bc *Context) error {
 		bc.ic = ic

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -188,8 +188,8 @@ func WithIncludePaths(includePaths []string) Option {
 // WithImageConfiguration sets the ImageConfiguration object
 // to use when building. It replaces the configuration rather than merging into
 // it, so any earlier Option that set one of its fields directly is discarded.
-// The field-level Options (WithFormat) are exempt: they are resolved after
-// every Option has been applied.
+// The field-level Options (WithFormat, WithAnnotations) are exempt: they are
+// resolved after every Option has been applied.
 func WithImageConfiguration(ic types.ImageConfiguration) Option {
 	return func(bc *Context) error {
 		bc.ic = ic
@@ -214,13 +214,14 @@ func WithVCS(enable bool) Option {
 }
 
 // WithAnnotations adds annotations from commandline to those in the config.
-// Commandline annotations take precedence.
+// Commandline annotations take precedence, wherever this Option appears in the
+// slice relative to WithImageConfiguration or WithConfig.
 func WithAnnotations(annotations map[string]string) Option {
 	return func(bc *Context) error {
-		if bc.ic.Annotations == nil {
-			bc.ic.Annotations = make(map[string]string)
+		if bc.annotationOverrides == nil {
+			bc.annotationOverrides = make(map[string]string, len(annotations))
 		}
-		maps.Copy(bc.ic.Annotations, annotations)
+		maps.Copy(bc.annotationOverrides, annotations)
 		return nil
 	}
 }

--- a/pkg/build/options_test.go
+++ b/pkg/build/options_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+// TestWithFormatOrderIndependent pins that WithFormat survives a later
+// WithImageConfiguration, which replaces the whole configuration.
+func TestWithFormatOrderIndependent(t *testing.T) {
+	configured := types.ImageConfiguration{Format: types.LayerFormatTar}
+
+	for _, tc := range []struct {
+		name string
+		opts []Option
+		want types.LayerFormat
+	}{{
+		name: "override before config",
+		opts: []Option{WithFormat("erofs"), WithImageConfiguration(types.ImageConfiguration{})},
+		want: types.LayerFormatErofs,
+	}, {
+		name: "override after config",
+		opts: []Option{WithImageConfiguration(types.ImageConfiguration{}), WithFormat("erofs")},
+		want: types.LayerFormatErofs,
+	}, {
+		name: "override beats configured value",
+		opts: []Option{WithFormat("erofs"), WithImageConfiguration(configured)},
+		want: types.LayerFormatErofs,
+	}, {
+		name: "empty override leaves configured value",
+		opts: []Option{WithFormat(""), WithImageConfiguration(configured)},
+		want: types.LayerFormatTar,
+	}, {
+		name: "no override leaves configured value",
+		opts: []Option{WithImageConfiguration(configured)},
+		want: types.LayerFormatTar,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ic, err := NewOptions(tc.opts...)
+			if err != nil {
+				t.Fatalf("NewOptions: %v", err)
+			}
+			if ic.Format != tc.want {
+				t.Errorf("Format = %q, want %q", ic.Format, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithFormatInvalid(t *testing.T) {
+	if _, _, err := NewOptions(WithFormat("squashfs")); err == nil {
+		t.Error("NewOptions(WithFormat(\"squashfs\")) = nil error, want an error")
+	}
+}

--- a/pkg/build/options_test.go
+++ b/pkg/build/options_test.go
@@ -15,6 +15,7 @@
 package build
 
 import (
+	"maps"
 	"testing"
 
 	"chainguard.dev/apko/pkg/build/types"
@@ -59,6 +60,67 @@ func TestWithFormatOrderIndependent(t *testing.T) {
 				t.Errorf("Format = %q, want %q", ic.Format, tc.want)
 			}
 		})
+	}
+}
+
+// TestWithAnnotationsOrderIndependent pins that WithAnnotations merges into,
+// and takes precedence over, the configured annotations regardless of where it
+// appears relative to WithImageConfiguration.
+func TestWithAnnotationsOrderIndependent(t *testing.T) {
+	override := map[string]string{"a": "override", "b": "added"}
+	configured := func() types.ImageConfiguration {
+		return types.ImageConfiguration{Annotations: map[string]string{"a": "configured", "c": "kept"}}
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts []Option
+		want map[string]string
+	}{{
+		name: "override before config",
+		opts: []Option{WithAnnotations(override), WithImageConfiguration(configured())},
+		want: map[string]string{"a": "override", "b": "added", "c": "kept"},
+	}, {
+		name: "override after config",
+		opts: []Option{WithImageConfiguration(configured()), WithAnnotations(override)},
+		want: map[string]string{"a": "override", "b": "added", "c": "kept"},
+	}, {
+		name: "no override leaves configured annotations",
+		opts: []Option{WithImageConfiguration(configured())},
+		want: map[string]string{"a": "configured", "c": "kept"},
+	}, {
+		name: "empty override leaves configured annotations",
+		opts: []Option{WithAnnotations(nil), WithImageConfiguration(configured())},
+		want: map[string]string{"a": "configured", "c": "kept"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ic, err := NewOptions(tc.opts...)
+			if err != nil {
+				t.Fatalf("NewOptions: %v", err)
+			}
+			if !maps.Equal(ic.Annotations, tc.want) {
+				t.Errorf("Annotations = %v, want %v", ic.Annotations, tc.want)
+			}
+		})
+	}
+}
+
+// TestWithAnnotationsDoesNotMutateCaller checks that resolving the annotations
+// leaves the ImageConfiguration the caller handed to WithImageConfiguration
+// alone; ic is copied by value but its Annotations map is not.
+func TestWithAnnotationsDoesNotMutateCaller(t *testing.T) {
+	caller := types.ImageConfiguration{Annotations: map[string]string{"a": "configured"}}
+
+	if _, _, err := NewOptions(
+		WithImageConfiguration(caller),
+		WithAnnotations(map[string]string{"a": "override", "b": "added"}),
+	); err != nil {
+		t.Fatalf("NewOptions: %v", err)
+	}
+
+	want := map[string]string{"a": "configured"}
+	if !maps.Equal(caller.Annotations, want) {
+		t.Errorf("caller annotations mutated: got %v, want %v", caller.Annotations, want)
 	}
 }
 


### PR DESCRIPTION
* build: make WithAnnotations order-independent
  
  Same fix as the previous commit, for the other field-level Option.
  WithAnnotations copied straight into bc.ic.Annotations, so a later
  WithImageConfiguration or WithConfig replaced the map and dropped the
  annotations entirely. It now records them on the Context and
  resolveImageConfiguration merges them once, after every Option has run,
  which is the ordinary Go shape for functional options: populate an
  intermediate struct, then resolve it into the final configuration.
  
  This makes the code do what pkg/build/options.go has always said it
  does. The doc comment already read "adds annotations from commandline
  to those in the config. Commandline annotations take precedence" --
  true only if the caller happened to order the Options correctly. That
  comment now states the ordering guarantee explicitly, and
  WithImageConfiguration names both field-level Options as exempt from
  being replaced.
  
  Resolving also clones instead of copying in place. Assigning bc.ic
  copies the struct but shares its Annotations map with the caller, so
  the old maps.Copy scribbled into a map the caller still held -- and
  into a map shared by every per-arch Context that NewMultiArch builds
  from one option slice.
  
  Unlike WithFormat, this one has released consumers. Anyone who passed
  WithAnnotations before a whole-config Option was silently getting no
  annotations and will now get them, so the OCI manifest gains entries it
  did not have and the image digest changes. That is the documented
  behavior finally happening, but it is worth a release note for anyone
  asserting on digests.
  
  apko's own CLI is unaffected either way: build.go and publish.go both
  apply WithAnnotations after WithConfig, and the WithImageConfiguration
  that buildImageComponents appends carries an ic that NewOptions already
  derived from the same option slice.
  
* build: make WithFormat order-independent
  
  WithImageConfiguration and WithConfig assign bc.ic outright, so they
  silently discarded the format an earlier WithFormat had asked for. There
  was no error and no empty output: ImageLayoutToLayer branches on
  ic.Format.Resolved(), which defaults to tar, while WithTarball still
  names the output whatever the caller asked for. The result is a
  gzip-framed tar sitting at a path ending in .erofs, which only fails
  later, in whatever reads it.
  
  WithFormat now records the requested format on the Context, and
  resolveImageConfiguration applies it once, after every Option has run.
  This is the ordinary Go shape for functional options -- populate an
  intermediate struct, then resolve it into the final configuration -- as
  in go-containerregistry's remote.makeOptions, which likewise derives
  values and reports option conflicts after the apply loop rather than
  inside individual options. The deviation was the whole-config setters:
  an Option that replaces the entire configuration breaks the invariant
  that each Option owns a disjoint field, and that invariant is what
  makes apply order irrelevant.
  
  pkg/build/options.go now describes this behavior. WithFormat states
  that it wins wherever it appears in the slice, and
  WithImageConfiguration and WithConfig state that they replace the
  configuration rather than merging into it, with the field-level
  overrides exempt.
  
  apko's own CLI was unaffected, but only incidentally:
  buildImageComponents re-injects the ic that NewOptions derived from the
  same option slice, so the discarded value happened to match. Nothing
  tested that. pkg/build/lock.go, meanwhile, appends
  WithImageConfiguration after the caller's options with a
  caller-supplied config, which is unconditionally the losing order; it
  escapes notice only because the format does not affect package
  resolution. The new options_test.go pins both orderings.
  
  WithFormat shipped in 35dcb7e9 and has not been in a release, so no
  consumer can depend on the previous behavior.
