### PR TITLE
apk: expose cache metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.7
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	github.com/tmc/dot v0.2.0
@@ -106,7 +107,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -43,14 +43,16 @@ func newFlightCache[K comparable, V any]() *flightCache[K, V] {
 	}
 }
 
-// Do returns coalesces multiple calls, like singleflight, but also caches
+// Do coalesces multiple calls, like singleflight, but also caches
 // the result if the call is successful. Failures are not cached to avoid
-// permanently failing for transient errors.
-func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, error) {
+// permanently failing for transient errors. The boolean result reports
+// whether the key was already present, including an in-flight call.
+func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, bool, error) {
 	f.mux.RLock()
 	if v, ok := f.cache[key]; ok {
 		f.mux.RUnlock()
-		return v()
+		value, err := v()
+		return value, true, err
 	}
 	f.mux.RUnlock()
 
@@ -59,7 +61,8 @@ func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, error) {
 	// Doubly-checked-locking in case of race conditions.
 	if v, ok := f.cache[key]; ok {
 		f.mux.Unlock()
-		return v()
+		value, err := v()
+		return value, true, err
 	}
 
 	v := sync.OnceValues(fn)
@@ -72,7 +75,7 @@ func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, error) {
 	if err != nil {
 		f.Forget(key)
 	}
-	return val, err
+	return val, false, err
 }
 
 // Forget removes the given key from the cache.

--- a/pkg/apk/apk/cache_test.go
+++ b/pkg/apk/apk/cache_test.go
@@ -28,14 +28,14 @@ import (
 func TestFlightCache(t *testing.T) {
 	s := newFlightCache[string, int]()
 	var called int
-	r1, err := s.Do("test", func() (int, error) {
+	r1, _, err := s.Do("test", func() (int, error) {
 		called++
 		return 42, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 42, r1)
 
-	r2, err := s.Do("test", func() (int, error) {
+	r2, _, err := s.Do("test", func() (int, error) {
 		called++
 		return 1337, nil
 	})
@@ -45,7 +45,7 @@ func TestFlightCache(t *testing.T) {
 
 	s.Forget("test")
 
-	r3, err := s.Do("test", func() (int, error) {
+	r3, _, err := s.Do("test", func() (int, error) {
 		called++
 		return 1337, nil
 	})
@@ -53,7 +53,7 @@ func TestFlightCache(t *testing.T) {
 	require.Equal(t, 1337, r3)
 	require.Equal(t, 2, called, "Function should be called twice, once before and once after Forget")
 
-	differentKey, err := s.Do("test2", func() (int, error) {
+	differentKey, _, err := s.Do("test2", func() (int, error) {
 		return 7, nil
 	})
 	require.NoError(t, err)
@@ -63,19 +63,37 @@ func TestFlightCache(t *testing.T) {
 func TestFlightCacheCachesNoErrors(t *testing.T) {
 	s := newFlightCache[string, int]()
 	var called int
-	_, err := s.Do("test", func() (int, error) {
+	_, _, err := s.Do("test", func() (int, error) {
 		called++
 		return 42, assert.AnError
 	})
 	require.ErrorIs(t, assert.AnError, err)
 
-	r2, err := s.Do("test", func() (int, error) {
+	r2, _, err := s.Do("test", func() (int, error) {
 		called++
 		return 1337, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1337, r2)
 	require.Equal(t, 2, called, "Function should be called twice, once for the error and once for the success")
+}
+
+func TestFlightCacheReportsHits(t *testing.T) {
+	s := newFlightCache[string, int]()
+
+	value, hit, err := s.Do("test", func() (int, error) {
+		return 42, nil
+	})
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Equal(t, 42, value)
+
+	value, hit, err = s.Do("test", func() (int, error) {
+		return 1337, nil
+	})
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, 42, value)
 }
 
 func TestFlightCacheCoalescesCalls(t *testing.T) {
@@ -88,7 +106,7 @@ func TestFlightCacheCoalescesCalls(t *testing.T) {
 	var eg errgroup.Group
 	for range 10 {
 		eg.Go(func() error {
-			_, err := s.Do("test", func() (int, error) {
+			_, _, err := s.Do("test", func() (int, error) {
 				mux.Lock() // Hangs until the unlock below.
 				called.Add(1)
 				return 42, nil
@@ -106,7 +124,7 @@ func TestFlightCacheForgetFunc(t *testing.T) {
 	s := newFlightCache[string, int]()
 
 	for k, v := range map[string]int{"a-1": 1, "a-2": 2, "b-1": 3} {
-		_, err := s.Do(k, func() (int, error) { return v, nil })
+		_, _, err := s.Do(k, func() (int, error) { return v, nil })
 		require.NoError(t, err)
 	}
 
@@ -116,16 +134,16 @@ func TestFlightCacheForgetFunc(t *testing.T) {
 	})
 
 	// "a-*" keys should be evicted, so new values are computed.
-	r, err := s.Do("a-1", func() (int, error) { return 100, nil })
+	r, _, err := s.Do("a-1", func() (int, error) { return 100, nil })
 	require.NoError(t, err)
 	require.Equal(t, 100, r)
 
-	r, err = s.Do("a-2", func() (int, error) { return 200, nil })
+	r, _, err = s.Do("a-2", func() (int, error) { return 200, nil })
 	require.NoError(t, err)
 	require.Equal(t, 200, r)
 
 	// "b-1" should still be cached.
-	r, err = s.Do("b-1", func() (int, error) { return 999, nil })
+	r, _, err = s.Do("b-1", func() (int, error) { return 999, nil })
 	require.NoError(t, err)
 	require.Equal(t, 3, r, "b-1 should still return the cached value")
 }

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -1155,9 +1155,10 @@ func (a *APK) DiscoverKeys(ctx context.Context, repository string) ([]Key, error
 			client = rc.StandardClient()
 		}
 
-		return a.cache.shared.discoverKeys.Do(repository, func() ([]Key, error) {
+		keys, _, err := a.cache.shared.discoverKeys.Do(repository, func() ([]Key, error) {
 			return DiscoverKeys(ctx, client, a.auth, repository)
 		})
+		return keys, err
 	}
 
 	return DiscoverKeys(ctx, client, a.auth, repository)

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -40,6 +40,7 @@ import (
 
 	"chainguard.dev/apko/pkg/apk/auth"
 	sign "chainguard.dev/apko/pkg/apk/signature"
+	apkometrics "chainguard.dev/apko/pkg/metrics"
 )
 
 var signatureFileRegex = regexp.MustCompile(`^\.SIGN\.(DSA|RSA|RSA256|RSA512)\.(.*\.rsa\.pub)$`)
@@ -158,13 +159,15 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		etag, ok := etagFromResponse(resp)
 		if !ok {
 			// If there's no etag, we can't cache it, so just return the result.
+			apkometrics.RecordIndexCacheAccess(apkometrics.CacheResultBypass)
 			return fetchAndParse(etag)
 		}
 
 		key := cacheKey{url: u, etag: etag}
-		idx, err := i.indexes.Do(key, func() (NamedIndex, error) {
+		idx, hit, err := i.indexes.Do(key, func() (NamedIndex, error) {
 			return fetchAndParse(etag)
 		})
+		apkometrics.RecordIndexCacheAccess(cacheResult(hit))
 
 		// Remove any stale entries with the same URL but a different etag.
 		// This races with concurrent callers that may have a different etag: a
@@ -200,7 +203,7 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		}
 		i.modtimes[u] = mod
 
-		idx, err := i.indexes.Do(key, func() (NamedIndex, error) {
+		idx, hit, err := i.indexes.Do(key, func() (NamedIndex, error) {
 			b, err := os.ReadFile(u)
 			if err != nil {
 				return nil, fmt.Errorf("reading file: %w", err)
@@ -211,11 +214,19 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			}
 			return NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(idx)), nil
 		})
+		apkometrics.RecordIndexCacheAccess(cacheResult(hit))
 		if err == nil {
 			i.setCurrent(u, idx)
 		}
 		return idx, err
 	}
+}
+
+func cacheResult(hit bool) apkometrics.CacheResult {
+	if hit {
+		return apkometrics.CacheResultHit
+	}
+	return apkometrics.CacheResultMiss
 }
 
 // IndexURL returns the full URL to the index file for the given repo and arch.

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -159,9 +159,7 @@ func (d *defaultPackageGetter) GetPackage(ctx context.Context, pkg InstallablePa
 		return d.getPackageImpl(ctx, pkg)
 	}
 
-	cached := true
-	val, err := globalApkCache.Do(pkg.URL(), func() (*expandapk.APKExpanded, error) {
-		cached = false
+	val, cached, err := globalApkCache.Do(pkg.URL(), func() (*expandapk.APKExpanded, error) {
 		return d.getPackageImpl(ctx, pkg)
 	})
 	if !cached {

--- a/pkg/apk/apk/shameful_global_caches.go
+++ b/pkg/apk/apk/shameful_global_caches.go
@@ -20,6 +20,8 @@ import (
 	"slices"
 	"strings"
 	"sync"
+
+	apkometrics "chainguard.dev/apko/pkg/metrics"
 )
 
 // It is expensive to parse every version in the APKINDEX and grow a bunch of maps.
@@ -73,6 +75,7 @@ func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResol
 	// in-flight resolutions holding it finish, and no future replacement
 	// will purge it, so it must not (re-)enter the cache.
 	if !currentAll(indexes) {
+		apkometrics.RecordResolverCacheAccess(apkometrics.CacheResultBypass)
 		return newPkgResolver(ctx, indexes)
 	}
 
@@ -80,8 +83,10 @@ func (r *resolverCache) Get(ctx context.Context, indexes []NamedIndex) *PkgResol
 	defer r.Unlock()
 
 	if pr := r.find(indexes); pr != nil {
+		apkometrics.RecordResolverCacheAccess(apkometrics.CacheResultHit)
 		return pr.Clone()
 	}
+	apkometrics.RecordResolverCacheAccess(apkometrics.CacheResultMiss)
 
 	pr := newPkgResolver(ctx, indexes)
 	r.fill(indexes, pr)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics exposes Prometheus metrics emitted by apko.
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	cacheIndex    = "index"
+	cacheResolver = "resolver"
+)
+
+// CacheResult describes the outcome of a cache access.
+type CacheResult string
+
+const (
+	CacheResultBypass CacheResult = "bypass"
+	CacheResultHit    CacheResult = "hit"
+	CacheResultMiss   CacheResult = "miss"
+)
+
+var cacheAccesses = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "apko_cache_accesses_total",
+		Help: "The number of APK cache accesses by cache and result.",
+	},
+	[]string{"cache", "result"},
+)
+
+func init() {
+	for _, cache := range []string{cacheIndex, cacheResolver} {
+		for _, result := range []CacheResult{CacheResultBypass, CacheResultHit, CacheResultMiss} {
+			cacheAccesses.WithLabelValues(cache, string(result))
+		}
+	}
+}
+
+// Register registers APK metrics with registerer.
+func Register(registerer prometheus.Registerer) error {
+	return registerer.Register(cacheAccesses)
+}
+
+// RecordIndexCacheAccess records an index cache access.
+func RecordIndexCacheAccess(result CacheResult) {
+	cacheAccesses.WithLabelValues(cacheIndex, string(result)).Inc()
+}
+
+// RecordResolverCacheAccess records a package resolver cache access.
+func RecordResolverCacheAccess(result CacheResult) {
+	cacheAccesses.WithLabelValues(cacheResolver, string(result)).Inc()
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheAccesses(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, Register(registry))
+	before := cacheValues(t, registry)
+
+	RecordIndexCacheAccess(CacheResultHit)
+	RecordIndexCacheAccess(CacheResultHit)
+	RecordIndexCacheAccess(CacheResultMiss)
+	RecordResolverCacheAccess(CacheResultBypass)
+
+	after := cacheValues(t, registry)
+	for key, value := range before {
+		after[key] -= value
+	}
+
+	require.Equal(t, map[string]float64{
+		"index/bypass":    0,
+		"index/hit":       2,
+		"index/miss":      1,
+		"resolver/bypass": 1,
+		"resolver/hit":    0,
+		"resolver/miss":   0,
+	}, after)
+}
+
+func cacheValues(t *testing.T, registry *prometheus.Registry) map[string]float64 {
+	t.Helper()
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	values := map[string]float64{}
+	for _, family := range families {
+		if family.GetName() != "apko_cache_accesses_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			labels := map[string]string{}
+			for _, label := range metric.Label {
+				labels[label.GetName()] = label.GetValue()
+			}
+			values[labels["cache"]+"/"+labels["result"]] = metric.GetCounter().GetValue()
+		}
+	}
+	return values
+}


### PR DESCRIPTION
Add opt-in Prometheus metrics for resolver and index cache accesses so long-lived consumers can measure cache effectiveness.