### PR TITLE
erofs: restore multi-layer splitting, with the bugs review found fixed

### DIFF
--- a/docs/apko_file.md
+++ b/docs/apko_file.md
@@ -286,6 +286,6 @@ EROFS layers advertise `erofs` in the image config's `os.features` so consumers 
 
 `format` may also be selected on the command line with `--format=erofs` on `apko build` and `apko publish`. The CLI flag overrides whatever is in the config file.
 
-**Status:** EROFS support is experimental and tracks the draft spec at https://github.com/erofs/erofs-image-spec; media types and annotations may change before the spec reaches a stable release. `format: erofs` produces a single layer: combining it with `layering` is rejected, and compression and dm-verity are not implemented.
+**Status:** EROFS support is experimental and tracks the draft spec at https://github.com/erofs/erofs-image-spec; media types and annotations may change before the spec reaches a stable release. Both single-layer and multi-layer (`layering`) builds are supported. Multi-layer builds emit each non-final layer with `org.erofs.role=overlay-lower` per spec §3.8; the final layer carries no role. Compression and dm-verity are not implemented.
 
 See [erofs.md](erofs.md) for a step-by-step guide to building, inspecting, mounting, and pulling EROFS images.

--- a/docs/erofs.md
+++ b/docs/erofs.md
@@ -229,13 +229,93 @@ Once you have the blob on disk you can inspect or mount it exactly as in the pre
 
 ## Multi-layer builds
 
-Not yet. `format: erofs` currently emits a single layer; combining it with apko's
-[layering](layering.md) configuration is rejected at config-validation time rather
-than silently producing a one-layer image.
+Combine `format: erofs` with apko's [layering](layering.md) configuration to get one EROFS layer per package group plus a top layer for unowned files.
 
-Support for splitting a rootfs into one EROFS layer per package group (each tagged
-`org.erofs.role=overlay-lower` per spec §3.8, with the final layer carrying no role)
-is in progress.
+`erofs-layered.yaml`:
+
+```yaml
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-base
+
+cmd: /bin/sh -l
+archs:
+  - host
+
+layering:
+  strategy: origin
+  budget: 4
+
+format: erofs
+```
+
+```sh
+mkdir -p out-layered
+apko build erofs-layered.yaml apko-erofs-layered:latest out-layered/ --arch=host
+```
+
+Inspect the manifest:
+
+```sh
+MANIFEST=$(jq -r '.manifests[0].digest | split(":")[1]' out-layered/index.json)
+jq '.layers[] | {mediaType, role: .annotations["org.erofs.role"]}' out-layered/blobs/sha256/$MANIFEST
+```
+
+Expected (last layer carries no role per spec §3.8 rule 1):
+
+```json
+{ "mediaType": "application/vnd.erofs", "role": "overlay-lower" }
+{ "mediaType": "application/vnd.erofs", "role": "overlay-lower" }
+{ "mediaType": "application/vnd.erofs", "role": "overlay-lower" }
+{ "mediaType": "application/vnd.erofs", "role": "overlay-lower" }
+{ "mediaType": "application/vnd.erofs", "role": null }
+```
+
+Each layer is independently mountable as an EROFS filesystem, and each carries its own partial `usr/lib/apk/db/installed` so per-layer scanners (Trivy, Snyk, Grype) can identify the packages it contributes.
+
+### Assemble the full rootfs with overlayfs
+
+The OCI spec composes layers with `overlayfs`-style semantics; for EROFS layers the composition is straightforward — mount each layer read-only, then stack them as `lowerdir`s:
+
+```sh
+# Pull each layer blob out of the OCI layout.
+BLOBS=$(pwd)/out-layered/blobs/sha256
+MANIFEST=$(jq -r '.manifests[0].digest | split(":")[1]' out-layered/index.json)
+mkdir -p mnt/{merged,work,upper}
+
+# Mount every layer; build the overlay lowerdir as we go. overlayfs lists
+# lowerdirs top-down (highest priority first), while OCI orders layers
+# bottom-up (index 0 is the base), so prepend each new layer.
+LOWERS=
+i=0
+for d in $(jq -r '.layers[].digest | split(":")[1]' "$BLOBS/$MANIFEST"); do
+  mp=mnt/lower$(printf %02d $i)
+  mkdir -p "$mp"
+  sudo mount -t erofs -o ro "$BLOBS/$d" "$mp" 2>/dev/null || \
+    erofsfuse "$BLOBS/$d" "$mp"
+  LOWERS="$mp${LOWERS:+:$LOWERS}"
+  i=$((i+1))
+done
+
+sudo mount -t overlay overlay \
+  -o "lowerdir=$LOWERS,upperdir=mnt/upper,workdir=mnt/work" \
+  mnt/merged
+
+ls mnt/merged/   # full rootfs
+```
+
+Clean up:
+
+```sh
+sudo umount mnt/merged
+for d in mnt/lower*; do sudo umount "$d" 2>/dev/null || fusermount -u "$d"; done
+```
+
+Production runtimes (containerd's erofs snapshotter, podman/CRI-O with the erofs-aware plugin, etc.) automate this assembly; the steps above are for verifying that an apko-built EROFS image really does compose into a valid rootfs.
 
 ## Using EROFS support as a Go library
 
@@ -268,11 +348,10 @@ For inspection, apko *does* expose a focused leaf library — see `chainguard.de
 
 ## Current limitations
 
-- **Single layer only.** `layering` and `format: erofs` cannot be combined yet; see [Multi-layer builds](#multi-layer-builds) above.
 - **No compression.** apko emits raw `application/vnd.erofs` layers only. The draft spec defines `application/vnd.erofs+zstd` but neither apko's writer nor the underlying go-erofs library writes compressed images yet.
 - **No dm-verity.** The spec's verified-mount path (§3.5) is not produced.
 - **No chunk index.** Lazy-loading runtimes (per spec §3.4) won't get an index; reads are sequential.
-- **No `overlay-data` or `device` roles.** apko emits one unannotated EROFS layer; `org.erofs.role` is never set.
+- **No `overlay-data` or `device` roles.** Only `overlay-lower` (and unannotated final) layers are emitted.
 - **Hardlinks become independent copies.** go-erofs has no API to point two names at one inode, so each link costs another full copy of the file's data (rounded up to the block size) and `st_nlink`/`st_ino` identity is lost. Spec §3.7's materialize-or-fail rule covers *cross-layer* hardlinks; within a single layer the spec is silent, so this is conformant but not blessed by that section. Either way, a hardlink-heavy image will be larger as EROFS than as tar, where extra links are zero-byte entries.
 - **Spec is draft.** Media-type strings and annotation keys may change before the spec stabilizes. Treat any image built today as experimental.
 

--- a/docs/erofs.md
+++ b/docs/erofs.md
@@ -352,7 +352,7 @@ For inspection, apko *does* expose a focused leaf library — see `chainguard.de
 - **No dm-verity.** The spec's verified-mount path (§3.5) is not produced.
 - **No chunk index.** Lazy-loading runtimes (per spec §3.4) won't get an index; reads are sequential.
 - **No `overlay-data` or `device` roles.** Only `overlay-lower` (and unannotated final) layers are emitted.
-- **Hardlinks become independent copies.** go-erofs has no API to point two names at one inode, so each link costs another full copy of the file's data (rounded up to the block size) and `st_nlink`/`st_ino` identity is lost. Spec §3.7's materialize-or-fail rule covers *cross-layer* hardlinks; within a single layer the spec is silent, so this is conformant but not blessed by that section. Either way, a hardlink-heavy image will be larger as EROFS than as tar, where extra links are zero-byte entries.
+- **Hardlinks become independent copies.** apko's EROFS writer materializes each link as its own inode, so it costs another full copy of the file's data (rounded up to the block size) and `st_nlink`/`st_ino` identity is lost. Spec §3.7's materialize-or-fail rule covers *cross-layer* hardlinks; within a single layer the spec is silent, so this is conformant but not blessed by that section. Either way, a hardlink-heavy image will be larger as EROFS than as tar, where extra links are zero-byte entries.
 - **Spec is draft.** Media-type strings and annotation keys may change before the spec stabilizes. Treat any image built today as experimental.
 
 If you need any of the above, please open an issue.

--- a/hack/test-erofs.sh
+++ b/hack/test-erofs.sh
@@ -427,6 +427,11 @@ while read -r digest; do
     # group's files -- not just the ancestor directories and the partial
     # installed db it needs to describe them.  This is the shape the routing
     # bug produced.
+    #
+    # This assumes every group contributes at least one regular file besides
+    # that db, which holds for the default config.  A group of packages that
+    # ship only symlinks would false-fail here; relax it to "-type f -o -type
+    # l" if you point the script at a yaml where that happens.
     if [ "${i}" -lt "$((nlayers - 1))" ]; then
         found=$("${sudo[@]}" find "${lmnt}" -type f \
             ! -path "${lmnt}/usr/lib/apk/db/installed" -print -quit)

--- a/hack/test-erofs.sh
+++ b/hack/test-erofs.sh
@@ -469,7 +469,10 @@ tmanifest="${tout}/blobs/sha256/${tmanifest}"
 while read -r digest; do
     [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
         fail "bad tar layer digest: ${digest}"
-    "${sudo[@]}" tar -C "${tarroot}" -xpf "${tout}/blobs/sha256/${digest#sha256:}"
+    # --numeric-owner or GNU tar resolves the layer's uname/gname against the
+    # runner's /etc/passwd, which has its own ids for lp, mail, news and uucp.
+    "${sudo[@]}" tar -C "${tarroot}" --numeric-owner -xpf \
+        "${tout}/blobs/sha256/${digest#sha256:}"
 done < <(jq -r '.layers[].digest' "${tmanifest}")
 
 tree_listing "${tarroot}" >"${workdir}/from-tar"

--- a/hack/test-erofs.sh
+++ b/hack/test-erofs.sh
@@ -8,6 +8,9 @@
 # `apko erofs ls` reports the same tree the kernel does, and
 # `apko erofs mount` / `apko erofs umount` drive that mount themselves.
 #
+# The same yaml is then built again with `layering`, and the check repeats
+# against the overlayfs stack the kernel assembles from those layers.
+#
 # Usage: hack/test-erofs.sh <yaml>
 #
 # Example:
@@ -115,6 +118,14 @@ plant_state() {
     }' >"$1/${state}"
 }
 
+# Both listings are whitespace-delimited, so a path containing a space would
+# silently misalign them.  Fail instead.
+check_ls_whitespace() {
+    if grep -qE '[[:space:]]$|  +->' "$1"; then
+        fail "unexpected whitespace in listing; comparison would be unreliable"
+    fi
+}
+
 # Both listings below collapse to "mode uid/gid path [-> target]" so they can
 # be diffed.  `apko erofs ls` columns: mode uid/gid size date time path
 # [-> target].
@@ -151,8 +162,7 @@ manifest=$(jq -r '.manifests[0].digest | split(":")[1]' "${out}/index.json")
 [[ "${manifest}" =~ ^[0-9a-f]{64}$ ]] ||
     { echo "bad manifest digest: ${manifest}" >&2; exit 1; }
 
-# A single layer is what apko produces today; `layering` with `format: erofs`
-# is rejected during validation.  Loosen this when splitting returns.
+# Without `layering` in the config, apko emits exactly one layer.
 [ "$(jq -r '.layers | length' "${out}/blobs/sha256/${manifest}")" = 1 ] ||
     { echo "expected a single layer" >&2; exit 1; }
 layer=$(jq -r '.layers[0].digest | split(":")[1]' "${out}/blobs/sha256/${manifest}")
@@ -191,13 +201,7 @@ echo "::endgroup::"
 # bug that motivated the v0.3.1 bump.
 echo "::group::compare 'apko erofs ls' against the mounted tree"
 "${apko}" erofs ls "${out}/" >"${workdir}/ls.raw"
-
-# Both listings are whitespace-delimited, so a path containing a space would
-# silently misalign them.  Fail instead.
-if grep -qE '[[:space:]]$|  +->' "${workdir}/ls.raw"; then
-    echo "unexpected whitespace in listing; comparison would be unreliable" >&2
-    exit 1
-fi
+check_ls_whitespace "${workdir}/ls.raw"
 
 normalize_ls <"${workdir}/ls.raw" >"${workdir}/from-apko"
 tree_listing "${mnt}" >"${workdir}/from-kernel"
@@ -341,5 +345,146 @@ assert_mounted "${decoy}"
 "${sudo[@]}" umount "${decoy}"
 echo "::endgroup::"
 
-echo "PASS: ${name} erofs layer mounts, matches 'apko erofs ls', and round-trips"
-echo "      through 'apko erofs mount' / 'apko erofs umount'"
+########################################################################
+# Multi-layer: the same rootfs split across one EROFS layer per package
+# group.  Nothing else executes the split against a real kernel, and the
+# overlay stack is the only thing that shows whether the layers actually
+# compose back into the rootfs they came from.
+########################################################################
+
+layered_yaml="${workdir}/layered.yaml"
+cp "${yaml}" "${layered_yaml}"
+if ! grep -qE '^layering:' "${layered_yaml}"; then
+    cat >>"${layered_yaml}" <<'EOF'
+
+layering:
+  strategy: origin
+  budget: 4
+EOF
+fi
+
+lout="${workdir}/out-layered"
+tout="${workdir}/out-tar"
+mkdir -p "${lout}" "${tout}"
+
+# The tar build of the same config is the reference for what the split must
+# preserve.  Both builds resolve from one lockfile, so a package published
+# between them cannot make them differ.
+lock="${workdir}/apko.lock.json"
+
+echo "::group::build ${name} as layered erofs, and as layered tar to compare"
+"${apko}" lock "${layered_yaml}" --output "${lock}" --arch=host
+"${apko}" build "${layered_yaml}" "${name}:layered" "${lout}/" \
+    --format=erofs --arch=host --lockfile "${lock}"
+"${apko}" build "${layered_yaml}" "${name}:layered-tar" "${tout}/" \
+    --arch=host --lockfile "${lock}"
+echo "::endgroup::"
+
+lmanifest=$(jq -r '.manifests[0].digest | split(":")[1]' "${lout}/index.json")
+[[ "${lmanifest}" =~ ^[0-9a-f]{64}$ ]] ||
+    fail "bad layered manifest digest: ${lmanifest}"
+lmanifest="${lout}/blobs/sha256/${lmanifest}"
+
+nlayers=$(jq -r '.layers | length' "${lmanifest}")
+[ "${nlayers}" -gt 1 ] ||
+    fail "expected more than one layer with layering, got ${nlayers}"
+
+# Spec §3.8 rule 1 as apko produces it: every layer but the last is an
+# overlay-lower, the last carries no role at all.
+roles=$(jq -r '.layers[] | .annotations["org.erofs.role"] // "null"' "${lmanifest}")
+expected=$(
+    for ((i = 1; i < nlayers; i++)); do echo overlay-lower; done
+    echo null
+)
+[ "${roles}" = "${expected}" ] || {
+    echo "unexpected layer roles:" >&2
+    printf '%s\n' "${roles}" >&2
+    exit 1
+}
+
+echo "::group::mount ${nlayers} layers and stack them"
+# overlayfs lists lowerdirs top-down (highest priority first) while OCI orders
+# layers bottom-up, so each new layer is prepended.
+lowers=""
+i=0
+while read -r digest; do
+    [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+        fail "bad layer digest: ${digest}"
+    lblob="${lout}/blobs/sha256/${digest#sha256:}"
+
+    mediatype=$(jq -r ".layers[${i}].mediaType" "${lmanifest}")
+    [ "${mediatype}" = "application/vnd.erofs" ] ||
+        fail "unexpected mediaType on layer ${i}: ${mediatype}"
+    echo "${digest#sha256:}  ${lblob}" | sha256sum -c -
+    fsck.erofs -d3 "${lblob}" >/dev/null
+
+    lmnt=$(printf '%s/layer%02d' "${workdir}" "${i}")
+    mkdir -p "${lmnt}"
+    "${sudo[@]}" mount -t erofs -o ro "${lblob}" "${lmnt}"
+    assert_mounted "${lmnt}"
+
+    # Every layer but the top one holds a package group, so it must carry that
+    # group's files -- not just the ancestor directories and the partial
+    # installed db it needs to describe them.  This is the shape the routing
+    # bug produced.
+    if [ "${i}" -lt "$((nlayers - 1))" ]; then
+        found=$("${sudo[@]}" find "${lmnt}" -type f \
+            ! -path "${lmnt}/usr/lib/apk/db/installed" -print -quit)
+        [ -n "${found}" ] || fail "layer ${i} holds no package files"
+    fi
+
+    lowers="${lmnt}${lowers:+:${lowers}}"
+    i=$((i + 1))
+done < <(jq -r '.layers[].digest' "${lmanifest}")
+
+merged="${workdir}/merged"
+mkdir -p "${merged}"
+# No upperdir, so the overlay is read-only, which is all this needs and keeps
+# a stray write from ending up in the comparison.
+"${sudo[@]}" mount -t overlay overlay -o "ro,lowerdir=${lowers}" "${merged}"
+assert_mounted "${merged}"
+echo "::endgroup::"
+
+echo "::group::compare 'apko erofs ls' against the overlay stack"
+"${apko}" erofs ls "${lout}/" >"${workdir}/ls-layered.raw"
+check_ls_whitespace "${workdir}/ls-layered.raw"
+normalize_ls <"${workdir}/ls-layered.raw" >"${workdir}/from-apko-layered"
+tree_listing "${merged}" >"${workdir}/from-kernel-layered"
+
+if ! diff -u "${workdir}/from-kernel-layered" "${workdir}/from-apko-layered"; then
+    fail "'apko erofs ls' disagrees with overlayfs about the merged tree"
+fi
+echo "$(wc -l <"${workdir}/from-apko-layered") entries agree across ${nlayers} layers"
+echo "::endgroup::"
+
+# The tar split of the same config is the reference: unpacking its layers in
+# order reproduces the rootfs both formats started from.  A directory that
+# reaches no EROFS layer, or a file routed into a layer something else
+# shadows, shows up here and nowhere else in this script.
+echo "::group::compare the merged tree against the tar build of the same config"
+tarroot="${workdir}/tarroot"
+mkdir -p "${tarroot}"
+tmanifest=$(jq -r '.manifests[0].digest | split(":")[1]' "${tout}/index.json")
+tmanifest="${tout}/blobs/sha256/${tmanifest}"
+while read -r digest; do
+    [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+        fail "bad tar layer digest: ${digest}"
+    "${sudo[@]}" tar -C "${tarroot}" -xpf "${tout}/blobs/sha256/${digest#sha256:}"
+done < <(jq -r '.layers[].digest' "${tmanifest}")
+
+tree_listing "${tarroot}" >"${workdir}/from-tar"
+if ! diff -u "${workdir}/from-tar" "${workdir}/from-apko-layered"; then
+    fail "the merged EROFS tree differs from the tar build of the same config"
+fi
+echo "::endgroup::"
+
+"${sudo[@]}" umount "${merged}"
+assert_not_mounted "${merged}"
+for ((i = nlayers - 1; i >= 0; i--)); do
+    lmnt=$(printf '%s/layer%02d' "${workdir}" "${i}")
+    "${sudo[@]}" umount "${lmnt}"
+    assert_not_mounted "${lmnt}"
+done
+
+echo "PASS: ${name} erofs layers mount, match 'apko erofs ls' single and layered,"
+echo "      and round-trip through 'apko erofs mount' / 'apko erofs umount'"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -201,7 +201,7 @@ func (bc *Context) ImageLayoutToLayer(ctx context.Context) (string, v1.Layer, er
 		// *os.File does no userspace buffering, so once Close returns, a fresh
 		// Open sees every byte.
 		outName := outfile.Name()
-		if err := writeErofs(ctx, outfile, bc.fs, bc.o.SourceDateEpoch); err != nil {
+		if err := writeErofs(ctx, outfile, bc.fs, bc.o.TempDir(), bc.o.SourceDateEpoch); err != nil {
 			_ = outfile.Close()
 			return "", nil, fmt.Errorf("generating erofs image: %w", err)
 		}

--- a/pkg/build/erofs.go
+++ b/pkg/build/erofs.go
@@ -250,6 +250,25 @@ func uidGidFromInfo(info fs.FileInfo) (int, int) {
 	return 0, 0
 }
 
+// newErofsLayerFile creates a temp file backing a single EROFS layer. The
+// caller is responsible for closing and removing it. Permissions are 0600 to
+// keep intermediate build artifacts off other users' eyes.
+func newErofsLayerFile(tmpdir, pattern string) (*os.File, error) {
+	if pattern == "" {
+		pattern = "apko-erofs-*.bin"
+	}
+	f, err := os.CreateTemp(tmpdir, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, err
+	}
+	return f, nil
+}
+
 // buildErofsLayerFromFile takes a finalized EROFS image already serialized to
 // path and returns a v1.Layer wrapping it. For the raw `application/vnd.erofs`
 // media type the DiffID and Digest are identical: the SHA-256 of the on-wire

--- a/pkg/build/erofs.go
+++ b/pkg/build/erofs.go
@@ -42,12 +42,16 @@ import (
 // buildTime sets the EROFS image build time, which seeds per-entry mtime
 // defaulting and is recorded in the superblock. It is always passed through, so
 // the image is reproducible for any caller; see erofsBuildTime.
-func writeErofs(ctx context.Context, out io.WriteSeeker, fsys apkfs.FullFS, buildTime time.Time) error {
+//
+// tmpdir is where go-erofs spools regular file data: an unlinked file it holds
+// open until Close, roughly the size of the rootfs. Left unset it lands in the
+// system temp dir, which is not the volume the caller sized for this build.
+func writeErofs(ctx context.Context, out io.WriteSeeker, fsys apkfs.FullFS, tmpdir string, buildTime time.Time) error {
 	ctx, span := otel.Tracer("apko").Start(ctx, "writeErofs")
 	defer span.End()
 
 	sec, nsec := erofsBuildTime(buildTime)
-	w := erofs.Create(out, erofs.WithBuildTime(sec, nsec))
+	w := erofs.Create(out, erofs.WithBuildTime(sec, nsec), erofs.WithTempDir(tmpdir))
 
 	buf := make([]byte, 1<<20)
 

--- a/pkg/build/erofs_dirfs_test.go
+++ b/pkg/build/erofs_dirfs_test.go
@@ -47,7 +47,7 @@ func TestWriteErofs_DirFS(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "image.erofs")
 	f, err := os.Create(out)
 	require.NoError(t, err)
-	require.NoError(t, writeErofs(ctx, f, fsys, epoch))
+	require.NoError(t, writeErofs(ctx, f, fsys, t.TempDir(), epoch))
 	require.NoError(t, f.Close())
 
 	rf, err := os.Open(out)

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -288,14 +288,15 @@ func newErofsGroupWriter(tmpdir string, buildTime time.Time) (*erofsGroupWriter,
 	if err != nil {
 		return nil, err
 	}
-	var createOpts []erofs.CreateOpt
-	if !buildTime.IsZero() {
-		createOpts = append(createOpts, erofs.WithBuildTime(uint64(buildTime.Unix()), uint32(buildTime.Nanosecond())))
-	}
+	// Always pass the build time, exactly as writeErofs does: omitting it
+	// makes go-erofs stamp time.Now() into the superblock from Close, so a
+	// caller who left the timestamp zero would get different layer digests on
+	// every build. See erofsBuildTime for the clamp.
+	sec, nsec := erofsBuildTime(buildTime)
 	return &erofsGroupWriter{
 		path:    f.Name(),
 		file:    f,
-		w:       erofs.Create(f, createOpts...),
+		w:       erofs.Create(f, erofs.WithBuildTime(sec, nsec)),
 		emitted: map[string]bool{},
 	}, nil
 }

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -93,7 +93,18 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 
 	// emitAncestors makes sure every ancestor of absPath (excluding "/" and
 	// absPath itself) has been created in gw with the correct metadata.
-	emitAncestors := func(gw *erofsGroupWriter, absPath string) error {
+	//
+	// modTime is the mtime of the entry the ancestors are being created for,
+	// and it overrides each ancestor's own. splitLayers does the same for the
+	// directories alignStacks replicates, and for the same reason: several
+	// packages usually share a directory, only one of their mtimes survives
+	// into the merged view, and copying that winner into a group layer makes
+	// the layer's bytes -- and so its digest -- depend on packages outside the
+	// group. The owning layer still carries the faithful mtime, and it is the
+	// one that wins on merge, so nothing observable changes. SOURCE_DATE_EPOCH
+	// does not cover this: it seeds the superblock, scripts.tar, the installed
+	// db and the config, not per-entry mtimes.
+	emitAncestors := func(gw *erofsGroupWriter, absPath string, modTime time.Time) error {
 		if absPath == "/" {
 			return nil
 		}
@@ -117,7 +128,7 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 				gw.emitted[anc] = true
 				continue
 			}
-			if err := emitErofsEntry(gw.w, anc, dirFsysPath[anc], info, fsys, buf); err != nil {
+			if err := emitErofsEntry(gw.w, anc, dirFsysPath[anc], normalizedModTime{info, modTime}, fsys, buf); err != nil {
 				return fmt.Errorf("emit ancestor %s: %w", anc, err)
 			}
 			gw.emitted[anc] = true
@@ -196,7 +207,7 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 			if err != nil {
 				return err
 			}
-			if err := emitAncestors(owner, absPath); err != nil {
+			if err := emitAncestors(owner, absPath, info.ModTime()); err != nil {
 				return err
 			}
 			if owner.emitted[absPath] {
@@ -221,7 +232,7 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 		if strings.TrimPrefix(absPath, "/") == "usr/lib/apk/db/installed" {
 			for _, g := range groups {
 				gw := groupToWriter[g]
-				if err := emitAncestors(gw, absPath); err != nil {
+				if err := emitAncestors(gw, absPath, info.ModTime()); err != nil {
 					return err
 				}
 				var idb bytes.Buffer
@@ -239,7 +250,7 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 			// path below.
 		}
 
-		if err := emitAncestors(owner, absPath); err != nil {
+		if err := emitAncestors(owner, absPath, info.ModTime()); err != nil {
 			return err
 		}
 		if err := emitErofsEntry(owner.w, absPath, fpath, info, fsys, buf); err != nil {
@@ -272,6 +283,15 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 	done = true
 	return layers, nil
 }
+
+// normalizedModTime is a FileInfo with its ModTime replaced. Sys() is
+// forwarded, so uid/gid still come from the source *tar.Header.
+type normalizedModTime struct {
+	fs.FileInfo
+	mtime time.Time
+}
+
+func (n normalizedModTime) ModTime() time.Time { return n.mtime }
 
 // erofsGroupWriter is one output layer under construction: a go-erofs Writer
 // over a temp file, plus the set of paths already written into it.

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -145,6 +145,35 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 		return nil
 	}
 
+	// ownerOf picks the writer an entry belongs in: the group that owns its
+	// package, or top for anything unowned.
+	//
+	// The assertion is on the FileInfo itself, not on info.Sys(). pkg/tarfs --
+	// what a real build walks -- hangs Package() off its FileInfo and returns a
+	// fresh *tar.Header from Sys(), which has no Package method, so asserting
+	// on Sys() routes every file to top. splitLayers asserts on the same
+	// receiver this does.
+	ownerOf := func(info fs.FileInfo, fpath string) (*erofsGroupWriter, error) {
+		pkger, ok := info.(interface {
+			Package() *apk.Package
+		})
+		if !ok {
+			return top, nil
+		}
+		pkg := pkger.Package()
+		if pkg == nil {
+			return top, nil
+		}
+		gw, ok := packageToWriter[pkg.Name]
+		if !ok {
+			// splitLayers panics on this; either way it has to be loud.
+			// Falling back to top would hide a grouping bug behind an image
+			// that looks fine and is laid out wrong.
+			return nil, fmt.Errorf("no layer for package %q, which owns %s", pkg.Name, fpath)
+		}
+		return gw, nil
+	}
+
 	if err := fs.WalkDir(fsys, ".", func(fpath string, d fs.DirEntry, err error) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
@@ -180,18 +209,9 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 			return nil
 		}
 
-		// Default to the top layer.
-		owner := top
-
-		// If the file info exposes its owning package, route to that group.
-		if pkger, ok := info.Sys().(interface {
-			Package() *apk.Package
-		}); ok {
-			if pkg := pkger.Package(); pkg != nil {
-				if gw, ok := packageToWriter[pkg.Name]; ok {
-					owner = gw
-				}
-			}
+		owner, err := ownerOf(info, fpath)
+		if err != nil {
+			return err
 		}
 
 		// Special-case the apk installed db: each group also gets a partial

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -189,9 +189,6 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 		}
 
 		if d.IsDir() {
-			// Record metadata; don't emit yet. Each writer creates this
-			// directory lazily the first time it needs to write something
-			// beneath it.
 			if absPath == "/" {
 				// The root of every EROFS image exists implicitly; still set
 				// its metadata across all writers (so uid/gid/xattrs match
@@ -204,8 +201,31 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 				}
 				return nil
 			}
+			// Record the metadata so any other writer that needs this
+			// directory as an ancestor can recreate it faithfully.
 			dirInfo[absPath] = info
 			dirFsysPath[absPath] = fpath
+
+			// Then emit it into its own owner right away. Leaving it to
+			// emitAncestors, which only runs for non-directory entries, drops
+			// every directory whose subtree holds no file at all -- /tmp,
+			// /run, /var/empty, every mount point -- from all layers, and so
+			// from the merged view. writeErofs and splitLayers both write
+			// every directory they walk.
+			owner, err := ownerOf(info, fpath)
+			if err != nil {
+				return err
+			}
+			if err := emitAncestors(owner, absPath); err != nil {
+				return err
+			}
+			if owner.emitted[absPath] {
+				return nil
+			}
+			if err := emitErofsEntry(owner.w, absPath, fpath, info, fsys, buf); err != nil {
+				return err
+			}
+			owner.emitted[absPath] = true
 			return nil
 		}
 

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+	"time"
+
+	erofs "github.com/erofs/go-erofs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build/types"
+)
+
+// splitErofsLayers is the EROFS analogue of splitLayers. It walks fsys once,
+// emitting each entry into the per-package group writer that owns it (or the
+// top writer for unowned entries). Each group becomes one EROFS layer tagged
+// with role=overlay-lower per the draft erofs/erofs-image-spec §3.8; the top
+// (final) layer carries no role per the same rule.
+//
+// Unlike tar's flat-stream model, EROFS images carry an inode table, so we
+// keep per-writer state for which directories have already been emitted and
+// only emit each directory once per writer. The fs.WalkDir guarantee that
+// ancestors are visited before descendants lets us record directory metadata
+// the first time we see it and reuse it when a child needs the ancestor to
+// exist in a writer.
+func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, pkgToDiff map[*apk.Package][]byte, tmpdir string, buildTime time.Time) ([]v1.Layer, error) {
+	buf := make([]byte, 1<<20)
+
+	type erofsGroupWriter struct {
+		path    string
+		w       *erofs.Writer
+		closer  func() error
+		emitted map[string]bool // absPath -> already emitted into this writer
+		pkgs    map[string]bool // package names owned by this group
+	}
+
+	newWriter := func() (*erofsGroupWriter, error) {
+		f, err := newErofsLayerFile(tmpdir, "apko-erofs-*.bin")
+		if err != nil {
+			return nil, err
+		}
+		var createOpts []erofs.CreateOpt
+		if !buildTime.IsZero() {
+			createOpts = append(createOpts, erofs.WithBuildTime(uint64(buildTime.Unix()), uint32(buildTime.Nanosecond())))
+		}
+		gw := &erofsGroupWriter{
+			path:    f.Name(),
+			w:       erofs.Create(f, createOpts...),
+			emitted: map[string]bool{},
+			pkgs:    map[string]bool{},
+		}
+		// Close the file only after closing the erofs writer (which may seek
+		// back to rewrite the superblock).
+		gw.closer = func() error {
+			if err := gw.w.Close(); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("finalizing erofs image %s: %w", f.Name(), err)
+			}
+			return f.Close()
+		}
+		return gw, nil
+	}
+
+	// One writer per group, plus a top writer for entries not owned by any
+	// package.
+	packageToWriter := map[string]*erofsGroupWriter{}
+	groupToWriter := map[*group]*erofsGroupWriter{}
+	writers := make([]*erofsGroupWriter, 0, len(groups)+1)
+
+	for _, g := range groups {
+		gw, err := newWriter()
+		if err != nil {
+			return nil, err
+		}
+		writers = append(writers, gw)
+		groupToWriter[g] = gw
+		for _, pkg := range g.pkgs {
+			packageToWriter[pkg.Name] = gw
+			gw.pkgs[pkg.Name] = true
+		}
+	}
+	top, err := newWriter()
+	if err != nil {
+		return nil, err
+	}
+	writers = append(writers, top)
+
+	// Record dir metadata as we go so we can recreate ancestors in any
+	// writer that needs them. Keyed by the absolute (writer-side) path.
+	dirInfo := map[string]fs.FileInfo{}
+	dirFsysPath := map[string]string{} // absPath -> source path (for xattr lookup)
+
+	// emitAncestors makes sure every ancestor of absPath (excluding "/" and
+	// absPath itself) has been created in gw with the correct metadata.
+	emitAncestors := func(gw *erofsGroupWriter, absPath string) error {
+		if absPath == "/" {
+			return nil
+		}
+		// Build the list of ancestor paths from shallowest to deepest.
+		var parts []string
+		p := path.Dir(absPath)
+		for p != "/" && p != "." {
+			parts = append([]string{p}, parts...)
+			p = path.Dir(p)
+		}
+		for _, anc := range parts {
+			if gw.emitted[anc] {
+				continue
+			}
+			info, ok := dirInfo[anc]
+			if !ok {
+				// Defensive: should never happen with fs.WalkDir ordering.
+				if err := gw.w.Mkdir(anc, 0o755); err != nil {
+					return fmt.Errorf("mkdir ancestor %s: %w", anc, err)
+				}
+				gw.emitted[anc] = true
+				continue
+			}
+			if err := emitErofsEntry(gw.w, anc, dirFsysPath[anc], info, fsys, buf); err != nil {
+				return fmt.Errorf("emit ancestor %s: %w", anc, err)
+			}
+			gw.emitted[anc] = true
+		}
+		return nil
+	}
+
+	if err := fs.WalkDir(fsys, ".", func(fpath string, d fs.DirEntry, err error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if err != nil {
+			return err
+		}
+
+		absPath := erofsAbsPath(fpath)
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", fpath, err)
+		}
+
+		if d.IsDir() {
+			// Record metadata; don't emit yet. Each writer creates this
+			// directory lazily the first time it needs to write something
+			// beneath it.
+			if absPath == "/" {
+				// The root of every EROFS image exists implicitly; still set
+				// its metadata across all writers (so uid/gid/xattrs match
+				// the source rootfs).
+				for _, gw := range writers {
+					if err := emitErofsEntry(gw.w, absPath, fpath, info, fsys, buf); err != nil {
+						return err
+					}
+					gw.emitted[absPath] = true
+				}
+				return nil
+			}
+			dirInfo[absPath] = info
+			dirFsysPath[absPath] = fpath
+			return nil
+		}
+
+		// Default to the top layer.
+		owner := top
+
+		// If the file info exposes its owning package, route to that group.
+		if pkger, ok := info.Sys().(interface {
+			Package() *apk.Package
+		}); ok {
+			if pkg := pkger.Package(); pkg != nil {
+				if gw, ok := packageToWriter[pkg.Name]; ok {
+					owner = gw
+				}
+			}
+		}
+
+		// Special-case the apk installed db: each group also gets a partial
+		// installed db containing only its own packages, so per-layer
+		// scanners (Trivy, Snyk, etc.) can identify the layer's contents.
+		// This matches splitLayers' behavior for tar layers.
+		if strings.TrimPrefix(absPath, "/") == "usr/lib/apk/db/installed" {
+			for _, g := range groups {
+				gw := groupToWriter[g]
+				if err := emitAncestors(gw, absPath); err != nil {
+					return err
+				}
+				var idb bytes.Buffer
+				for _, pkg := range g.pkgs {
+					if _, err := idb.Write(pkgToDiff[pkg]); err != nil {
+						return err
+					}
+				}
+				if err := writeErofsRegularBytes(gw.w, absPath, info, idb.Bytes()); err != nil {
+					return err
+				}
+				gw.emitted[absPath] = true
+			}
+			// The top layer also gets the full installed db via the normal
+			// path below.
+		}
+
+		if err := emitAncestors(owner, absPath); err != nil {
+			return err
+		}
+		if err := emitErofsEntry(owner.w, absPath, fpath, info, fsys, buf); err != nil {
+			return err
+		}
+		owner.emitted[absPath] = true
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Finalize each writer and produce v1.Layer values.
+	layers := make([]v1.Layer, 0, len(writers))
+	for i, gw := range writers {
+		if err := gw.closer(); err != nil {
+			return nil, err
+		}
+		// All layers except the final (top) carry role=overlay-lower per
+		// spec §3.8 rule 1. The final layer carries no role.
+		var anns map[string]string
+		if i < len(writers)-1 {
+			anns = map[string]string{types.ErofsRoleAnnotation: types.ErofsRoleOverlayLower}
+		}
+		l, err := buildErofsLayerFromFile(gw.path, anns)
+		if err != nil {
+			return nil, fmt.Errorf("finalizing erofs layer %d: %w", i, err)
+		}
+		layers = append(layers, l)
+	}
+	return layers, nil
+}
+
+// writeErofsRegularBytes writes a regular file with the given content into w
+// at absPath, copying mode/uid/gid/mtime from info. xattrs are *not* copied
+// because the per-group installed db is a synthesized payload, not a
+// faithful copy of the source file.
+func writeErofsRegularBytes(w *erofs.Writer, absPath string, info fs.FileInfo, data []byte) error {
+	fout, err := w.Create(absPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", absPath, err)
+	}
+	if len(data) > 0 {
+		n, err := fout.Write(data)
+		if err != nil {
+			_ = fout.Close()
+			return fmt.Errorf("write %s: %w", absPath, err)
+		}
+		if n != len(data) {
+			_ = fout.Close()
+			return fmt.Errorf("write %s: %w (wrote %d of %d bytes)", absPath, io.ErrShortWrite, n, len(data))
+		}
+	}
+	if err := fout.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", absPath, err)
+	}
+	if err := w.Chmod(absPath, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("chmod %s: %w", absPath, err)
+	}
+	uid, gid := uidGidFromInfo(info)
+	if err := w.Chown(absPath, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", absPath, err)
+	}
+	if mt := info.ModTime(); !mt.IsZero() {
+		if err := w.Chtimes(absPath, time.Time{}, mt); err != nil {
+			return fmt.Errorf("chtimes %s: %w", absPath, err)
+		}
+	}
+	return nil
+}

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -47,49 +48,29 @@ import (
 func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, pkgToDiff map[*apk.Package][]byte, tmpdir string, buildTime time.Time) ([]v1.Layer, error) {
 	buf := make([]byte, 1<<20)
 
-	type erofsGroupWriter struct {
-		path    string
-		w       *erofs.Writer
-		closer  func() error
-		emitted map[string]bool // absPath -> already emitted into this writer
-		pkgs    map[string]bool // package names owned by this group
-	}
-
-	newWriter := func() (*erofsGroupWriter, error) {
-		f, err := newErofsLayerFile(tmpdir, "apko-erofs-*.bin")
-		if err != nil {
-			return nil, err
-		}
-		var createOpts []erofs.CreateOpt
-		if !buildTime.IsZero() {
-			createOpts = append(createOpts, erofs.WithBuildTime(uint64(buildTime.Unix()), uint32(buildTime.Nanosecond())))
-		}
-		gw := &erofsGroupWriter{
-			path:    f.Name(),
-			w:       erofs.Create(f, createOpts...),
-			emitted: map[string]bool{},
-			pkgs:    map[string]bool{},
-		}
-		// Close the file only after closing the erofs writer (which may seek
-		// back to rewrite the superblock).
-		gw.closer = func() error {
-			if err := gw.w.Close(); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("finalizing erofs image %s: %w", f.Name(), err)
-			}
-			return f.Close()
-		}
-		return gw, nil
-	}
-
 	// One writer per group, plus a top writer for entries not owned by any
 	// package.
 	packageToWriter := map[string]*erofsGroupWriter{}
 	groupToWriter := map[*group]*erofsGroupWriter{}
 	writers := make([]*erofsGroupWriter, 0, len(groups)+1)
 
+	// Nothing here is usable half-built: a caller that gets an error gets no
+	// layers, so every writer opened along the way has to be released and its
+	// temp file removed. Library callers have no MkdirTemp/RemoveAll wrapper
+	// around this the way the CLI does, and each writer holds an unlinked
+	// spool fd besides.
+	done := false
+	defer func() {
+		if done {
+			return
+		}
+		for _, gw := range writers {
+			gw.discard()
+		}
+	}()
+
 	for _, g := range groups {
-		gw, err := newWriter()
+		gw, err := newErofsGroupWriter(tmpdir, buildTime)
 		if err != nil {
 			return nil, err
 		}
@@ -97,10 +78,9 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 		groupToWriter[g] = gw
 		for _, pkg := range g.pkgs {
 			packageToWriter[pkg.Name] = gw
-			gw.pkgs[pkg.Name] = true
 		}
 	}
-	top, err := newWriter()
+	top, err := newErofsGroupWriter(tmpdir, buildTime)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +254,7 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 	// Finalize each writer and produce v1.Layer values.
 	layers := make([]v1.Layer, 0, len(writers))
 	for i, gw := range writers {
-		if err := gw.closer(); err != nil {
+		if err := gw.finish(); err != nil {
 			return nil, err
 		}
 		// All layers except the final (top) carry role=overlay-lower per
@@ -289,7 +269,63 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 		}
 		layers = append(layers, l)
 	}
+	done = true
 	return layers, nil
+}
+
+// erofsGroupWriter is one output layer under construction: a go-erofs Writer
+// over a temp file, plus the set of paths already written into it.
+type erofsGroupWriter struct {
+	path    string
+	file    *os.File
+	w       *erofs.Writer
+	emitted map[string]bool // absPath -> already emitted into this writer
+	closed  bool
+}
+
+func newErofsGroupWriter(tmpdir string, buildTime time.Time) (*erofsGroupWriter, error) {
+	f, err := newErofsLayerFile(tmpdir, "apko-erofs-*.bin")
+	if err != nil {
+		return nil, err
+	}
+	var createOpts []erofs.CreateOpt
+	if !buildTime.IsZero() {
+		createOpts = append(createOpts, erofs.WithBuildTime(uint64(buildTime.Unix()), uint32(buildTime.Nanosecond())))
+	}
+	return &erofsGroupWriter{
+		path:    f.Name(),
+		file:    f,
+		w:       erofs.Create(f, createOpts...),
+		emitted: map[string]bool{},
+	}, nil
+}
+
+// finish serializes the image and closes the temp file, which stays on disk
+// for the v1.Layer to read back. The erofs writer is closed first: it seeks
+// back to rewrite the superblock.
+func (gw *erofsGroupWriter) finish() error {
+	gw.closed = true
+	if err := gw.w.Close(); err != nil {
+		_ = gw.file.Close()
+		return fmt.Errorf("finalizing erofs image %s: %w", gw.path, err)
+	}
+	return gw.file.Close()
+}
+
+// discard releases everything gw holds and removes its temp file. It is safe
+// to call on a writer that has already been finished, and safe to call twice.
+//
+// go-erofs offers no abort: Writer.Close is the only thing that releases the
+// unlinked spool fd holding the file data, and it writes the whole image out
+// as a side effect. So the image gets written and then thrown away, which
+// costs some IO on a path that is already failing.
+func (gw *erofsGroupWriter) discard() {
+	if !gw.closed {
+		gw.closed = true
+		_ = gw.w.Close()
+		_ = gw.file.Close()
+	}
+	_ = os.Remove(gw.path)
 }
 
 // writeErofsRegularBytes writes a regular file with the given content into w

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -321,11 +321,16 @@ func newErofsGroupWriter(tmpdir string, buildTime time.Time) (*erofsGroupWriter,
 	// makes go-erofs stamp time.Now() into the superblock from Close, so a
 	// caller who left the timestamp zero would get different layer digests on
 	// every build. See erofsBuildTime for the clamp.
+	//
+	// tmpdir is also where go-erofs spools file data. A split holds
+	// len(groups)+1 writers open at once, each with an unlinked spool fd, so
+	// letting them default to the system temp dir puts roughly a rootfs of
+	// scratch on a volume the caller did not pick.
 	sec, nsec := erofsBuildTime(buildTime)
 	return &erofsGroupWriter{
 		path:    f.Name(),
 		file:    f,
-		w:       erofs.Create(f, erofs.WithBuildTime(sec, nsec)),
+		w:       erofs.Create(f, erofs.WithBuildTime(sec, nsec), erofs.WithTempDir(tmpdir)),
 		emitted: map[string]bool{},
 	}, nil
 }

--- a/pkg/build/erofs_layers.go
+++ b/pkg/build/erofs_layers.go
@@ -250,6 +250,15 @@ func splitErofsLayers(ctx context.Context, fsys apkfs.FullFS, groups []*group, p
 			// path below.
 		}
 
+		// Emit once per writer, the same guard directories get above.
+		// go-erofs errors on a duplicate path where tar tolerates one
+		// (last-wins). Unreachable today -- the installed db is unowned, so
+		// its owner is top and the loop above skips it -- but if it ever
+		// routed to a group, that group already holds the partial db.
+		if owner.emitted[absPath] {
+			return nil
+		}
+
 		if err := emitAncestors(owner, absPath, info.ModTime()); err != nil {
 			return err
 		}

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	erofs "github.com/erofs/go-erofs"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -258,6 +259,38 @@ func TestSplitErofsLayers_LayersAreValidImages(t *testing.T) {
 			require.NoError(t, err, "fsck.erofs rejected layer[%d]:\n%s", i, out)
 		}
 	}
+}
+
+// TestSplitErofsLayers_ZeroBuildTimeIsEpoch is the layered counterpart of
+// TestWriteErofs_ZeroBuildTimeIsEpoch: a caller that leaves the build time
+// zero must still get the same layers twice, not a wall-clock stamp.
+func TestSplitErofsLayers_ZeroBuildTimeIsEpoch(t *testing.T) {
+	pkg1 := newPkg("pkg1")
+
+	split := func(buildTime time.Time) []v1.Hash {
+		fsys := tarfsFixture(t, []entry{
+			dirEntry("usr/lib/apk/db"),
+			{path: "usr/lib/apk/db/installed", data: "pkg1 info\n"},
+			{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+			{path: "etc/hello", data: "hi\n"},
+		})
+		groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
+		pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
+
+		layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), buildTime)
+		require.NoError(t, err)
+
+		out := make([]v1.Hash, 0, len(layers))
+		for _, l := range layers {
+			d, err := l.Digest()
+			require.NoError(t, err)
+			out = append(out, d)
+		}
+		return out
+	}
+
+	require.Equal(t, split(time.Unix(0, 0)), split(time.Time{}),
+		"a zero buildTime must produce the same layers as an explicit epoch")
 }
 
 func TestSplitErofsLayers_UngroupedPackageIsAnError(t *testing.T) {

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -40,12 +40,20 @@ import (
 
 // entry describes one node in a tarfs fixture. A nil pkg means the entry is
 // not owned by any package, which is what apko's own post-install steps
-// produce.
+// produce. A zero mtime means epoch.
 type entry struct {
-	path string
-	data string
-	pkg  *apk.Package
-	dir  bool
+	path  string
+	data  string
+	pkg   *apk.Package
+	dir   bool
+	mtime time.Time
+}
+
+func (e entry) modTime() time.Time {
+	if e.mtime.IsZero() {
+		return epoch
+	}
+	return e.mtime
 }
 
 func dirEntry(p string) entry { return entry{path: p, dir: true} }
@@ -74,7 +82,7 @@ func tarfsFixture(t *testing.T, entries []entry) apkfs.FullFS {
 	for _, e := range entries {
 		if e.dir {
 			require.NoError(t, m.MkdirAll(e.path, 0o755))
-			require.NoError(t, m.Chtimes(e.path, epoch, epoch))
+			require.NoError(t, m.Chtimes(e.path, e.modTime(), e.modTime()))
 			continue
 		}
 		require.NoError(t, m.MkdirAll(path.Dir(e.path), 0o755))
@@ -85,7 +93,7 @@ func tarfsFixture(t *testing.T, entries []entry) apkfs.FullFS {
 			Name:     e.path,
 			Size:     int64(len(e.data)),
 			Mode:     0o644,
-			ModTime:  epoch,
+			ModTime:  e.modTime(),
 			PAXRecords: map[string]string{
 				"APK-TOOLS.checksum.SHA1": hex.EncodeToString(sum[:]),
 			},
@@ -205,6 +213,38 @@ func TestSplitErofsLayers_EmitsDirOnlySubtrees(t *testing.T) {
 	for _, want := range []string{"tmp", "run", "var", "var/empty"} {
 		require.Contains(t, top, want, "dir-only subtree missing from every layer")
 	}
+}
+
+// TestSplitErofsLayers_AncestorModTimeIsNormalized pins the deduplication
+// property splitLayers already has: a group layer's bytes must not depend on
+// packages outside the group. Directories are shared, only one package's
+// mtime survives into the merged view, so replicating that winner faithfully
+// into a group layer would make the group's digest move whenever an unrelated
+// package installed the shared directory with a different timestamp.
+func TestSplitErofsLayers_AncestorModTimeIsNormalized(t *testing.T) {
+	// Only the shared ancestor's mtime differs between the two builds.
+	split := func(sharedDirModTime time.Time) v1.Hash {
+		pkg1 := newPkg("pkg1")
+		fsys := tarfsFixture(t, []entry{
+			dirEntry("usr/lib/apk/db"),
+			{path: "usr/lib/apk/db/installed", data: "pkg1 info\n"},
+			{path: "usr/bin", dir: true, mtime: sharedDirModTime},
+			{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		})
+		groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
+		pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
+
+		layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+		require.NoError(t, err)
+		require.Len(t, layers, 2)
+
+		d, err := layers[0].Digest()
+		require.NoError(t, err)
+		return d
+	}
+
+	require.Equal(t, split(epoch), split(epoch.Add(72*time.Hour)),
+		"a group layer's digest must not depend on a shared directory's mtime")
 }
 
 func TestSplitErofsLayers_LayersAreValidImages(t *testing.T) {

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -40,10 +40,12 @@ import (
 
 // entry describes one node in a tarfs fixture. A nil pkg means the entry is
 // not owned by any package, which is what apko's own post-install steps
-// produce. A zero mtime means epoch.
+// produce. A non-empty link makes it a symlink to that target; a zero mtime
+// means epoch.
 type entry struct {
 	path  string
 	data  string
+	link  string
 	pkg   *apk.Package
 	dir   bool
 	mtime time.Time
@@ -73,7 +75,7 @@ func tarfsFixture(t *testing.T, entries []entry) apkfs.FullFS {
 	// reads it back lazily, so the fixture needs one to point at.
 	content := fstest.MapFS{}
 	for _, e := range entries {
-		if !e.dir {
+		if !e.dir && e.link == "" {
 			content[e.path] = &fstest.MapFile{Data: []byte(e.data), Mode: 0o644}
 		}
 	}
@@ -87,17 +89,29 @@ func tarfsFixture(t *testing.T, entries []entry) apkfs.FullFS {
 		}
 		require.NoError(t, m.MkdirAll(path.Dir(e.path), 0o755))
 
-		sum := sha1.Sum([]byte(e.data)) //nolint:gosec // see the import comment
 		hdr := tar.Header{
 			Typeflag: tar.TypeReg,
 			Name:     e.path,
 			Size:     int64(len(e.data)),
 			Mode:     0o644,
 			ModTime:  e.modTime(),
-			PAXRecords: map[string]string{
-				"APK-TOOLS.checksum.SHA1": hex.EncodeToString(sum[:]),
-			},
 		}
+		payload := e.data
+		if e.link != "" {
+			// tarfs routes symlinks through the same WriteHeader path as
+			// regular files, checksum and owning package included, which is
+			// how a package-owned symlink reaches splitErofsLayers.
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = e.link
+			hdr.Size = 0
+			hdr.Mode = 0o777
+			payload = e.link
+		}
+		sum := sha1.Sum([]byte(payload)) //nolint:gosec // see the import comment
+		hdr.PAXRecords = map[string]string{
+			"APK-TOOLS.checksum.SHA1": hex.EncodeToString(sum[:]),
+		}
+
 		_, err := m.WriteHeader(hdr, content, e.pkg)
 		require.NoError(t, err, "writing %s", e.path)
 	}
@@ -140,6 +154,7 @@ func TestSplitErofsLayers_RoutesFilesToTheirPackageLayer(t *testing.T) {
 		{path: "usr/lib/apk/db/installed", data: "pkg1 info\npkg2 info\n"},
 		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
 		{path: "usr/share/one/data", data: "data\n", pkg: pkg1},
+		{path: "usr/bin/one-compat", link: "one", pkg: pkg1},
 		{path: "usr/bin/two", data: "two\n", pkg: pkg2},
 		{path: "etc/hello", data: "hi\n"},
 	})
@@ -169,6 +184,12 @@ func TestSplitErofsLayers_RoutesFilesToTheirPackageLayer(t *testing.T) {
 
 	require.Contains(t, two, "usr/bin/two")
 	require.NotContains(t, two, "usr/bin/one")
+
+	// Symlinks route on the same Package() the walk reads off a regular
+	// file's FileInfo, so a package's compat links must not drift to top.
+	require.Contains(t, one, "usr/bin/one-compat")
+	require.NotContains(t, two, "usr/bin/one-compat")
+	require.NotContains(t, top, "usr/bin/one-compat")
 
 	require.NotContains(t, top, "usr/bin/one")
 	require.NotContains(t, top, "usr/bin/two")

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -178,6 +178,34 @@ func TestSplitErofsLayers_RoutesFilesToTheirPackageLayer(t *testing.T) {
 	require.Equal(t, "pkg1 info\npkg2 info\n", string(readLayerFile(t, layers[2], "usr/lib/apk/db/installed")))
 }
 
+func TestSplitErofsLayers_EmitsDirOnlySubtrees(t *testing.T) {
+	pkg1 := newPkg("pkg1")
+	fsys := tarfsFixture(t, []entry{
+		dirEntry("usr/lib/apk/db"),
+		{path: "usr/lib/apk/db/installed", data: "pkg1 info\n"},
+		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		// Directories with no file anywhere beneath them. apko creates these
+		// from `paths:` and from the base layout, and an image without them
+		// has no /tmp to write to and no mount points to mount over.
+		dirEntry("tmp"),
+		dirEntry("run"),
+		dirEntry("var/empty"),
+	})
+
+	groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
+	pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
+
+	layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	require.NoError(t, err)
+	require.Len(t, layers, 2)
+
+	// They belong to no package, so they land in the top layer.
+	top := layerPaths(t, layers[len(layers)-1])
+	for _, want := range []string{"tmp", "run", "var", "var/empty"} {
+		require.Contains(t, top, want, "dir-only subtree missing from every layer")
+	}
+}
+
 func TestSplitErofsLayers_LayersAreValidImages(t *testing.T) {
 	pkg1, pkg2 := newPkg("pkg1"), newPkg("pkg2")
 	fsys := tarfsFixture(t, []entry{

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -270,8 +270,46 @@ func TestSplitErofsLayers_UngroupedPackageIsAnError(t *testing.T) {
 	groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
 	pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
 
-	_, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	tmpdir := t.TempDir()
+	_, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, tmpdir, epoch)
 	require.ErrorContains(t, err, "orphan")
+
+	// And nothing is left behind on the way out.
+	require.Empty(t, lsDir(t, tmpdir), "temp layer files leaked on the error path")
+}
+
+// TestSplitErofsLayers_CleansUpOnError covers the other shape of failure: an
+// error raised part-way through the walk rather than before it starts.
+func TestSplitErofsLayers_CleansUpOnError(t *testing.T) {
+	pkg1 := newPkg("pkg1")
+	fsys := tarfsFixture(t, []entry{
+		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		{path: "etc/hello", data: "hi\n"},
+	})
+
+	groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
+	pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tmpdir := t.TempDir()
+	_, err := splitErofsLayers(ctx, fsys, groups, pkgToDiff, tmpdir, epoch)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, lsDir(t, tmpdir), "temp layer files leaked on the error path")
+}
+
+func lsDir(t *testing.T, dir string) []string {
+	t.Helper()
+
+	ents, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	out := make([]string, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, e.Name())
+	}
+	return out
 }
 
 func readLayerFile(t *testing.T, l v1.Layer, name string) []byte {

--- a/pkg/build/erofs_layers_test.go
+++ b/pkg/build/erofs_layers_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"archive/tar"
+	"context"
+	"crypto/sha1" //nolint:gosec // the checksum tarfs verifies is apk's, which is SHA-1
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"testing"
+	"testing/fstest"
+
+	erofs "github.com/erofs/go-erofs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
+	"chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/apko/pkg/tarfs"
+)
+
+// entry describes one node in a tarfs fixture. A nil pkg means the entry is
+// not owned by any package, which is what apko's own post-install steps
+// produce.
+type entry struct {
+	path string
+	data string
+	pkg  *apk.Package
+	dir  bool
+}
+
+func dirEntry(p string) entry { return entry{path: p, dir: true} }
+
+func newPkg(name string) *apk.Package {
+	return &apk.Package{Name: name, Origin: name, Version: "1.0.0", InstalledSize: 1024}
+}
+
+// tarfsFixture builds a pkg/tarfs filesystem, which is what a real apko build
+// walks. apkfs.NewMemFS() cannot stand in for it here: its FileInfo has no
+// Package() method at all, so every file in a MemFS fixture is unowned by
+// construction and package routing is never exercised.
+func tarfsFixture(t *testing.T, entries []entry) apkfs.FullFS {
+	t.Helper()
+
+	// tarfs keeps regular file data in the fs.FS the header came from and
+	// reads it back lazily, so the fixture needs one to point at.
+	content := fstest.MapFS{}
+	for _, e := range entries {
+		if !e.dir {
+			content[e.path] = &fstest.MapFile{Data: []byte(e.data), Mode: 0o644}
+		}
+	}
+
+	m := tarfs.New()
+	for _, e := range entries {
+		if e.dir {
+			require.NoError(t, m.MkdirAll(e.path, 0o755))
+			require.NoError(t, m.Chtimes(e.path, epoch, epoch))
+			continue
+		}
+		require.NoError(t, m.MkdirAll(path.Dir(e.path), 0o755))
+
+		sum := sha1.Sum([]byte(e.data)) //nolint:gosec // see the import comment
+		hdr := tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     e.path,
+			Size:     int64(len(e.data)),
+			Mode:     0o644,
+			ModTime:  epoch,
+			PAXRecords: map[string]string{
+				"APK-TOOLS.checksum.SHA1": hex.EncodeToString(sum[:]),
+			},
+		}
+		_, err := m.WriteHeader(hdr, content, e.pkg)
+		require.NoError(t, err, "writing %s", e.path)
+	}
+	return m
+}
+
+// layerPaths returns the sorted set of paths an EROFS layer contains,
+// excluding the root.
+func layerPaths(t *testing.T, l v1.Layer) []string {
+	t.Helper()
+
+	erl, ok := l.(*erofsLayer)
+	require.True(t, ok, "layer is not an *erofsLayer")
+
+	f, err := os.Open(erl.path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	img, err := erofs.Open(f)
+	require.NoError(t, err)
+
+	var out []string
+	require.NoError(t, fs.WalkDir(img, ".", func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p != "." {
+			out = append(out, p)
+		}
+		return nil
+	}))
+	sort.Strings(out)
+	return out
+}
+
+func TestSplitErofsLayers_RoutesFilesToTheirPackageLayer(t *testing.T) {
+	pkg1, pkg2 := newPkg("pkg1"), newPkg("pkg2")
+	fsys := tarfsFixture(t, []entry{
+		dirEntry("usr/lib/apk/db"),
+		{path: "usr/lib/apk/db/installed", data: "pkg1 info\npkg2 info\n"},
+		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		{path: "usr/share/one/data", data: "data\n", pkg: pkg1},
+		{path: "usr/bin/two", data: "two\n", pkg: pkg2},
+		{path: "etc/hello", data: "hi\n"},
+	})
+
+	// Groups are ordered the way groupByOriginAndSize hands them over: one
+	// group per origin, largest first, with the top layer appended last.
+	groups := []*group{
+		{pkgs: []*apk.Package{pkg1}, size: 2000, tiebreaker: "pkg1"},
+		{pkgs: []*apk.Package{pkg2}, size: 1000, tiebreaker: "pkg2"},
+	}
+	pkgToDiff := map[*apk.Package][]byte{
+		pkg1: []byte("pkg1 info\n"),
+		pkg2: []byte("pkg2 info\n"),
+	}
+
+	layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	require.NoError(t, err)
+	require.Len(t, layers, 3)
+
+	one, two, top := layerPaths(t, layers[0]), layerPaths(t, layers[1]), layerPaths(t, layers[2])
+
+	// Each package's files land in its own group layer and nowhere else.
+	require.Contains(t, one, "usr/bin/one")
+	require.Contains(t, one, "usr/share/one/data")
+	require.NotContains(t, one, "usr/bin/two")
+	require.NotContains(t, one, "etc/hello")
+
+	require.Contains(t, two, "usr/bin/two")
+	require.NotContains(t, two, "usr/bin/one")
+
+	require.NotContains(t, top, "usr/bin/one")
+	require.NotContains(t, top, "usr/bin/two")
+	require.Contains(t, top, "etc/hello")
+
+	// Ancestors of a routed file are recreated in the layer that needs them,
+	// so each group layer is mountable on its own.
+	require.Contains(t, one, "usr")
+	require.Contains(t, one, "usr/bin")
+	require.Contains(t, two, "usr/bin")
+
+	// Every group layer carries a partial installed db naming only its own
+	// packages; the top layer carries the real one.
+	require.Equal(t, "pkg1 info\n", string(readLayerFile(t, layers[0], "usr/lib/apk/db/installed")))
+	require.Equal(t, "pkg2 info\n", string(readLayerFile(t, layers[1], "usr/lib/apk/db/installed")))
+	require.Equal(t, "pkg1 info\npkg2 info\n", string(readLayerFile(t, layers[2], "usr/lib/apk/db/installed")))
+}
+
+func TestSplitErofsLayers_LayersAreValidImages(t *testing.T) {
+	pkg1, pkg2 := newPkg("pkg1"), newPkg("pkg2")
+	fsys := tarfsFixture(t, []entry{
+		dirEntry("usr/lib/apk/db"),
+		{path: "usr/lib/apk/db/installed", data: "pkg1 info\npkg2 info\n"},
+		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		{path: "usr/bin/two", data: "two\n", pkg: pkg2},
+		{path: "etc/hello", data: "hi\n"},
+	})
+
+	groups := []*group{
+		{pkgs: []*apk.Package{pkg1}, size: 2000, tiebreaker: "pkg1"},
+		{pkgs: []*apk.Package{pkg2}, size: 1000, tiebreaker: "pkg2"},
+	}
+	pkgToDiff := map[*apk.Package][]byte{
+		pkg1: []byte("pkg1 info\n"),
+		pkg2: []byte("pkg2 info\n"),
+	}
+
+	layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	require.NoError(t, err)
+	require.Len(t, layers, 3)
+
+	fsckBin := optionalFsckErofs(t)
+	for i, l := range layers {
+		erl, ok := l.(*erofsLayer)
+		require.True(t, ok, "layer[%d] is not an *erofsLayer", i)
+
+		mt, err := l.MediaType()
+		require.NoError(t, err)
+		require.Equal(t, types.ErofsLayerMediaType, string(mt))
+
+		// Every layer but the final one carries role=overlay-lower, per spec
+		// §3.8 rule 1.
+		anns := erl.LayerAnnotations()
+		if i < len(layers)-1 {
+			require.Equal(t, types.ErofsRoleOverlayLower, anns[types.ErofsRoleAnnotation], "layer[%d]", i)
+		} else {
+			require.Empty(t, anns, "the final layer must carry no role annotation")
+		}
+
+		f, err := os.Open(erl.path)
+		require.NoError(t, err)
+		_, err = erofs.Open(f)
+		_ = f.Close()
+		require.NoError(t, err, "layer[%d] is not a valid EROFS image", i)
+
+		if fsckBin != "" {
+			out, err := exec.Command(fsckBin, "-d3", erl.path).CombinedOutput()
+			require.NoError(t, err, "fsck.erofs rejected layer[%d]:\n%s", i, out)
+		}
+	}
+}
+
+func TestSplitErofsLayers_UngroupedPackageIsAnError(t *testing.T) {
+	pkg1, orphan := newPkg("pkg1"), newPkg("orphan")
+	fsys := tarfsFixture(t, []entry{
+		{path: "usr/bin/one", data: "one\n", pkg: pkg1},
+		{path: "usr/bin/orphan", data: "orphan\n", pkg: orphan},
+	})
+
+	groups := []*group{{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"}}
+	pkgToDiff := map[*apk.Package][]byte{pkg1: []byte("pkg1 info\n")}
+
+	_, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	require.ErrorContains(t, err, "orphan")
+}
+
+func readLayerFile(t *testing.T, l v1.Layer, name string) []byte {
+	t.Helper()
+
+	erl, ok := l.(*erofsLayer)
+	require.True(t, ok, "layer is not an *erofsLayer")
+
+	f, err := os.Open(erl.path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	img, err := erofs.Open(f)
+	require.NoError(t, err)
+
+	data, err := fs.ReadFile(img, name)
+	require.NoError(t, err, "reading %s", name)
+	return data
+}

--- a/pkg/build/erofs_test.go
+++ b/pkg/build/erofs_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
@@ -367,6 +368,94 @@ func TestWriteErofs_FsckErofs(t *testing.T) {
 	target, err := os.Readlink(filepath.Join(extractDir, "a", "link"))
 	require.NoError(t, err)
 	require.Equal(t, "b", target)
+}
+
+func TestSplitErofsLayers(t *testing.T) {
+	fsys := apkfs.NewMemFS()
+	require.NoError(t, fsys.MkdirAll("usr/lib/apk/db", 0o755))
+	require.NoError(t, fsys.WriteFile("usr/lib/apk/db/installed", []byte("idb top\n"), 0o644))
+	require.NoError(t, fsys.MkdirAll("etc", 0o755))
+	require.NoError(t, fsys.WriteFile("etc/hello", []byte("hi\n"), 0o644))
+
+	pkg1 := newPkg("pkg1")
+	pkg2 := newPkg("pkg2")
+	groups := []*group{
+		{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"},
+		{pkgs: []*apk.Package{pkg2}, size: 2000, tiebreaker: "pkg2"},
+	}
+	pkgToDiff := map[*apk.Package][]byte{
+		pkg1: []byte("pkg1 info\n"),
+		pkg2: []byte("pkg2 info\n"),
+	}
+
+	layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
+	require.NoError(t, err)
+	require.Len(t, layers, 3, "expected 2 group layers + 1 top layer")
+
+	// All three layers should be valid EROFS images.
+	fsckBin := optionalFsckErofs(t)
+	for i, l := range layers {
+		erl, ok := l.(*erofsLayer)
+		require.True(t, ok, "layer[%d] not *erofsLayer", i)
+
+		mt, err := l.MediaType()
+		require.NoError(t, err)
+		require.Equal(t, "application/vnd.erofs", string(mt))
+
+		// Layer roles: overlay-lower on the package layers, absent on the top.
+		anns := erl.LayerAnnotations()
+		if i < len(layers)-1 {
+			require.Equal(t, "overlay-lower", anns[types.ErofsRoleAnnotation], "layer[%d] missing overlay-lower role", i)
+		} else {
+			require.Empty(t, anns, "top layer must carry no role annotation")
+		}
+
+		// The image must parse via go-erofs.
+		f, err := os.Open(erl.path)
+		require.NoError(t, err)
+		_, err = erofs.Open(f)
+		_ = f.Close()
+		require.NoError(t, err, "layer[%d] is not a valid EROFS image", i)
+
+		if fsckBin != "" {
+			cmd := exec.Command(fsckBin, "-d3", erl.path)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "fsck.erofs rejected layer[%d]:\n%s", i, out)
+		}
+	}
+
+	// The package layers must each carry their own partial installed db; the
+	// top layer carries the source file via the normal path.
+	for i, l := range layers[:2] {
+		erl := l.(*erofsLayer)
+		f, err := os.Open(erl.path)
+		require.NoError(t, err)
+		img, err := erofs.Open(f)
+		require.NoError(t, err)
+		data, err := fs.ReadFile(img, "usr/lib/apk/db/installed")
+		require.NoError(t, err, "layer[%d] missing per-group installed db", i)
+		require.NotEmpty(t, data, "layer[%d] installed db must not be empty", i)
+		_ = f.Close()
+	}
+
+	// The top layer should hold etc/hello (unowned content) and the original
+	// installed db.
+	topL := layers[len(layers)-1].(*erofsLayer)
+	tf, err := os.Open(topL.path)
+	require.NoError(t, err)
+	defer tf.Close()
+	topImg, err := erofs.Open(tf)
+	require.NoError(t, err)
+	hello, err := fs.ReadFile(topImg, "etc/hello")
+	require.NoError(t, err)
+	require.Equal(t, "hi\n", string(hello))
+	topIdb, err := fs.ReadFile(topImg, "usr/lib/apk/db/installed")
+	require.NoError(t, err)
+	require.Equal(t, "idb top\n", string(topIdb))
+}
+
+func newPkg(name string) *apk.Package {
+	return &apk.Package{Name: name, Origin: name, Version: "1.0.0", InstalledSize: 1024}
 }
 
 // optionalFsckErofs returns the path to fsck.erofs, or "" when erofs-utils is

--- a/pkg/build/erofs_test.go
+++ b/pkg/build/erofs_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
-	"chainguard.dev/apko/pkg/apk/apk"
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
@@ -368,94 +367,6 @@ func TestWriteErofs_FsckErofs(t *testing.T) {
 	target, err := os.Readlink(filepath.Join(extractDir, "a", "link"))
 	require.NoError(t, err)
 	require.Equal(t, "b", target)
-}
-
-func TestSplitErofsLayers(t *testing.T) {
-	fsys := apkfs.NewMemFS()
-	require.NoError(t, fsys.MkdirAll("usr/lib/apk/db", 0o755))
-	require.NoError(t, fsys.WriteFile("usr/lib/apk/db/installed", []byte("idb top\n"), 0o644))
-	require.NoError(t, fsys.MkdirAll("etc", 0o755))
-	require.NoError(t, fsys.WriteFile("etc/hello", []byte("hi\n"), 0o644))
-
-	pkg1 := newPkg("pkg1")
-	pkg2 := newPkg("pkg2")
-	groups := []*group{
-		{pkgs: []*apk.Package{pkg1}, size: 1000, tiebreaker: "pkg1"},
-		{pkgs: []*apk.Package{pkg2}, size: 2000, tiebreaker: "pkg2"},
-	}
-	pkgToDiff := map[*apk.Package][]byte{
-		pkg1: []byte("pkg1 info\n"),
-		pkg2: []byte("pkg2 info\n"),
-	}
-
-	layers, err := splitErofsLayers(context.Background(), fsys, groups, pkgToDiff, t.TempDir(), epoch)
-	require.NoError(t, err)
-	require.Len(t, layers, 3, "expected 2 group layers + 1 top layer")
-
-	// All three layers should be valid EROFS images.
-	fsckBin := optionalFsckErofs(t)
-	for i, l := range layers {
-		erl, ok := l.(*erofsLayer)
-		require.True(t, ok, "layer[%d] not *erofsLayer", i)
-
-		mt, err := l.MediaType()
-		require.NoError(t, err)
-		require.Equal(t, "application/vnd.erofs", string(mt))
-
-		// Layer roles: overlay-lower on the package layers, absent on the top.
-		anns := erl.LayerAnnotations()
-		if i < len(layers)-1 {
-			require.Equal(t, "overlay-lower", anns[types.ErofsRoleAnnotation], "layer[%d] missing overlay-lower role", i)
-		} else {
-			require.Empty(t, anns, "top layer must carry no role annotation")
-		}
-
-		// The image must parse via go-erofs.
-		f, err := os.Open(erl.path)
-		require.NoError(t, err)
-		_, err = erofs.Open(f)
-		_ = f.Close()
-		require.NoError(t, err, "layer[%d] is not a valid EROFS image", i)
-
-		if fsckBin != "" {
-			cmd := exec.Command(fsckBin, "-d3", erl.path)
-			out, err := cmd.CombinedOutput()
-			require.NoError(t, err, "fsck.erofs rejected layer[%d]:\n%s", i, out)
-		}
-	}
-
-	// The package layers must each carry their own partial installed db; the
-	// top layer carries the source file via the normal path.
-	for i, l := range layers[:2] {
-		erl := l.(*erofsLayer)
-		f, err := os.Open(erl.path)
-		require.NoError(t, err)
-		img, err := erofs.Open(f)
-		require.NoError(t, err)
-		data, err := fs.ReadFile(img, "usr/lib/apk/db/installed")
-		require.NoError(t, err, "layer[%d] missing per-group installed db", i)
-		require.NotEmpty(t, data, "layer[%d] installed db must not be empty", i)
-		_ = f.Close()
-	}
-
-	// The top layer should hold etc/hello (unowned content) and the original
-	// installed db.
-	topL := layers[len(layers)-1].(*erofsLayer)
-	tf, err := os.Open(topL.path)
-	require.NoError(t, err)
-	defer tf.Close()
-	topImg, err := erofs.Open(tf)
-	require.NoError(t, err)
-	hello, err := fs.ReadFile(topImg, "etc/hello")
-	require.NoError(t, err)
-	require.Equal(t, "hi\n", string(hello))
-	topIdb, err := fs.ReadFile(topImg, "usr/lib/apk/db/installed")
-	require.NoError(t, err)
-	require.Equal(t, "idb top\n", string(topIdb))
-}
-
-func newPkg(name string) *apk.Package {
-	return &apk.Package{Name: name, Origin: name, Version: "1.0.0", InstalledSize: 1024}
 }
 
 // optionalFsckErofs returns the path to fsck.erofs, or "" when erofs-utils is

--- a/pkg/build/erofs_test.go
+++ b/pkg/build/erofs_test.go
@@ -64,7 +64,7 @@ func TestWriteErofs_Roundtrip(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
 
-	require.NoError(t, writeErofs(context.Background(), f, m, epoch))
+	require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), epoch))
 	require.NoError(t, f.Close())
 
 	r, err := os.Open(out)
@@ -135,7 +135,7 @@ func TestWriteErofs_SpecialModeBits(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "image.erofs")
 	f, err := os.Create(out)
 	require.NoError(t, err)
-	require.NoError(t, writeErofs(context.Background(), f, m, epoch))
+	require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), epoch))
 	require.NoError(t, f.Close())
 
 	r, err := os.Open(out)
@@ -223,7 +223,7 @@ func TestWriteErofs_Xattrs(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "image.erofs")
 	f, err := os.Create(out)
 	require.NoError(t, err)
-	require.NoError(t, writeErofs(context.Background(), f, m, epoch))
+	require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), epoch))
 	require.NoError(t, f.Close())
 
 	r, err := os.Open(out)
@@ -337,7 +337,7 @@ func TestWriteErofs_FsckErofs(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "image.erofs")
 	f, err := os.Create(out)
 	require.NoError(t, err)
-	require.NoError(t, writeErofs(context.Background(), f, m, epoch))
+	require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), epoch))
 	require.NoError(t, f.Close())
 
 	// Plain integrity check: superblock CRC, layout, all reachable inodes.
@@ -393,7 +393,7 @@ func TestWriteErofs_Reproducible(t *testing.T) {
 		m := seedFS(t)
 		f, err := os.Create(path)
 		require.NoError(t, err)
-		require.NoError(t, writeErofs(context.Background(), f, m, epoch))
+		require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), epoch))
 		require.NoError(t, f.Close())
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -422,7 +422,7 @@ func TestWriteErofs_ZeroBuildTimeIsEpoch(t *testing.T) {
 		m := seedFS(t)
 		f, err := os.Create(path)
 		require.NoError(t, err)
-		require.NoError(t, writeErofs(context.Background(), f, m, bt))
+		require.NoError(t, writeErofs(context.Background(), f, m, t.TempDir(), bt))
 		require.NoError(t, f.Close())
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)

--- a/pkg/build/layers.go
+++ b/pkg/build/layers.go
@@ -86,10 +86,8 @@ func (bc *Context) buildLayers(ctx context.Context) ([]v1.Layer, error) {
 	}
 
 	// Then partition that single fs.FS into multiple layers based on our layering strategy.
-	// ImageConfiguration.Validate rejects this combination up front; this guards
-	// library callers that build a configuration without validating it.
 	if bc.ic.Format.Resolved() == types.LayerFormatErofs {
-		return nil, fmt.Errorf("layering is not supported with format %q yet", types.LayerFormatErofs)
+		return splitErofsLayers(ctx, bc.fs, groups, pkgToDiff, bc.o.TempDir(), bc.o.SourceDateEpoch)
 	}
 	return splitLayers(ctx, bc.fs, groups, pkgToDiff, bc.o.TempDir())
 }

--- a/pkg/build/types/image_configuration.go
+++ b/pkg/build/types/image_configuration.go
@@ -244,13 +244,6 @@ func (ic *ImageConfiguration) Validate() error {
 		return fmt.Errorf("invalid layer format %q (must be %q or %q)", ic.Format, LayerFormatTar, LayerFormatErofs)
 	}
 
-	// Splitting a rootfs across several EROFS layers is not implemented yet.
-	// Fail here rather than silently emitting a single layer, which would not
-	// be the image the config asked for.
-	if ic.Format.Resolved() == LayerFormatErofs && ic.Layering != nil {
-		return fmt.Errorf("layering is not supported with format %q yet (use one or the other)", LayerFormatErofs)
-	}
-
 	if ic.Certificates != nil {
 		for _, additional := range ic.Certificates.Additional {
 			if additional.Name == "" {


### PR DESCRIPTION
Section 2 of #2408: brings back the EROFS layer split, descoped in
e5778f17 so #2249 could land as a single-layer writer plus `ls`, with the
five bugs review found fixed on top.

#2415 has since merged, and this is rebased on it. The code is still
disjoint — that PR is `pkg/erofsmount` and the CLI, this one is
`pkg/build` — they meet only in `hack/test-erofs.sh`.

### 1. Restore, unchanged

`pkg/build/erofs_layers.go` and its test come back exactly as they were,
and the `layering` + `format: erofs` rejection leaves
`ImageConfiguration.Validate` and `buildLayers`. This commit deliberately
restores the known-broken behavior; the four after it are the fix, and
that delta is the point of the PR.

### 2. Package routing — the bug that inverted the whole thing

The type assertion asked `info.Sys()` for a `Package()` method. tarfs,
which is what a real build walks, returns a fresh `*tar.Header` from
`Sys()` and hangs `Package()` off the FileInfo itself — the receiver
`splitLayers` asserts on. So it never succeeded outside a fixture: every
file landed in the top layer, each group layer held only ancestor
directories plus a partial installed db (that case keys on the path
string, so it still fired), and per-layer scanners read a db naming
packages whose files were not there.

Assert on `info`, and turn a `packageToWriter` miss into an error rather
than a silent fall back to `top`.

`TestSplitErofsLayers` could not catch this: it drove the split through
`apkfs.NewMemFS()`, which implements `Package()` nowhere, so the fixture
had zero package-owned files by construction and passed identically with
and without routing. It is replaced by `erofs_layers_test.go`, which
builds its fixture with `pkg/tarfs` and installs files through
`WriteHeader` with an `*apk.Package`, the way an apk install does. Its
routing assertions fail against the previous code.

### 3. Directory-only subtrees

Directories were recorded during the walk and materialized only by
`emitAncestors`, which runs for non-directory entries. A directory whose
subtree holds no file was therefore never written anywhere: `/tmp`,
`/run`, `/var/empty`, every empty dir and every mount point were absent
from the merged view. Each directory is now emitted into its owning
writer as it is walked, which is what both siblings already do.

### 4. Temp files and fds

No error return out of `splitErofsLayers` closed or removed the per-layer
temp files, and each go-erofs `Writer` also holds an unlinked spool fd
that only `Close` releases. The CLI happened to be bounded by its
`MkdirTemp`/`RemoveAll` wrapper; a library caller accumulated both until
process exit. The per-writer state moves into an `erofsGroupWriter` type
with `finish`/`discard`, and a deferred sweep discards every writer
unless the function reaches its return. Still no upstream abort API, so
`discard` writes an image it then removes.

### 5. Build time

`newErofsGroupWriter` passed `WithBuildTime` only for a non-zero build
time — the exact case `erofsBuildTime`'s comment describes, where
go-erofs stamps `time.Now()` from `Close` and a library caller gets
different layer digests every build. It now uses `erofsBuildTime`, same
as `writeErofs`. apko's own CLI was never affected.

### 6. Drive it from `hack/test-erofs.sh`

The privileged job from #2414, extended by #2415, only built and mounted
a single layer, because that was all apko could produce. The script now
builds the same config again with `layering` and adds, after the existing
comparisons:

- layer roles and mediaTypes across the manifest, and `digest` == the
  sha256 of each blob;
- `fsck.erofs` on every layer, and a kernel mount of every layer stacked
  as read-only overlayfs lowerdirs;
- `apko erofs ls` on the layered OCI directory diffed against that
  overlay mount — `Stack`'s merge only becomes reachable for apko's own
  output now that splitting is back, and this is the first thing to
  compare it with what the kernel assembles;
- every non-final layer must hold a regular file other than the partial
  installed db, which is exactly the shape the routing bug produced;
- the merged tree diffed against a **tar** build of the same config
  unpacked in layer order. The tar split is the reference for what
  splitting must preserve, and a directory that reaches no layer shows up
  here and nowhere else. Both builds resolve from one `apko lock` output
  so a package published between them cannot make them differ. The unpack
  uses `--numeric-owner`; without it GNU tar resolves each header's
  uname/gname against the runner's `/etc/passwd` and invents ids for
  `lp`, `mail`, `news` and `uucp`.

The layered section runs last, after #2415's `apko erofs mount` /
`apko erofs umount` checks, and reuses their helpers — `fail`,
`assert_mounted`, `normalize_ls`, `tree_listing`. Their `cleanup` already
unmounts everything under the workdir deepest-first, so the layer and
overlay mounts need no separate bookkeeping. The one existing line this
touches is the whitespace-in-paths guard, lifted into a
`check_ls_whitespace` function so the layered listing gets it too.

### Not in this PR

Whiteout support in `Stack` — the last item in section 2 — is really the
layer-horizon fix from section 5, and is reader-side and independently
testable. Left for its own PR.

### Verification

`gofmt -l` clean, `golangci-lint run -n` reports 0 issues, `go build
./...` and `GOOS=darwin go build ./...` both succeed, and
`SOURCE_DATE_EPOCH=0 go test ./...` passes. `shellcheck` is clean on the
script.

Each fix was checked to fail without its change: the four new tests are
red against the restore commit and green after their own commit.

Locally, a layered `wolfi-base` build produces five layers whose merged
`apko erofs ls` listing is identical to the single-layer build's, and
whose non-top layers are 0.7–7.4 MB rather than the directories-only
skeletons the routing bug produced.

Refs #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

