### PR TITLE
erofs: small cleanups to erofsmount tool

### DIFF
--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -172,6 +172,12 @@ func (d *fuseDriver) Unmount(ctx context.Context, mp string) error {
 	if kerr == nil {
 		return nil
 	}
+	// A symlinked mountpoint is a refusal, not a sign that the wrong tool was
+	// tried. fusermount carries its own UMOUNT_NOFOLLOW and would only refuse
+	// it again, so running it adds nothing and buries the reason in a join.
+	if errors.Is(kerr, errSymlinkedMountpoint) {
+		return kerr
+	}
 	fm, err := lookupFusermount()
 	if err != nil {
 		return errors.Join(kerr, err)
@@ -234,6 +240,11 @@ func buildKernelLayerArgs(blob, mp string) []string {
 // This covers the final component only. A symlinked *parent* -- <dest>/layers
 // itself -- resolves during the syscall's own path walk, and checkResolved is
 // what rejects that, with the narrower race it documents.
+// errSymlinkedMountpoint reports a mountpoint whose final component is a
+// symlink. UMOUNT_NOFOLLOW refuses those, and callers use this to tell the
+// refusal apart from an ordinary unmount failure.
+var errSymlinkedMountpoint = errors.New("refusing to follow a symlink")
+
 func kernelUnmount(ctx context.Context, mp string) error {
 	clog.FromContext(ctx).Debugf("umount2: %s (UMOUNT_NOFOLLOW)", mp)
 	err := unix.Unmount(mp, unix.UMOUNT_NOFOLLOW)
@@ -245,7 +256,7 @@ func kernelUnmount(ctx context.Context, mp string) error {
 	// argument". This is for the message only -- the flag above is what
 	// provides the guarantee, so an lstat racing it cannot weaken anything.
 	if fi, lerr := os.Lstat(mp); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("umount %s: refusing to follow a symlink", mp)
+		return fmt.Errorf("umount %s: %w", mp, errSymlinkedMountpoint)
 	}
 	return fmt.Errorf("umount %s: %w", mp, err)
 }

--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -202,17 +202,19 @@ func (d *fuseDriver) AssembleOverlay(ctx context.Context, lowers []string, upper
 		}, nil
 	}
 
-	if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
-		return nil, fmt.Errorf("kernel overlay failed and fuse-overlayfs is not installed: %w", err)
-	}
 	// Only the fall-back needs this. The kernel overlay attempted just above
 	// unescapes the way escapeOverlayPath escapes; fuse-overlayfs does not.
+	// Ahead of the LookPath below because a path fuse-overlayfs cannot
+	// round-trip is terminal, while "not installed" is fixable.
 	paths := slices.Clone(lowers)
 	if !readOnly {
 		paths = append(paths, upper, work)
 	}
 	if err := checkFuseOverlayPaths(paths...); err != nil {
 		return nil, err
+	}
+	if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
+		return nil, fmt.Errorf("kernel overlay failed and fuse-overlayfs is not installed: %w", err)
 	}
 	fArgs := buildFuseOverlayArgs(lowers, upper, work, merged, readOnly)
 	if err := runCmd(ctx, fArgs[0], fArgs[1:]...); err != nil {

--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -164,7 +164,8 @@ func (d *fuseDriver) MountLayer(ctx context.Context, blob, mp string) (func() er
 // fuse-overlayfs mount, and per-layer mounts are erofsfuse; umount handles the
 // first, fusermount -u the other two.
 //
-// Both failures are reported. Unmount is also the fall-back for a blob mount,
+// Both failures are reported, unless the kernel refused a symlinked
+// mountpoint -- see below. Unmount is also the fall-back for a blob mount,
 // whose mode is unknown, so the kernel attempt is the one that failed for the
 // interesting reason -- returning only the fusermount error turns "target is
 // busy" into "neither fusermount3 nor fusermount found in PATH".
@@ -239,6 +240,11 @@ func buildKernelLayerArgs(blob, mp string) []string {
 	return []string{"mount", "-t", "erofs", "-o", "ro", blob, mp}
 }
 
+// errSymlinkedMountpoint reports a mountpoint whose final component is a
+// symlink. UMOUNT_NOFOLLOW refuses those, and callers use this to tell the
+// refusal apart from an ordinary unmount failure.
+var errSymlinkedMountpoint = errors.New("refusing to follow a symlink")
+
 // kernelUnmount unmounts mp with umount(2) rather than umount(8).
 //
 // UMOUNT_NOFOLLOW is the reason: it makes the kernel refuse a symlink at the
@@ -250,21 +256,22 @@ func buildKernelLayerArgs(blob, mp string) []string {
 // This covers the final component only. A symlinked *parent* -- <dest>/layers
 // itself -- resolves during the syscall's own path walk, and checkResolved is
 // what rejects that, with the narrower race it documents.
-// errSymlinkedMountpoint reports a mountpoint whose final component is a
-// symlink. UMOUNT_NOFOLLOW refuses those, and callers use this to tell the
-// refusal apart from an ordinary unmount failure.
-var errSymlinkedMountpoint = errors.New("refusing to follow a symlink")
-
 func kernelUnmount(ctx context.Context, mp string) error {
 	clog.FromContext(ctx).Debugf("umount2: %s (UMOUNT_NOFOLLOW)", mp)
 	err := unix.Unmount(mp, unix.UMOUNT_NOFOLLOW)
 	if err == nil {
 		return nil
 	}
-	// EINVAL covers both "not a mountpoint" and "target is a symlink", so
-	// name the second case rather than leaving the user with "invalid
-	// argument". This is for the message only -- the flag above is what
-	// provides the guarantee, so an lstat racing it cannot weaken anything.
+	// Name the symlink case rather than leaving the user with a bare errno.
+	// fuseDriver.Unmount branches on the result too, so this classifies as
+	// well as describes -- but the flag above is what provides the guarantee,
+	// so an lstat racing it cannot weaken anything.
+	//
+	// Deliberately errno-blind. As root the errno is EINVAL, which covers both
+	// "not a mountpoint" and "target is a symlink"; a non-root caller gets
+	// EPERM instead, because the kernel checks may_mount() before
+	// path_mounted(). Keying this on EINVAL would stop classifying on exactly
+	// the leg the branch is for.
 	if fi, lerr := os.Lstat(mp); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("umount %s: %w", mp, errSymlinkedMountpoint)
 	}

--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/chainguard-dev/clog"
@@ -203,6 +204,15 @@ func (d *fuseDriver) AssembleOverlay(ctx context.Context, lowers []string, upper
 	if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
 		return nil, fmt.Errorf("kernel overlay failed and fuse-overlayfs is not installed: %w", err)
 	}
+	// Only the fall-back needs this. The kernel overlay attempted just above
+	// unescapes the way escapeOverlayPath escapes; fuse-overlayfs does not.
+	paths := slices.Clone(lowers)
+	if !readOnly {
+		paths = append(paths, upper, work)
+	}
+	if err := checkFuseOverlayPaths(paths...); err != nil {
+		return nil, err
+	}
 	fArgs := buildFuseOverlayArgs(lowers, upper, work, merged, readOnly)
 	if err := runCmd(ctx, fArgs[0], fArgs[1:]...); err != nil {
 		return nil, err
@@ -309,6 +319,30 @@ func buildKernelOverlayArgs(lowers []string, upper, work, merged string, readOnl
 
 func buildFuseOverlayArgs(lowers []string, upper, work, merged string, readOnly bool) []string {
 	return []string{"fuse-overlayfs", "-o", overlayOpts(lowers, upper, work, readOnly), merged}
+}
+
+// fuseOverlayUnsupported are the characters fuse-overlayfs cannot round-trip
+// in a path, whatever escaping it is handed. Measured against 1.17 by mounting
+// a tree whose path contains each one, escaped and verbatim, with a clean-path
+// control:
+//
+//	,  escaped works; verbatim is split into separate options
+//	:  broken both ways -- \: is not honoured as the kernel honours it
+//	\  broken both ways -- eaten, so the path never resolves
+//
+// So escapeOverlayPath earns its keep for the comma and cannot help with the
+// other two. Refuse those rather than hand fuse-overlayfs an option string it
+// will misread and then fail on with a path the user never named.
+const fuseOverlayUnsupported = `:\`
+
+func checkFuseOverlayPaths(paths ...string) error {
+	for _, p := range paths {
+		if i := strings.IndexAny(p, fuseOverlayUnsupported); i >= 0 {
+			return fmt.Errorf("fuse-overlayfs cannot handle %q in a path (%s); use --mode=kernel, or a dest without it",
+				p[i:i+1], p)
+		}
+	}
+	return nil
 }
 
 // lookupFusermount returns the path to whichever of `fusermount3` or

--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -347,7 +347,7 @@ const fuseOverlayUnsupported = `:\`
 func checkFuseOverlayPaths(paths ...string) error {
 	for _, p := range paths {
 		if i := strings.IndexAny(p, fuseOverlayUnsupported); i >= 0 {
-			return fmt.Errorf("fuse-overlayfs cannot handle %q in a path (%s); use --mode=kernel, or a dest without it",
+			return fmt.Errorf("fuse-overlayfs cannot handle %q in a path (%s); use --mode=kernel (as root), or a dest without it",
 				p[i:i+1], p)
 		}
 	}

--- a/pkg/erofsmount/driver_linux.go
+++ b/pkg/erofsmount/driver_linux.go
@@ -29,9 +29,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// driver wraps the externally-invoked mount and umount commands used by Mount.
-// Two implementations exist on Linux: kernelDriver shells out to mount(8) and
-// umount(8); fuseDriver shells out to erofsfuse and fusermount.
+// driver wraps the mount and umount operations used by Mount. Two
+// implementations exist on Linux: kernelDriver shells out to mount(8) and
+// unmounts with umount(2) directly; fuseDriver shells out to erofsfuse and
+// fusermount, trying the kernel unmount first.
 type driver interface {
 	// Name returns the resolved mode (kernel or fuse), never auto.
 	Name() mode

--- a/pkg/erofsmount/driver_linux_test.go
+++ b/pkg/erofsmount/driver_linux_test.go
@@ -196,6 +196,65 @@ func TestCheckFuseOverlayPaths(t *testing.T) {
 	}
 }
 
+// The refusal is terminal and "not installed" is fixable, so AssembleOverlay
+// has to reach the path check first. An empty PATH fails both the kernel
+// overlay above it and the fuse-overlayfs LookPath after it, which makes the
+// order -- and which paths are checked, in what form -- observable.
+func TestAssembleOverlayChecksPathsBeforeLookPath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		lowers   []string
+		upper    string
+		work     string
+		readOnly bool
+		want     string
+	}{
+		{
+			name:   "colon in a lowerdir is refused, not deferred to LookPath",
+			lowers: []string{"/mnt/x:y/layers/00"},
+			want:   "fuse-overlayfs cannot handle",
+		},
+		{
+			// The check sees raw paths: escapeOverlayPath would turn this
+			// into "\," and a check on the escaped form would refuse it.
+			name:   "comma survives escaping and is not refused",
+			lowers: []string{"/mnt/x,y/layers/00"},
+			want:   "not installed",
+		},
+		{
+			name:     "read-only does not check upper or work",
+			lowers:   []string{"/mnt/x/layers/00"},
+			upper:    "/mnt/x:y/upper",
+			work:     "/mnt/x:y/work",
+			readOnly: true,
+			want:     "not installed",
+		},
+		{
+			name:   "writable checks upper",
+			lowers: []string{"/mnt/x/layers/00"},
+			upper:  "/mnt/x:y/upper",
+			work:   "/mnt/x/work",
+			want:   "fuse-overlayfs cannot handle",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PATH", t.TempDir())
+
+			merged := filepath.Join(t.TempDir(), "merged")
+			cleanup, err := (&fuseDriver{}).AssembleOverlay(context.Background(), tc.lowers, tc.upper, tc.work, merged, tc.readOnly)
+			if err == nil {
+				t.Fatal("AssembleOverlay succeeded with an empty PATH")
+			}
+			if cleanup != nil {
+				t.Error("a failed AssembleOverlay returned a cleanup func")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
 // fusermount carries its own UMOUNT_NOFOLLOW, so running it after the kernel
 // refusal only restates it -- and the join would bury the reason behind
 // fusermount's own wording.

--- a/pkg/erofsmount/driver_linux_test.go
+++ b/pkg/erofsmount/driver_linux_test.go
@@ -18,6 +18,7 @@ package erofsmount
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -161,6 +162,29 @@ func TestOverlayArgsEscapeSeparators(t *testing.T) {
 	}
 	if fuse[3] != merged {
 		t.Errorf("mountpoint: got %s want %s", fuse[3], merged)
+	}
+}
+
+// fusermount carries its own UMOUNT_NOFOLLOW, so running it after the kernel
+// refusal only restates it -- and the join would bury the reason behind
+// fusermount's own wording.
+func TestFuseDriverUnmountStopsAtASymlinkRefusal(t *testing.T) {
+	// An empty PATH means any fusermount attempt shows up in the error.
+	t.Setenv("PATH", t.TempDir())
+
+	link := filepath.Join(t.TempDir(), "merged")
+	if err := os.Symlink(t.TempDir(), link); err != nil {
+		t.Fatal(err)
+	}
+	err := (&fuseDriver{}).Unmount(context.Background(), link)
+	if err == nil {
+		t.Fatal("Unmount followed a symlinked mountpoint")
+	}
+	if !errors.Is(err, errSymlinkedMountpoint) {
+		t.Errorf("error %q is not the symlink refusal", err)
+	}
+	if strings.Contains(err.Error(), "fusermount") {
+		t.Errorf("fusermount was still attempted: %q", err)
 	}
 }
 

--- a/pkg/erofsmount/driver_linux_test.go
+++ b/pkg/erofsmount/driver_linux_test.go
@@ -165,6 +165,37 @@ func TestOverlayArgsEscapeSeparators(t *testing.T) {
 	}
 }
 
+// fuse-overlayfs cannot round-trip these however they are escaped, so they are
+// refused with a reason rather than handed over to fail on a path the user
+// never named. See the table on fuseOverlayUnsupported.
+func TestCheckFuseOverlayPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"plain", "/mnt/x/layers/00", false},
+		// The comma survives escaping, so it must not be refused here.
+		{"comma", "/mnt/x,y/layers/00", false},
+		{"colon", "/mnt/x:y/layers/00", true},
+		{"backslash", `/mnt/x\y/layers/00`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkFuseOverlayPaths(tc.path)
+			if tc.wantErr && err == nil {
+				t.Fatalf("checkFuseOverlayPaths(%q) accepted it", tc.path)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("checkFuseOverlayPaths(%q): %v", tc.path, err)
+			}
+		})
+	}
+	// Every path is checked, not just the first.
+	if err := checkFuseOverlayPaths("/fine", "/also/fine", "/no:pe"); err == nil {
+		t.Error("a bad path after good ones was accepted")
+	}
+}
+
 // fusermount carries its own UMOUNT_NOFOLLOW, so running it after the kernel
 // refusal only restates it -- and the join would bury the reason behind
 // fusermount's own wording.


### PR DESCRIPTION
The three take-or-leave nits from the review of #2415, all in
`pkg/erofsmount/driver_linux.go`. One commit each.

### 1. The interface comment describes an unmount that no longer happens

`28acdfd7` dropped the `umount(8)` requirement from `Preflight` but left the
`driver` doc comment saying `kernelDriver` shells out to it. Text only.

### 2. Stop at a symlink refusal in fuse mode

`fuseDriver.Unmount` tries the kernel unmount and falls back to `fusermount`,
which is right when the mount was simply made by the other tool and wrong when
the kernel refused because the mountpoint is a symlink. `fusermount` has
carried its own `UMOUNT_NOFOLLOW` since the CVE-2010-3879 fix, so it refuses
the same path again and the joined error buries the reason:

```
Error: umount .../decoy-link: refusing to follow a symlink
/usr/bin/fusermount3 -u .../decoy-link: exit status 1: ... Invalid argument
```

That second line is noise once the first has decided the matter. `kernelUnmount`
now wraps a sentinel for the symlink case so `Unmount` can return it as-is.
State-file paths pass `checkResolved` before reaching a driver, so this shrinks
surface rather than fixing an exposure.

### 3. Refuse paths fuse-overlayfs cannot round-trip

`escapeOverlayPath` emits the kernel's escaping to both legs, and review asked
whether fuse-overlayfs honours it. **Measured against 1.17 rather than
assumed** — mounting a tree whose path contains each character, escaped and
verbatim, against a clean-path control:

| in `DEST` | escaped (today) | verbatim (before #2415) |
| --- | --- | --- |
| *(control)* | ok | ok |
| `,` | **ok** | broken — split into separate options |
| `:` | broken | broken |
| `\` | broken | broken |

Two things follow. The escaping is a straight win for the comma on this leg and
cannot help with the other two. And it is **not** the regression it looked
like: a bare backslash was already eaten before the escaping went in, so that
dest fails identically before and after.

What is left is a bad failure mode rather than a wrong mount — fuse-overlayfs
reports `cannot resolve path .../dd`, naming a path the user never wrote. So
`:` and `\` are refused up front on the fall-back leg, with the reason and a
pointer at `--mode=kernel`, which handles them correctly. The kernel overlay
attempted just before the fall-back is unaffected: only the tool that cannot
cope declines.

The probe script is not included — it needs a live `fuse-overlayfs` and the
result is a fact about that tool, not about apko, so it is recorded as a table
in the comment on `fuseOverlayUnsupported` instead.

### Verification

`gofmt -l` clean, `golangci-lint run -n` reports 0 issues, `go build ./...` and
`GOOS=darwin go build ./...` both succeed, and `SOURCE_DATE_EPOCH=0 go test
./...` passes. The fuse-mode symlink test was checked to fail without its
change.

Both new unit tests do run in CI, in the `go-tests` job on the non-root
runner — where the symlink test passes via the EPERM+lstat path rather than
EINVAL, since the kernel checks `may_mount()` before `path_mounted()`. What
never runs anywhere is the **e2e** fuse leg: `hack/test-erofs.sh` goes through
sudo, so `resolveMode` picks kernel. That is one of the two items already
filed against #2408.

### Review follow-ups

Four commits addressing the review, one concern each:

- `06801ac9` — move `errSymlinkedMountpoint` above `kernelUnmount`'s doc block
  (it had captured the whole UMOUNT_NOFOLLOW rationale as its own godoc), and
  fix the two comments commit 2 made untrue: the lstat is no longer "for the
  message only", and "Both failures are reported" is now conditional. The
  lstat comment records the EPERM-vs-EINVAL detail, so a later cleanup keying
  it on EINVAL does not silently break the fuse leg.
- `64166080` — run `checkFuseOverlayPaths` before the `fuse-overlayfs`
  `LookPath`, since the refusal is terminal and "not installed" is fixable.
  With that order an empty-PATH test can pin the wiring: raw paths, and
  read-only excluding upper/work. Mutation-checked both ways.
- `cabc8693` — `--mode=kernel (as root)`; the user on this leg is non-root by
  construction, so the bare suggestion bounces off `kernelDriver.Preflight`.

On the fifth comment: yes, the refusal is deliberately version-blind rather
than a versioned check — "refuse until re-measured". There is no probe, and
1.17 is what the comment records.

Refs #2408
