### PR TITLE
build: install a pre-resolved package list from supplied contents

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // this is what apk tools is using
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -856,6 +857,58 @@ func (a *APK) InstallPackages(ctx context.Context, sourceDateEpoch *time.Time, a
 		return nil, fmt.Errorf("installing packages: %w", withCause(ctx, err))
 	}
 
+	return a.recordInstalled(ctx, infos, allFiles)
+}
+
+// InstallPackageContents installs exactly the given packages, in the given
+// order, from their supplied contents: no index is consulted, no dependency
+// resolution happens, and nothing is fetched — the caller has already settled
+// the set and supplies each member's contents.
+func (a *APK) InstallPackageContents(ctx context.Context, sourceDateEpoch *time.Time, all []PackageContents) ([]InstalledDiff, error) {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "InstallPackageContents")
+	defer span.End()
+
+	allFiles := make([][]tar.Header, len(all))
+	infos := make([]*Package, len(all))
+
+	for i, contents := range all {
+		pkgInfo, err := contents.PkgInfo()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read .PKGINFO for package %d: %w", i, err)
+		}
+
+		isInstalled, err := a.isInstalledPackage(pkgInfo.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error checking if package %s is installed: %w", pkgInfo.Name, err)
+		}
+		if isInstalled {
+			continue
+		}
+
+		// The package checksum is, by definition, the SHA1 of the compressed
+		// control section.
+		section, err := contents.ControlSection()
+		if err != nil {
+			return nil, fmt.Errorf("opening control section for %s: %w", pkgInfo.Name, err)
+		}
+		checksum := sha1.Sum(section) //nolint:gosec // this is what apk tools is using
+		asPackage := pkgInfo.AsPackage(checksum[:], uint64(contents.Size()))
+		infos[i] = asPackage
+
+		installedFiles, err := a.installPackage(ctx, asPackage, contents, sourceDateEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("installing %s: %w", pkgInfo.Name, err)
+		}
+
+		allFiles[i] = installedFiles
+	}
+
+	return a.recordInstalled(ctx, infos, allFiles)
+}
+
+// recordInstalled writes the installed-database entries for the given
+// packages and their files, dropping files a later package overwrote.
+func (a *APK) recordInstalled(ctx context.Context, infos []*Package, allFiles [][]tar.Header) ([]InstalledDiff, error) {
 	diffs := make([]InstalledDiff, 0, len(allFiles))
 
 	// update the installed file

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -152,7 +152,13 @@ func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) 
 		pkgs []apk.InstalledDiff
 		err  error
 	)
-	if bc.o.Lockfile != "" {
+	switch {
+	case len(bc.o.PreResolvedPackages) > 0:
+		pkgs, err = bc.apk.InstallPackageContents(ctx, &bc.o.SourceDateEpoch, bc.o.PreResolvedPackages)
+		if err != nil {
+			return nil, fmt.Errorf("failed installation from pre-resolved packages: %w", err)
+		}
+	case bc.o.Lockfile != "":
 		log.Debugf("Using lockfile: %s", bc.o.Lockfile)
 		lock, err := lock.FromFile(bc.o.Lockfile)
 		if err != nil {
@@ -170,7 +176,7 @@ func (bc *Context) buildImage(ctx context.Context) ([]apk.InstalledDiff, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed installation from lockfile %s: %w", bc.o.Lockfile, err)
 		}
-	} else {
+	default:
 		pkgs, err = bc.apk.FixateWorld(ctx, &bc.o.SourceDateEpoch)
 		if err != nil {
 			return nil, fmt.Errorf("installing apk packages: %w", err)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -263,6 +263,18 @@ func WithLockFile(lockFile string) Option {
 	}
 }
 
+// WithPreResolvedPackages provides the exact package set to install, in
+// order, with the contents each member installs from. The build installs
+// precisely these: no index is consulted and no dependency resolution
+// happens. The image configuration's package list still names the requested
+// world (written to /etc/apk/world); this option settles how it is satisfied.
+func WithPreResolvedPackages(contents []apk.PackageContents) Option {
+	return func(bc *Context) error {
+		bc.o.PreResolvedPackages = contents
+		return nil
+	}
+}
+
 func WithTempDir(tmp string) Option {
 	return func(bc *Context) error {
 		bc.o.TempDirPath = tmp

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -80,6 +80,7 @@ type Options struct {
 	Offline                 bool                  `json:"offline,omitempty"`
 	SharedCache             *apk.Cache            `json:"-"`
 	Lockfile                string                `json:"lockfile,omitempty"`
+	PreResolvedPackages     []apk.PackageContents `json:"-"`
 	Auth                    auth.Authenticator    `json:"-"`
 	IncludePaths            []string              `json:"includePaths,omitempty"`
 	IgnoreSignatures        bool                  `json:"ignoreSignatures,omitempty"`


### PR DESCRIPTION
InstallPackageContents installs exactly a caller-supplied, pre-settled package list from its contents — no index is consulted, no dependency resolution happens, and nothing is fetched; the package checksum is derived from each carrier's control section (its SHA1, by definition). The installed-database tail is shared with InstallPackages via recordInstalled, so both installers write the database through one code path.

build.WithPreResolvedPackages exposes this to image builds as a third way to satisfy the configured world, beside the existing lockfile path and FixateWorld: the configuration's package list still names the requested world; the option settles how it is satisfied. Downstream callers can then carry package contents in forms of their own choosing without apko learning those forms.