### PR TITLE
apk: feed installation from an abstract PackageContents

### DIFF
--- a/pkg/apk/apk/contents.go
+++ b/pkg/apk/apk/contents.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"archive/tar"
+	"io/fs"
+	"os"
+
+	"chainguard.dev/apko/pkg/apk/expandapk"
+	"chainguard.dev/apko/pkg/apk/types"
+)
+
+// PackageContents is the per-package input to installation: the package's
+// control-section metadata, its install records (tar headers, in install
+// order), and a filesystem that opens each record's content by name. It
+// abstracts the expanded APK so installation can be fed the same information
+// from another carrier of it (e.g. a pre-indexed image of the package)
+// without consulting the APK itself.
+type PackageContents interface {
+	// PkgInfo returns the package's parsed .PKGINFO.
+	PkgInfo() (*types.PackageInfo, error)
+	// ControlSection returns the package's control section exactly as
+	// distributed — the compressed tar segment. This is the section's
+	// identity-bearing form: its SHA1 is the checksum apk records for the
+	// package.
+	ControlSection() ([]byte, error)
+	// ControlData returns the same section as the uncompressed tar stream,
+	// which script and trigger extraction read. Carriers hold one form or
+	// the other natively, and consumers need one or the other, so the
+	// contract carries both rather than making every side convert.
+	ControlData() ([]byte, error)
+	// Size returns the package's total size in bytes, as recorded in the
+	// installed database.
+	Size() int64
+	// Entries returns the package's install records in install order.
+	Entries() ([]tar.Header, error)
+	// FS opens an entry's content by its record name.
+	FS() fs.FS
+}
+
+// ExpandedContents adapts an expanded APK to [PackageContents].
+func ExpandedContents(exp *expandapk.APKExpanded) PackageContents {
+	return expandedContents{exp}
+}
+
+type expandedContents struct {
+	exp *expandapk.APKExpanded
+}
+
+func (e expandedContents) PkgInfo() (*types.PackageInfo, error) { return e.exp.PkgInfo() }
+func (e expandedContents) ControlSection() ([]byte, error)      { return os.ReadFile(e.exp.ControlFile) }
+func (e expandedContents) ControlData() ([]byte, error)         { return e.exp.ControlData() }
+func (e expandedContents) Size() int64                          { return e.exp.Size }
+func (e expandedContents) FS() fs.FS                            { return e.exp.TarFS }
+
+func (e expandedContents) Entries() ([]tar.Header, error) {
+	entries := e.exp.TarFS.Entries()
+	headers := make([]tar.Header, 0, len(entries))
+	for _, entry := range entries {
+		headers = append(headers, entry.Header)
+	}
+	return headers, nil
+}
+
+// PackageData exposes the whole data section as a tar stream, which the
+// non-WriteHeaderer install path consumes.
+func (e expandedContents) PackageData() (*os.File, error) { return e.exp.PackageData() }

--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -824,7 +824,7 @@ func (a *APK) InstallPackages(ctx context.Context, sourceDateEpoch *time.Time, a
 				asPackage := pkgInfo.AsPackage(exp.ControlHash, uint64(exp.Size))
 				infos[i] = asPackage
 
-				installedFiles, err := a.installPackage(ctx, asPackage, exp, sourceDateEpoch)
+				installedFiles, err := a.installPackage(ctx, asPackage, ExpandedContents(exp), sourceDateEpoch)
 				if err != nil {
 					return fmt.Errorf("installing %s: %w", pkg, err)
 				}
@@ -1253,11 +1253,11 @@ type WriteHeaderer interface {
 }
 
 // installPackage installs a single package and updates installed db.
-func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expandapk.APKExpanded, sourceDateEpoch *time.Time) ([]tar.Header, error) {
+func (a *APK) installPackage(ctx context.Context, pkg *Package, contents PackageContents, sourceDateEpoch *time.Time) ([]tar.Header, error) {
 	log := clog.FromContext(ctx)
 	log.Infof("installing %s (%s)", pkg.Name, pkg.Version)
 
-	// We don't want to call `defer expanded.Close()` to to remove tempDir because our
+	// For expanded APKs we don't remove the backing tempDir because our
 	// cached files are advertised by symlinks pointing into them.
 	//
 	// This is not a big deal because the temp files if not referred by
@@ -1272,14 +1272,24 @@ func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expand
 	)
 
 	if wh, ok := a.fs.(WriteHeaderer); ok {
-		installedFiles, err = a.lazilyInstallAPKFiles(ctx, wh, expanded.TarFS, pkg)
+		entries, err := contents.Entries()
+		if err != nil {
+			return nil, fmt.Errorf("reading install records for pkg %s: %w", pkg.Name, err)
+		}
+		installedFiles, err = a.lazilyInstallAPKFiles(ctx, wh, entries, contents.FS(), pkg)
 		if err != nil {
 			return nil, fmt.Errorf("unable to install files for pkg %s: %w", pkg.Name, err)
 		}
 	} else {
-		packageData, err := expanded.PackageData()
+		// The non-WriteHeaderer path streams the whole data section as a
+		// tar, which not every contents carrier can produce.
+		pd, ok := contents.(interface{ PackageData() (*os.File, error) })
+		if !ok {
+			return nil, fmt.Errorf("installing %s: filesystem does not implement WriteHeaderer and the package contents carry no data stream", pkg.Name)
+		}
+		packageData, err := pd.PackageData()
 		if err != nil {
-			return nil, fmt.Errorf("opening package file %q: %w", expanded.PackageFile, err)
+			return nil, fmt.Errorf("opening package data for %s: %w", pkg.Name, err)
 		}
 		defer packageData.Close()
 
@@ -1290,18 +1300,17 @@ func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expand
 	}
 
 	// update the scripts.tar
-	controlData, err := expanded.ControlData()
+	controlData, err := contents.ControlData()
 	if err != nil {
-		return nil, fmt.Errorf("opening control file %q: %w", expanded.ControlFile, err)
+		return nil, fmt.Errorf("opening control data for %s: %w", pkg.Name, err)
 	}
-
 	controlTar := bytes.NewReader(controlData)
 	if err := a.updateScriptsTar(pkg, controlTar, sourceDateEpoch); err != nil {
 		return nil, fmt.Errorf("unable to update scripts.tar for pkg %s: %w", pkg.Name, err)
 	}
 
 	// update the triggers
-	pkgInfo, err := expanded.PkgInfo()
+	pkgInfo, err := contents.PkgInfo()
 	if err != nil {
 		return nil, fmt.Errorf("reading pkginfo from %s: %w", pkg.Name, err)
 	}

--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -24,13 +24,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"slices"
 	"strings"
 
 	"go.opentelemetry.io/otel"
-
-	"chainguard.dev/apko/pkg/apk/expandapk/tarfs"
 )
 
 // writeOneFile writes one file from the APK given the tar header and tar reader.
@@ -307,40 +306,39 @@ func checksumFromHeader(header *tar.Header) ([]byte, error) {
 	return checksum, nil
 }
 
-// lazilyInstallAPKFiles avoids actually writing anything to disk, instead relying on a tarfs.FS
-// to provide much cheaper access to the file data when we read it later.
+// lazilyInstallAPKFiles avoids actually writing anything to disk, instead relying on the
+// contents' filesystem to provide much cheaper access to the file data when we read it later.
 //
 // This is an optimizing fastpath for when a.fs is a specific implementation that supports it.
-func (a *APK) lazilyInstallAPKFiles(ctx context.Context, wh WriteHeaderer, tf *tarfs.FS, pkg *Package) ([]tar.Header, error) {
+func (a *APK) lazilyInstallAPKFiles(ctx context.Context, wh WriteHeaderer, entries []tar.Header, src fs.FS, pkg *Package) ([]tar.Header, error) {
 	_, span := otel.Tracer("go-apk").Start(ctx, "lazilyInstallAPKFiles")
 	defer span.End()
 
-	entries := tf.Entries()
 	files := make([]tar.Header, 0, len(entries))
 
 	var startedDataSection bool
-	for _, file := range entries {
+	for _, hdr := range entries {
 		// per https://git.alpinelinux.org/apk-tools/tree/src/extract_v2.c?id=337734941831dae9a6aa441e38611c43a5fd72c0#n120
 		//  * APKv1.0 compatibility - first non-hidden file is
 		//  * considered to start the data section of the file.
 		//  * This does not make any sense if the file has v2.0
 		//  * style .PKGINFO
-		if !startedDataSection && file.Header.Name[0] == '.' && !strings.Contains(file.Header.Name, "/") {
+		if !startedDataSection && hdr.Name[0] == '.' && !strings.Contains(hdr.Name, "/") {
 			continue
 		}
 		// whatever it is now, it is in the data section
 		startedDataSection = true
 
-		installed, err := wh.WriteHeader(file.Header, tf, pkg)
+		installed, err := wh.WriteHeader(hdr, src, pkg)
 		if err != nil {
 			return nil, err
 		}
 
-		if installed && file.Header.Typeflag == tar.TypeReg {
-			a.installedFiles[file.Header.Name] = pkg
+		if installed && hdr.Typeflag == tar.TypeReg {
+			a.installedFiles[hdr.Name] = pkg
 		}
 
-		files = append(files, file.Header)
+		files = append(files, hdr)
 	}
 
 	return files, nil


### PR DESCRIPTION
Installation consumed *expandapk.APKExpanded concretely, coupling it to the expanded-APK carrier even though the lazy install path only needs the ordered install records and a filesystem to open their content. Introduce PackageContents as the per-package installation input, adapt the expanded APK to it, and generalize installPackage/lazilyInstallAPKFiles over it.

The control-shaped surface is one method: ControlSection returns the compressed control segment exactly as distributed, and installation derives everything from those bytes — their SHA1 is the package checksum apk records (by definition), and script/trigger extraction reads the decompressed stream. Carriers therefore cannot disagree with themselves about the checksum of the control data they present.

InstallPackageContents installs exactly a caller-supplied, pre-settled package list from its contents — no index, no resolution, no fetch — and build.WithPreResolvedPackages exposes that to image builds, alongside the existing lockfile path. Downstream callers can then carry package contents in forms of their own choosing without apko learning those forms.