### PR TITLE
fix(apk): stop racing on the shared indexOpts authenticator

### DIFF
--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -129,10 +129,7 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		if err != nil {
 			return nil, err
 		}
-		if opts.auth == nil {
-			opts.auth = auth.DefaultAuthenticators
-		}
-		if err := opts.auth.AddAuth(ctx, head); err != nil {
+		if err := opts.authenticator().AddAuth(ctx, head); err != nil {
 			return nil, fmt.Errorf("unable to add auth to request: %w", err)
 		}
 
@@ -320,10 +317,7 @@ func fetchRepositoryIndex(ctx context.Context, u string, etag string, opts *inde
 		req.Header.Set("I-Cant-Believe-Its-Not-If-None-Match", etag)
 	}
 
-	if opts.auth == nil {
-		opts.auth = auth.DefaultAuthenticators
-	}
-	if err := opts.auth.AddAuth(ctx, req); err != nil {
+	if err := opts.authenticator().AddAuth(ctx, req); err != nil {
 		return nil, fmt.Errorf("unable to add auth to request: %w", err)
 	}
 
@@ -490,6 +484,18 @@ type indexOpts struct {
 	auth                     auth.Authenticator
 	indexDecompressedMaxSize int64
 }
+
+// authenticator returns the configured authenticator, defaulting to the
+// ambient set when none was supplied. It deliberately does not memoize into o:
+// GetRepositoryIndexes shares one indexOpts across a goroutine per repository,
+// so writing the default back would be a data race.
+func (o *indexOpts) authenticator() auth.Authenticator {
+	if o.auth == nil {
+		return auth.DefaultAuthenticators
+	}
+	return o.auth
+}
+
 type IndexOption func(*indexOpts)
 
 func WithIgnoreSignatures(ignoreSignatures bool) IndexOption {

--- a/pkg/apk/apk/index_auth_test.go
+++ b/pkg/apk/apk/index_auth_test.go
@@ -1,0 +1,81 @@
+package apk
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"chainguard.dev/apko/pkg/apk/auth"
+)
+
+// TestAuthenticatorDoesNotMemoize pins the property the race fix depends on:
+// resolving the default authenticator must not write it back into the
+// indexOpts that GetRepositoryIndexes shares across its per-repository
+// goroutines.
+func TestAuthenticatorDoesNotMemoize(t *testing.T) {
+	opts := &indexOpts{}
+	// DefaultAuthenticators holds a slice type, which == would panic on.
+	if got := opts.authenticator(); !reflect.DeepEqual(got, auth.DefaultAuthenticators) {
+		t.Errorf("authenticator() = %v, want auth.DefaultAuthenticators", got)
+	}
+	if opts.auth != nil {
+		t.Error("authenticator() wrote the default back into indexOpts")
+	}
+
+	want := auth.StaticAuth("", "user", "pass")
+	opts = &indexOpts{auth: want}
+	if got := opts.authenticator(); got != want {
+		t.Errorf("authenticator() = %v, want the configured authenticator", got)
+	}
+}
+
+// TestGetRepositoryIndexesAnonymousConcurrent fetches several repositories
+// with no authenticator configured, which is what makes the shared indexOpts
+// interesting: every per-repository goroutine used to resolve the default
+// authenticator by writing to it. Fails under -race before the fix.
+func TestGetRepositoryIndexesAnonymousConcurrent(t *testing.T) {
+	idx := &APKIndex{Description: "auth-race-test"}
+	for i := range 4 {
+		idx.Packages = append(idx.Packages, &Package{
+			Name:     fmt.Sprintf("pkg-%d", i),
+			Version:  "1.0.0-r0",
+			Arch:     "x86_64",
+			Checksum: []byte("01234567890123456789"),
+		})
+	}
+	archive, err := ArchiveFromIndex(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	if _, err := body.ReadFrom(archive); err != nil {
+		t.Fatal(err)
+	}
+
+	// No ETag: the fetch is not deduplicated, so every repository runs the
+	// full HEAD-then-GET path, each of which authenticates its request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body.Bytes())
+	}))
+	defer srv.Close()
+
+	repos := make([]string, 0, 8)
+	for i := range cap(repos) {
+		repos = append(repos, fmt.Sprintf("%s/repo-%d", srv.URL, i))
+	}
+
+	indexes, err := GetRepositoryIndexes(t.Context(), repos, nil, "x86_64",
+		WithIgnoreSignatures(true), WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(indexes) != len(repos) {
+		t.Errorf("got %d indexes, want %d", len(indexes), len(repos))
+	}
+}


### PR DESCRIPTION
GetRepositoryIndexes builds one indexOpts and hands the same pointer to a goroutine per repository. Both places that authenticate a request resolved the default authenticator by writing it back into that shared struct:

    if opts.auth == nil {
        opts.auth = auth.DefaultAuthenticators
    }

so any caller that supplies no authenticator and more than one repository has its goroutines writing opts.auth concurrently. The qemu and firecracker kernel fetches in mono always carry an authenticator, which is why the anonymous multi-repo shape only surfaced now, as a `-race` failure in chainguard-dev/mono#52348.

Resolve the default through a read-only accessor instead of memoizing it. Behavior is unchanged: an unset authenticator still means auth.DefaultAuthenticators on every request.

The regression test fails under -race before the fix (both writes reported at index.go:132-133, from the errgroup fan-out) and passes after.