### PR TITLE
fix(oci): tolerate an unreadable config when building the index

### DIFF
--- a/pkg/build/oci/index.go
+++ b/pkg/build/oci/index.go
@@ -106,11 +106,14 @@ func generateIndexWithMediaType(mediaType ggcrtypes.MediaType, ic types.ImageCon
 		// requires the feature in both the config and the index platform
 		// descriptor, and §8.2 item 1 has consumers refuse an image whose
 		// os.features they do not implement.
-		cfg, err := img.ConfigFile()
-		if err != nil {
-			return name.Digest{}, nil, fmt.Errorf("failed to get config file: %w", err)
-		}
-		if len(cfg.OSFeatures) > 0 {
+		//
+		// os.features is optional, so an image whose config is not reachable
+		// is not a failure: some callers pass a manifest-only v1.Image that
+		// deliberately serves no config or layer content. Index generation
+		// proceeds without the feature rather than aborting. Images apko
+		// itself builds always carry a readable config, so the §5.4 MUST
+		// still holds for every EROFS image apko produces.
+		if cfg, err := img.ConfigFile(); err == nil && cfg != nil && len(cfg.OSFeatures) > 0 {
 			platform.OSFeatures = slices.Clone(cfg.OSFeatures)
 		}
 

--- a/pkg/build/oci/index_test.go
+++ b/pkg/build/oci/index_test.go
@@ -16,6 +16,7 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -78,6 +79,53 @@ func TestGenerateIndex_PropagatesOSFeatures(t *testing.T) {
 	tarImg := buildImage(t, types.ImageConfiguration{}, ggcrtypes.OCILayer)
 	require.Nil(t, platformOf(t, tarImg).OSFeatures,
 		"tar-format builds must not declare os.features on the index descriptor")
+}
+
+// configlessImage serves a real manifest but refuses every content-reaching
+// method, mirroring a caller that stages only a leg's manifest blob and never
+// its config or layers.
+type configlessImage struct {
+	v1.Image
+}
+
+var errNoContent = errors.New("content not staged")
+
+func (configlessImage) ConfigFile() (*v1.ConfigFile, error) { return nil, errNoContent }
+func (configlessImage) RawConfigFile() ([]byte, error)      { return nil, errNoContent }
+func (configlessImage) Layers() ([]v1.Layer, error)         { return nil, errNoContent }
+
+// os.features is optional, so an unreadable config must not abort index
+// generation -- it only means there is no feature to carry. Reaching for
+// config content unconditionally broke descriptor-plane callers that pass a
+// manifest-only v1.Image; keep that from coming back.
+func TestGenerateIndex_ToleratesUnreadableConfig(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	arch := types.ParseArchitecture("amd64")
+
+	img, err := BuildImageFromLayer(ctx, empty.Image, static.NewLayer([]byte("hello"), ggcrtypes.OCILayer), types.ImageConfiguration{}, now, arch)
+	require.NoError(t, err)
+
+	imgs := map[types.Architecture]v1.Image{arch: configlessImage{Image: img}}
+
+	_, idx, err := GenerateIndex(ctx, types.ImageConfiguration{}, imgs, now)
+	require.NoError(t, err, "an unreadable config must not fail index generation")
+
+	mf, err := idx.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, mf.Manifests, 1)
+	require.NotNil(t, mf.Manifests[0].Platform, "index descriptor has no platform")
+	require.Nil(t, mf.Manifests[0].Platform.OSFeatures,
+		"an unreadable config must not invent os.features")
+	require.Equal(t, arch.ToOCIPlatform(), mf.Manifests[0].Platform,
+		"the descriptor platform must match the plain arch platform")
+
+	// The docker manifest list path shares the same loop.
+	_, didx, err := GenerateDockerIndex(ctx, types.ImageConfiguration{}, imgs, now)
+	require.NoError(t, err, "an unreadable config must not fail docker index generation")
+	dmf, err := didx.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, dmf.Manifests, 1)
 }
 
 // The propagation reads whatever os.features the finished config carries, and


### PR DESCRIPTION
GenerateIndex carries the config's os.features onto the index platform descriptor, added so EROFS images satisfy erofs-image-spec 5.4. It did so with an unconditional img.ConfigFile(), turning any image whose config is not reachable into a hard failure.

os.features is optional, so an unreadable config only means there is no feature to carry. Callers that pass a manifest-only v1.Image -- staging just a leg's index.json and manifest blob, never its config or layers -- worked on v1.2.36 and broke on v1.2.38. For those images the config would have contributed nothing anyway: the descriptor is byte-identical to arch.ToOCIPlatform() either way.

Read the config opportunistically instead. Images apko itself builds always carry a readable config, so the 5.4 MUST still holds for every EROFS image apko produces; the existing propagation tests cover that.

Fixes #2417.