### PR TITLE
erofs: add a privileged CI job that mounts a layer

### DIFF
--- a/.github/workflows/erofs.yaml
+++ b/.github/workflows/erofs.yaml
@@ -31,7 +31,9 @@ jobs:
             9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
             api.github.com:443
             apk.cgr.dev:443
+            archive.ubuntu.com:443
             archive.ubuntu.com:80
+            azure.archive.ubuntu.com:443
             azure.archive.ubuntu.com:80
             dl.google.com:443
             github.com:443
@@ -40,6 +42,7 @@ jobs:
             packages.wolfi.dev:443
             proxy.golang.org:443
             release-assets.githubusercontent.com:443
+            security.ubuntu.com:443
             security.ubuntu.com:80
             spdx.org:443
             storage.googleapis.com:443

--- a/.github/workflows/erofs.yaml
+++ b/.github/workflows/erofs.yaml
@@ -1,0 +1,83 @@
+name: EROFS
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  # Everything else that touches EROFS runs unprivileged and reads the image
+  # back with go-erofs -- the same library that wrote it, so a shared
+  # misunderstanding stays invisible. This job is the only place an
+  # apko-produced EROFS layer meets the kernel driver and the C tools.
+  mount:
+    name: build and mount an erofs layer
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+            api.github.com:443
+            apk.cgr.dev:443
+            archive.ubuntu.com:80
+            azure.archive.ubuntu.com:80
+            dl.google.com:443
+            github.com:443
+            go.dev:443
+            objects.githubusercontent.com:443
+            packages.wolfi.dev:443
+            proxy.golang.org:443
+            release-assets.githubusercontent.com:443
+            security.ubuntu.com:80
+            spdx.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Install erofs-utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends erofs-utils
+          command -v fsck.erofs
+          command -v dump.erofs
+
+      # erofs is a module, not built in, and the runner image does not ship
+      # every module by default. Try the cheap path first and only reach for
+      # the ~50MB linux-modules-extra download if the module is genuinely
+      # absent.
+      - name: Ensure the kernel erofs driver is available
+        run: |
+          if ! grep -qw erofs /proc/filesystems && ! sudo modprobe erofs; then
+            sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+            sudo modprobe erofs
+          fi
+          # Fail here rather than inside the test, where an absent driver would
+          # look like a mount bug.
+          grep -qw erofs /proc/filesystems
+
+      - name: Build, fsck and mount
+        run: |
+          make apko
+          ./hack/test-erofs.sh ./examples/wolfi-base.yaml

--- a/docs/erofs.md
+++ b/docs/erofs.md
@@ -192,6 +192,8 @@ fusermount3 -u /mnt/apko-erofs       # or `fusermount -u`
 
 If `mount` reports "unknown filesystem type 'erofs'", the kernel module is missing on your system; install it (e.g. `linux-modules-extra-$(uname -r)` on Ubuntu) or use `erofsfuse`, which needs no root and works inside CI containers that lack the module.
 
+`hack/test-erofs.sh` runs everything above in one go — build, `fsck.erofs`, kernel mount, and a comparison of `apko erofs ls` against the mounted tree — and is what the `EROFS` CI workflow executes.
+
 ## Pulling from a registry
 
 If you push the image with `apko publish` or `crane push`, the registry stores each blob unchanged — including the EROFS layer blob.

--- a/hack/test-erofs.sh
+++ b/hack/test-erofs.sh
@@ -127,7 +127,12 @@ awk '{
     print line
 }' "${workdir}/ls.raw" | LC_ALL=C sort >"${workdir}/from-apko"
 
-find "${mnt}" -mindepth 1 -printf '%M\t%U/%G\t%P\t%y\t%l\n' |
+# The walk runs privileged.  The image intentionally contains mode-0700
+# directories owned by other uids (root, usr/man, var/adm), which an
+# unprivileged find cannot descend into; `apko erofs ls` reads the image
+# directly and is not subject to that, so the two would disagree for a reason
+# that has nothing to do with apko.
+"${sudo[@]}" find "${mnt}" -mindepth 1 -printf '%M\t%U/%G\t%P\t%y\t%l\n' |
     awk -F'\t' '{
         line = $1 " " $2 " " $3
         if ($4 == "l") line = line " -> " $5

--- a/hack/test-erofs.sh
+++ b/hack/test-erofs.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# End-to-end check of an apko --format=erofs build: the layer blob is a real
+# EROFS filesystem that erofs-utils accepts and the kernel will mount, and
+# `apko erofs ls` reports the same tree the kernel does.
+#
+# Usage: hack/test-erofs.sh <yaml>
+#
+# Example:
+#   hack/test-erofs.sh ./examples/wolfi-base.yaml
+#
+# Requires: jq, erofs-utils (fsck.erofs, dump.erofs), the kernel erofs driver,
+# and root (or passwordless sudo) for the mount.  Set APKO to use a binary
+# other than ./apko.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <yaml>"
+    exit 1
+fi
+
+yaml="$1"
+apko="${APKO:-./apko}"
+name=$(basename "${yaml}" .yaml)
+
+if [ ! -x "${apko}" ]; then
+    echo "no apko binary at ${apko}; run 'make apko' first" >&2
+    exit 1
+fi
+
+for tool in jq fsck.erofs dump.erofs; do
+    command -v "${tool}" >/dev/null || {
+        echo "missing required tool: ${tool}" >&2
+        exit 1
+    }
+done
+
+# Root in a container, sudo on a CI runner.
+if [ "$(id -u)" -eq 0 ]; then
+    sudo=()
+else
+    sudo=(sudo)
+fi
+
+workdir=$(mktemp -d)
+mnt="${workdir}/mnt"
+out="${workdir}/out"
+mkdir -p "${mnt}" "${out}"
+
+mounted=""
+cleanup() {
+    # Unmount before removing anything, on the failure paths too: leaving a
+    # mount behind wedges the rest of the job.
+    [ -n "${mounted}" ] && "${sudo[@]}" umount "${mnt}" || true
+    rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+echo "::group::build ${name} as erofs"
+"${apko}" build "${yaml}" "${name}:build" "${out}/" --format=erofs --arch=host
+echo "::endgroup::"
+
+# Resolve the layer blob through the OCI index, as docs/erofs.md describes.
+[ "$(jq -r '.manifests | length' "${out}/index.json")" = 1 ] ||
+    { echo "expected a single manifest for --arch=host" >&2; exit 1; }
+manifest=$(jq -r '.manifests[0].digest | split(":")[1]' "${out}/index.json")
+[[ "${manifest}" =~ ^[0-9a-f]{64}$ ]] ||
+    { echo "bad manifest digest: ${manifest}" >&2; exit 1; }
+
+# A single layer is what apko produces today; `layering` with `format: erofs`
+# is rejected during validation.  Loosen this when splitting returns.
+[ "$(jq -r '.layers | length' "${out}/blobs/sha256/${manifest}")" = 1 ] ||
+    { echo "expected a single layer" >&2; exit 1; }
+layer=$(jq -r '.layers[0].digest | split(":")[1]' "${out}/blobs/sha256/${manifest}")
+[[ "${layer}" =~ ^[0-9a-f]{64}$ ]] ||
+    { echo "bad layer digest: ${layer}" >&2; exit 1; }
+
+blob="${out}/blobs/sha256/${layer}"
+mediatype=$(jq -r '.layers[0].mediaType' "${out}/blobs/sha256/${manifest}")
+[ "${mediatype}" = "application/vnd.erofs" ] ||
+    { echo "unexpected layer mediaType: ${mediatype}" >&2; exit 1; }
+
+# The blob is stored uncompressed, so digest == diffID == sha256 of the
+# filesystem image itself.  Anything else means a compression step crept in.
+echo "${layer}  ${blob}" | sha256sum -c -
+
+echo "::group::fsck.erofs and dump.erofs"
+fsck.erofs -d3 "${blob}"
+dump.erofs "${blob}" | head -20
+echo "::endgroup::"
+
+echo "::group::kernel mount"
+if ! grep -qw erofs /proc/filesystems; then
+    "${sudo[@]}" modprobe erofs ||
+        { echo "kernel erofs driver unavailable; install linux-modules-extra-$(uname -r)" >&2; exit 1; }
+    grep -qw erofs /proc/filesystems ||
+        { echo "erofs absent from /proc/filesystems after modprobe" >&2; exit 1; }
+fi
+
+"${sudo[@]}" mount -t erofs -o ro "${blob}" "${mnt}"
+mounted=1
+mountpoint -q "${mnt}"
+echo "::endgroup::"
+
+# Cross-check apko's own reader against the kernel's: same paths, same mode
+# bits, same ownership, same symlink targets.  This is what would catch a
+# go-erofs regression in the setuid/setgid/sticky bits, which is the class of
+# bug that motivated the v0.3.1 bump.
+echo "::group::compare 'apko erofs ls' against the mounted tree"
+"${apko}" erofs ls "${out}/" >"${workdir}/ls.raw"
+
+# Both listings are whitespace-delimited, so a path containing a space would
+# silently misalign them.  Fail instead.
+if grep -qE '[[:space:]]$|  +->' "${workdir}/ls.raw"; then
+    echo "unexpected whitespace in listing; comparison would be unreliable" >&2
+    exit 1
+fi
+
+# ls columns: mode uid/gid size date time path [-> target]
+awk '{
+    line = $1 " " $2 " " $6
+    if ($7 == "->") line = line " -> " $8
+    print line
+}' "${workdir}/ls.raw" | LC_ALL=C sort >"${workdir}/from-apko"
+
+find "${mnt}" -mindepth 1 -printf '%M\t%U/%G\t%P\t%y\t%l\n' |
+    awk -F'\t' '{
+        line = $1 " " $2 " " $3
+        if ($4 == "l") line = line " -> " $5
+        print line
+    }' | LC_ALL=C sort >"${workdir}/from-kernel"
+
+if ! diff -u "${workdir}/from-kernel" "${workdir}/from-apko"; then
+    echo "'apko erofs ls' disagrees with the kernel about the layer contents" >&2
+    exit 1
+fi
+echo "$(wc -l <"${workdir}/from-apko") entries agree"
+echo "::endgroup::"
+
+"${sudo[@]}" umount "${mnt}"
+mounted=""
+if mountpoint -q "${mnt}"; then
+    echo "${mnt} still mounted after umount" >&2
+    exit 1
+fi
+
+echo "PASS: ${name} erofs layer mounts and matches 'apko erofs ls'"


### PR DESCRIPTION
First of the section 1 items from #2408, and the one that makes the rest of
them testable.

### Why

Every EROFS check that exists today runs unprivileged and reads the image back
with go-erofs — the same library that wrote it. That arrangement cannot see a
misunderstanding shared by our writer and our reader. `fsck.erofs` appears in
`pkg/build/erofs_test.go` as an optional second opinion, but nothing anywhere
has ever handed an apko-produced EROFS layer to the **kernel** driver.

The pre-descope tree in #2249 didn't either — grepping `.github/` on
`feat/apko-erofs-full` for "erofs" returns nothing. So this is new work rather
than a restore.

### What it does

`hack/test-erofs.sh` follows the recipe `docs/erofs.md` already publishes:
build into an OCI layout with `--format=erofs`, resolve the layer blob through
`index.json` and the manifest, then

1. assert the layer mediaType is `application/vnd.erofs`, and that the blob's
   filename matches sha256 of its own bytes — the layer is stored
   uncompressed, so `digest == diffID`, and a compression step creeping into
   this path fails here;
2. `fsck.erofs -d3` and `dump.erofs` — the C implementation's opinion;
3. `mount -t erofs -o ro` — the kernel's opinion;
4. compare `apko erofs ls` against the mounted tree: path, mode string,
   uid/gid and symlink target, for every entry.

Step 4 is the point of the job. On `examples/wolfi-base` it covers **395
entries**, including a sticky directory (`tmp`), five char devices with rdev,
237 symlinks and several non-root uid/gid pairs. setuid and setgid aren't
present in that fixture; the writer's handling of those stays covered by the
optional `fsck.erofs` checks in `pkg/build/erofs_test.go`.

The comparison is verified to have teeth: fed a listing with the sticky bit
rewritten to `drwxrwxrwx`, the job fails with

```
-drwxrwxrwt 0/0 tmp
+drwxrwxrwx 0/0 tmp
'apko erofs ls' disagrees with the kernel about the layer contents
```

That is the class of bug the go-erofs bump in #2412 was about — `Mkdir`
dropping setuid/setgid/sticky on write and `FileInfo.Mode()` misreporting them
on read.

### Job details

`erofs` is a module rather than built in, and the runner image doesn't ship
every module, so the workflow tries `modprobe` first and only downloads
`linux-modules-extra-$(uname -r)` if the module is genuinely absent. It fails
in that step rather than inside the script, where an absent driver would read
as a mount bug. There is no silent skip — an unavailable driver is a red job,
not a quiet pass.

The script installs nothing itself, so it stays usable locally. Package
installation lives in the workflow.

`sudo` on `ubuntu-latest` is already established practice here:
`go-tests.yaml` installs `erofs-utils` the same way.

### Verification

Ran end-to-end in a privileged `ubuntu:24.04` container against a real kernel
mount, not just dry-read: `fsck.erofs` reports "No errors found", 395 entries
agree, umount is clean. Plus the negative test above.

`shellcheck -e SC2129` clean (matching the actionlint config), `actionlint`
clean, `zizmor --persona pedantic --config .github/zizmor.yml` reports no
findings.

### Not in this PR

The rest of section 1 of #2408: restoring `apko erofs mount`/`umount` with
state-file containment, partial-unmount recovery, a read-only default and a
`Driver` test seam. That work is deliberately second — this job only exercises
what is already on `main`, so it can land green now, and once it is here the
restored `mount` has somewhere to be tested. It will extend this job rather
than add another.

Refs #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)
