### PR TITLE
apk: keep dir mode bits and ownership in the streaming install path

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -305,8 +305,11 @@ func (a *APK) InitDB(ctx context.Context, buildRepos ...string) error {
 			return fmt.Errorf("error opening base directory %s: %w", e.path, err)
 		case !stat.IsDir():
 			return fmt.Errorf("base directory %s is not a directory", e.path)
-		case stat.Mode().Perm() != e.perms:
-			return fmt.Errorf("base directory %s has incorrect permissions: %o", e.path, stat.Mode().Perm())
+		// Compare every non-type bit, not just Perm(): /tmp is expected to be
+		// sticky, and Perm() masks fs.ModeSticky off, so the two could never
+		// be equal.
+		case stat.Mode()&^fs.ModeType != e.perms:
+			return fmt.Errorf("base directory %s has incorrect permissions: %s, expected %s", e.path, stat.Mode()&^fs.ModeType, e.perms)
 		}
 	}
 	for _, e := range initDirectories {

--- a/pkg/apk/apk/implementation_test.go
+++ b/pkg/apk/apk/implementation_test.go
@@ -1033,3 +1033,25 @@ func TestDiscoverKeysRSA(t *testing.T) {
 	require.Len(t, keys, 1)
 	require.Equal(t, "rsa-test.rsa.pub", keys[0].ID)
 }
+
+// TestInitDBBaseDirectoryPerms covers the base-directory permission check
+// against a filesystem where the directories already exist, which is the only
+// case that reaches the comparison.
+func TestInitDBBaseDirectoryPerms(t *testing.T) {
+	t.Run("sticky tmp accepted", func(t *testing.T) {
+		src := apkfs.NewMemFS()
+		require.NoError(t, src.Mkdir("/tmp", fs.ModeSticky|0o777))
+		apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		require.NoError(t, err)
+		require.NoError(t, apk.InitDB(t.Context()))
+	})
+
+	t.Run("non-sticky tmp rejected", func(t *testing.T) {
+		src := apkfs.NewMemFS()
+		require.NoError(t, src.Mkdir("/tmp", 0o777))
+		apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+		require.NoError(t, err)
+		err = apk.InitDB(t.Context())
+		require.ErrorContains(t, err, "base directory /tmp has incorrect permissions")
+	})
+}

--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -236,11 +236,16 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 				// need a separate Chmod. Restrict both of these to directories we
 				// just created: InitDB creates /tmp as 1777 before any package
 				// installs, and packages ship a tmp header without the sticky bit.
-				if err := a.fs.Chmod(header.Name, mode&^fs.ModeType); err != nil {
-					return nil, fmt.Errorf("error setting mode on directory %s: %w", header.Name, err)
-				}
+				//
+				// Chown comes first, as it must for a regular file (see below).
+				// Directories are exempt from that clearing, but the two paths
+				// disagreeing on the order would invite a cleanup that breaks
+				// the one where it matters.
 				if err := a.fs.Chown(header.Name, header.Uid, header.Gid); err != nil {
 					return nil, fmt.Errorf("error setting owner on directory %s: %w", header.Name, err)
+				}
+				if err := a.fs.Chmod(header.Name, mode&^fs.ModeType); err != nil {
+					return nil, fmt.Errorf("error setting mode on directory %s: %w", header.Name, err)
 				}
 			}
 			// xattrs
@@ -263,6 +268,21 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 			if installed {
 				a.installedFiles[header.Name] = pkg
 
+				// Nothing on this path applies the header's ownership, so
+				// without this every installed file comes out 0:0 — which for a
+				// setgid binary means setgid to root rather than to the group
+				// the package asked for.
+				//
+				// Chown MUST come before Chmod, and the order is load-bearing:
+				// chown(2) on a regular file clears setuid/setgid, for root as
+				// well, so chowning after restoring those bits would drop them
+				// again on any filesystem that writes through to disk. The
+				// in-memory overrides would still say otherwise, which is what
+				// makes the loss silent. TestInstallAPKFilesMetadataOrder pins
+				// this.
+				if err := a.fs.Chown(header.Name, header.Uid, header.Gid); err != nil {
+					return nil, fmt.Errorf("error setting owner on %s: %w", header.Name, err)
+				}
 				// The mode passed to OpenFile only reaches the in-memory
 				// metadata; an on-disk write drops setuid/setgid/sticky, both
 				// because *os.Root refuses them in OpenFile and because Linux
@@ -274,13 +294,6 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 					if err := a.fs.Chmod(header.Name, mode&^fs.ModeType); err != nil {
 						return nil, fmt.Errorf("error setting mode on %s: %w", header.Name, err)
 					}
-				}
-				// Nothing on this path applies the header's ownership, so
-				// without this every installed file comes out 0:0 — which for a
-				// setgid binary means setgid to root rather than to the group
-				// the package asked for.
-				if err := a.fs.Chown(header.Name, header.Uid, header.Gid); err != nil {
-					return nil, fmt.Errorf("error setting owner on %s: %w", header.Name, err)
 				}
 
 				if err := a.fs.Chtimes(header.Name, header.AccessTime, header.ModTime); err != nil {

--- a/pkg/apk/apk/install.go
+++ b/pkg/apk/apk/install.go
@@ -216,16 +216,32 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 		case tar.TypeDir:
 			// special case, if the target already exists, and it is a symlink to a directory, we can accept it as is
 			// otherwise, we need to create the directory.
-			if fi, err := a.fs.Stat(header.Name); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			// Whether it already exists also decides if we get to set its
+			// metadata below, so keep the error from this one Stat.
+			existing, statErr := a.fs.Stat(header.Name)
+			if statErr == nil && existing.Mode()&os.ModeSymlink != 0 {
 				if target, err := a.fs.Readlink(header.Name); err == nil {
-					if fi, err = a.fs.Stat(target); err == nil && fi.IsDir() {
+					if fi, err := a.fs.Stat(target); err == nil && fi.IsDir() {
 						// "break" rather than "continue", so that any handling outside of this switch statement is processed
 						break
 					}
 				}
 			}
-			if err := a.fs.MkdirAll(header.Name, header.FileInfo().Mode().Perm()); err != nil {
+			mode := header.FileInfo().Mode()
+			if err := a.fs.MkdirAll(header.Name, mode.Perm()); err != nil {
 				return nil, fmt.Errorf("error creating directory %s: %w", header.Name, err)
+			}
+			if statErr != nil {
+				// MkdirAll carries only permission bits, so setuid/setgid/sticky
+				// need a separate Chmod. Restrict both of these to directories we
+				// just created: InitDB creates /tmp as 1777 before any package
+				// installs, and packages ship a tmp header without the sticky bit.
+				if err := a.fs.Chmod(header.Name, mode&^fs.ModeType); err != nil {
+					return nil, fmt.Errorf("error setting mode on directory %s: %w", header.Name, err)
+				}
+				if err := a.fs.Chown(header.Name, header.Uid, header.Gid); err != nil {
+					return nil, fmt.Errorf("error setting owner on directory %s: %w", header.Name, err)
+				}
 			}
 			// xattrs
 			for k, v := range header.PAXRecords {
@@ -246,6 +262,26 @@ func (a *APK) installAPKFiles(ctx context.Context, in io.Reader, pkg *Package) (
 
 			if installed {
 				a.installedFiles[header.Name] = pkg
+
+				// The mode passed to OpenFile only reaches the in-memory
+				// metadata; an on-disk write drops setuid/setgid/sticky, both
+				// because *os.Root refuses them in OpenFile and because Linux
+				// clears them on write for unprivileged processes. Chmod after
+				// the content is written, and only when there is something
+				// beyond the permission bits to restore.
+				mode := header.FileInfo().Mode()
+				if mode&^fs.ModePerm != 0 {
+					if err := a.fs.Chmod(header.Name, mode&^fs.ModeType); err != nil {
+						return nil, fmt.Errorf("error setting mode on %s: %w", header.Name, err)
+					}
+				}
+				// Nothing on this path applies the header's ownership, so
+				// without this every installed file comes out 0:0 — which for a
+				// setgid binary means setgid to root rather than to the group
+				// the package asked for.
+				if err := a.fs.Chown(header.Name, header.Uid, header.Gid); err != nil {
+					return nil, fmt.Errorf("error setting owner on %s: %w", header.Name, err)
+				}
 
 				if err := a.fs.Chtimes(header.Name, header.AccessTime, header.ModTime); err != nil {
 					return nil, fmt.Errorf("chtimes for %s: %w", header.Name, err)

--- a/pkg/apk/apk/install_test.go
+++ b/pkg/apk/apk/install_test.go
@@ -27,10 +27,14 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 	"text/template"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	apkfs "chainguard.dev/apko/pkg/apk/fs"
 )
 
 type testDirEntry struct {
@@ -479,3 +483,122 @@ provider_priority = {{ .Dependencies.ProviderPriority }}
 {{- end }}
 datahash = {{.DataHash}}
 `
+
+// TestInstallAPKFilesModesAndOwnership covers the metadata the streaming
+// install path has to carry over from the tar headers: the mode bits outside
+// of Perm(), and the ownership.
+func TestInstallAPKFilesModesAndOwnership(t *testing.T) {
+	type entry struct {
+		name    string
+		mode    int64 // POSIX mode bits, as they appear in a tar header
+		dir     bool
+		uid     int
+		gid     int
+		content []byte
+	}
+	entries := []entry{
+		// dirs first, so they exist before the files under them
+		{name: "opt", mode: 0o755, dir: true},
+		{name: "opt/bin", mode: 0o755, dir: true},
+		{name: "var", mode: 0o755, dir: true},
+		{name: "var/spool", mode: 0o1777, dir: true},
+		{name: "var/spool/postfix", mode: 0o2755, dir: true, gid: 101},
+		// modelled on wolfi's postfix, which ships these setgid to gid 101
+		{name: "opt/bin/postdrop", mode: 0o2755, gid: 101, content: []byte("postdrop")},
+		{name: "opt/bin/plain", mode: 0o644, content: []byte("plain")},
+		// a package that ships a header for a directory the base layout
+		// already created must not overwrite what is there
+		{name: "tmp", mode: 0o755, dir: true, uid: 7, gid: 7},
+	}
+
+	apk, src, err := testGetTestAPK()
+	require.NoErrorf(t, err, "failed to get test APK")
+
+	// stand in for InitDB, which creates /tmp as 1777 before any package installs
+	require.NoError(t, src.MkdirAll("tmp", fs.ModeDir|fs.ModeSticky|0o777))
+	require.NoError(t, src.Chmod("tmp", fs.ModeSticky|0o777))
+	require.NoError(t, src.Chown("tmp", 5, 5))
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: tar.TypeReg,
+			Mode:     e.mode,
+			Uid:      e.uid,
+			Gid:      e.gid,
+			Size:     int64(len(e.content)),
+		}
+		if e.dir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Size = 0
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if e.content != nil {
+			_, err := tw.Write(e.content)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+
+	_, err = apk.installAPKFiles(context.Background(), bytes.NewReader(buf.Bytes()), &Package{Origin: ""})
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		fi, err := src.Stat(e.name)
+		require.NoError(t, err, "error statting %s", e.name)
+
+		wantMode := (&tar.Header{Mode: e.mode}).FileInfo().Mode() &^ fs.ModeType
+		wantUID, wantGID := e.uid, e.gid
+		if e.name == "tmp" {
+			// pre-existing: keeps the mode and owner it already had
+			wantMode = fs.ModeSticky | 0o777
+			wantUID, wantGID = 5, 5
+		}
+		if e.dir {
+			wantMode |= fs.ModeDir
+		}
+		assert.Equal(t, wantMode, fi.Mode(), "mismatched mode for %s", e.name)
+
+		hdr, ok := fi.Sys().(*tar.Header)
+		require.True(t, ok, "no tar.Header from Sys() for %s", e.name)
+		assert.Equal(t, wantUID, hdr.Uid, "mismatched uid for %s", e.name)
+		assert.Equal(t, wantGID, hdr.Gid, "mismatched gid for %s", e.name)
+	}
+}
+
+// TestInstallAPKFilesModesOnDisk is the same concern as
+// TestInstallAPKFilesModesAndOwnership, against a disk-backed filesystem.
+// Those strip setuid/setgid/sticky from the mode passed to MkdirAll and
+// OpenFile, so the bits only reach the disk if we Chmod afterwards. Ownership
+// is not asserted: Chown needs privileges the test does not have, and the
+// filesystem tolerates the EPERM.
+func TestInstallAPKFilesModesOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	src := apkfs.DirFS(t.Context(), dir)
+	require.NotNil(t, src)
+	apk, err := New(t.Context(), WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "var", Typeflag: tar.TypeDir, Mode: 0o755}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "var/spool", Typeflag: tar.TypeDir, Mode: 0o1777}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "postdrop", Typeflag: tar.TypeReg, Mode: 0o2755, Size: 8}))
+	_, err = tw.Write([]byte("postdrop"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	_, err = apk.installAPKFiles(t.Context(), bytes.NewReader(buf.Bytes()), &Package{Origin: ""})
+	require.NoError(t, err)
+
+	for name, want := range map[string]fs.FileMode{
+		"var/spool": fs.ModeDir | fs.ModeSticky | 0o777,
+		"postdrop":  fs.ModeSetgid | 0o755,
+	} {
+		fi, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err, "error statting %s", name)
+		assert.Equal(t, want, fi.Mode(), "mismatched on-disk mode for %s", name)
+	}
+}

--- a/pkg/apk/apk/install_test.go
+++ b/pkg/apk/apk/install_test.go
@@ -28,6 +28,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
 	"text/template"
 
@@ -588,6 +590,16 @@ func TestInstallAPKFilesModesOnDisk(t *testing.T) {
 	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "postdrop", Typeflag: tar.TypeReg, Mode: 0o2755, Size: 8}))
 	_, err = tw.Write([]byte("postdrop"))
 	require.NoError(t, err)
+	// A header owned by whoever runs the test is the one case where the disk
+	// chown actually succeeds unprivileged, so this is the entry that reaches
+	// the kernel's clearing of setgid on chown(2) rather than an EPERM the
+	// filesystem swallows. It fails if Chmod is applied before Chown.
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "selfowned", Typeflag: tar.TypeReg, Mode: 0o2755,
+		Uid: os.Getuid(), Gid: os.Getgid(), Size: 4,
+	}))
+	_, err = tw.Write([]byte("self"))
+	require.NoError(t, err)
 	require.NoError(t, tw.Close())
 
 	_, err = apk.installAPKFiles(t.Context(), bytes.NewReader(buf.Bytes()), &Package{Origin: ""})
@@ -596,9 +608,77 @@ func TestInstallAPKFilesModesOnDisk(t *testing.T) {
 	for name, want := range map[string]fs.FileMode{
 		"var/spool": fs.ModeDir | fs.ModeSticky | 0o777,
 		"postdrop":  fs.ModeSetgid | 0o755,
+		"selfowned": fs.ModeSetgid | 0o755,
 	} {
 		fi, err := os.Stat(filepath.Join(dir, name))
 		require.NoError(t, err, "error statting %s", name)
 		assert.Equal(t, want, fi.Mode(), "mismatched on-disk mode for %s", name)
+	}
+}
+
+// orderRecordingFS records the order in which Chmod and Chown reach each path.
+// It only records — every call still runs against the wrapped filesystem, so
+// there is no emulated behavior here to drift out of sync with the real thing.
+type orderRecordingFS struct {
+	apkfs.FullFS
+
+	mu    sync.Mutex
+	calls map[string][]string
+}
+
+func newOrderRecordingFS(inner apkfs.FullFS) *orderRecordingFS {
+	return &orderRecordingFS{FullFS: inner, calls: map[string][]string{}}
+}
+
+func (o *orderRecordingFS) record(path, op string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls[path] = append(o.calls[path], op)
+}
+
+func (o *orderRecordingFS) ops(path string) []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.calls[path])
+}
+
+func (o *orderRecordingFS) Chmod(path string, perm fs.FileMode) error {
+	o.record(path, "chmod")
+	return o.FullFS.Chmod(path, perm)
+}
+
+func (o *orderRecordingFS) Chown(path string, uid, gid int) error {
+	o.record(path, "chown")
+	return o.FullFS.Chown(path, uid, gid)
+}
+
+// TestInstallAPKFilesMetadataOrder pins Chown before Chmod. chown(2) on a
+// regular file clears setuid/setgid — for root too — so chowning after the
+// Chmod that restores those bits drops them again on any filesystem that
+// writes through to disk. No unprivileged test can observe that: dirFS
+// tolerates the EPERM from the disk chown and never reaches the kernel
+// behavior, so the call order is pinned here instead.
+func TestInstallAPKFilesMetadataOrder(t *testing.T) {
+	rec := newOrderRecordingFS(apkfs.NewMemFS())
+	apk, err := New(t.Context(), WithFS(rec), WithIgnoreMknodErrors(ignoreMknodErrors))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "var", Typeflag: tar.TypeDir, Mode: 0o755}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "var/spool", Typeflag: tar.TypeDir, Mode: 0o1777}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "postdrop", Typeflag: tar.TypeReg, Mode: 0o2755, Gid: 101, Size: 8}))
+	_, err = tw.Write([]byte("postdrop"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	_, err = apk.installAPKFiles(t.Context(), bytes.NewReader(buf.Bytes()), &Package{Origin: ""})
+	require.NoError(t, err)
+
+	// The setgid file is the case the kernel would bite; the sticky directory
+	// is here so the two paths cannot drift apart unnoticed.
+	for _, name := range []string{"postdrop", "var/spool"} {
+		assert.Equal(t, []string{"chown", "chmod"}, rec.ops(name),
+			"metadata calls for %s must be chown then chmod", name)
 	}
 }

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -166,12 +166,16 @@ func DirFS(ctx context.Context, dir string, opts ...DirFSOption) FullFS {
 // resolves against (Lstat reads them directly, Stat takes Mode() from them),
 // so an entry seeded as the wrong type is reported as the wrong type from then
 // on. readlink resolves a symlink's target through the sandboxed root.
+//
+// The same goes for the mode: seeding only Perm() would report a sticky
+// directory or a setgid binary already on disk without those bits, so
+// directories and regular files carry every non-type bit over.
 func (f *dirFS) seedOverride(path string, fi fs.FileInfo, readlink func(string) (string, error)) error {
 	mode := fi.Mode()
 	perm := mode.Perm()
 	switch {
 	case mode.IsDir():
-		return f.overrides.Mkdir(path, os.ModeDir|perm)
+		return f.overrides.Mkdir(path, os.ModeDir|mode&^fs.ModeType)
 	case mode&fs.ModeSymlink != 0:
 		target, err := readlink(path)
 		if err != nil {
@@ -192,7 +196,7 @@ func (f *dirFS) seedOverride(path string, fi fs.FileInfo, readlink func(string) 
 		// Everything else — regular files, and the block devices, FIFOs and
 		// sockets the memFS overrides cannot represent — becomes an empty
 		// regular file whose content is served from disk.
-		memFile, err := f.overrides.OpenFile(path, os.O_CREATE, perm)
+		memFile, err := f.overrides.OpenFile(path, os.O_CREATE, mode&^fs.ModeType)
 		if memFile != nil {
 			_ = memFile.Close()
 		}

--- a/pkg/apk/fs/rwosfs.go
+++ b/pkg/apk/fs/rwosfs.go
@@ -170,18 +170,33 @@ func DirFS(ctx context.Context, dir string, opts ...DirFSOption) FullFS {
 // The same goes for the mode: seeding only Perm() would report a sticky
 // directory or a setgid binary already on disk without those bits, so
 // directories and regular files carry every non-type bit over.
+//
+// Mode and ownership have to be seeded together. A node seeded setuid but
+// left at the default uid 0 is worse than one with no setuid at all: a tree
+// holding a setuid file owned by an unprivileged user would serialize into an
+// image as setuid *root*. So the owner comes from the same Sys() as the mode,
+// and when it cannot be determined setuid/setgid are dropped instead.
 func (f *dirFS) seedOverride(path string, fi fs.FileInfo, readlink func(string) (string, error)) error {
 	mode := fi.Mode()
-	perm := mode.Perm()
+	uid, gid, haveOwner := ownerFromInfo(fi)
+	seedMode := mode &^ fs.ModeType
+	if !haveOwner {
+		seedMode &^= fs.ModeSetuid | fs.ModeSetgid
+	}
+
 	switch {
-	case mode.IsDir():
-		return f.overrides.Mkdir(path, os.ModeDir|mode&^fs.ModeType)
 	case mode&fs.ModeSymlink != 0:
+		// Handled without ownership: memFS.getNode resolves the final path
+		// component, so a Chown here would retarget the link's target.
 		target, err := readlink(path)
 		if err != nil {
 			return err
 		}
 		return f.overrides.Symlink(target, path)
+	case mode.IsDir():
+		if err := f.overrides.Mkdir(path, os.ModeDir|seedMode); err != nil {
+			return err
+		}
 	case mode&fs.ModeCharDevice != 0:
 		// Must be a bit test: Go reports a character device as
 		// ModeDevice|ModeCharDevice (os.Lstat sets both), so comparing
@@ -191,16 +206,42 @@ func (f *dirFS) seedOverride(path string, fi fs.FileInfo, readlink func(string) 
 		if err != nil {
 			return err
 		}
-		return f.overrides.Mknod(path, unix.S_IFCHR|uint32(perm), dev)
+		// Mknod takes the unix encoding, where the special bits are numbered
+		// differently and mean nothing on a device node anyway.
+		if err := f.overrides.Mknod(path, unix.S_IFCHR|uint32(mode.Perm()), dev); err != nil {
+			return err
+		}
 	default:
 		// Everything else — regular files, and the block devices, FIFOs and
 		// sockets the memFS overrides cannot represent — becomes an empty
 		// regular file whose content is served from disk.
-		memFile, err := f.overrides.OpenFile(path, os.O_CREATE, mode&^fs.ModeType)
+		memFile, err := f.overrides.OpenFile(path, os.O_CREATE, seedMode)
 		if memFile != nil {
 			_ = memFile.Close()
 		}
-		return err
+		if err != nil {
+			return err
+		}
+	}
+
+	if !haveOwner {
+		return nil
+	}
+	return f.overrides.Chown(path, uid, gid)
+}
+
+// ownerFromInfo extracts the owning uid and gid from a FileInfo's Sys(). The
+// walk that seeds a dirFS yields *syscall.Stat_t; callers holding a value from
+// x/sys/unix yield *unix.Stat_t. Anything else — a FileInfo synthesized by a
+// memFS, say — has no owner to report.
+func ownerFromInfo(fi fs.FileInfo) (uid, gid int, ok bool) {
+	switch st := fi.Sys().(type) {
+	case *syscall.Stat_t:
+		return int(st.Uid), int(st.Gid), true
+	case *unix.Stat_t:
+		return int(st.Uid), int(st.Gid), true
+	default:
+		return 0, 0, false
 	}
 }
 

--- a/pkg/apk/fs/rwosfs_test.go
+++ b/pkg/apk/fs/rwosfs_test.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -925,4 +926,45 @@ func TestSeedOverride_TypesFromWalk(t *testing.T) {
 	target, err := fsys.Readlink("etc/link")
 	require.NoError(t, err)
 	require.Equal(t, "hostname", target)
+}
+
+// TestSeedOverride_SpecialModeBits pins that setuid/setgid/sticky already on
+// disk survive being seeded into the overrides, which are what every mode
+// lookup on a dirFS resolves against.
+func TestSeedOverride_SpecialModeBits(t *testing.T) {
+	entries := []struct {
+		name string
+		mode fs.FileMode
+		dir  bool
+	}{
+		{"tmp", fs.ModeSticky | 0o777, true},
+		{"spool", fs.ModeSetgid | 0o755, true},
+		{"postdrop", fs.ModeSetgid | 0o755, false},
+		{"su", fs.ModeSetuid | 0o755, false},
+	}
+
+	dir := t.TempDir()
+	for _, e := range entries {
+		path := filepath.Join(dir, e.name)
+		if e.dir {
+			require.NoError(t, os.Mkdir(path, 0o755))
+		} else {
+			require.NoError(t, os.WriteFile(path, []byte("x"), 0o755))
+		}
+		// mkdir and create both mask these bits off, so chmod after the fact.
+		require.NoError(t, os.Chmod(path, e.mode))
+	}
+
+	fsys := DirFS(t.Context(), dir)
+	require.NotNil(t, fsys)
+
+	for _, e := range entries {
+		want := e.mode
+		if e.dir {
+			want |= fs.ModeDir
+		}
+		fi, err := fsys.Stat(e.name)
+		require.NoError(t, err, "error statting %s", e.name)
+		assert.Equal(t, want, fi.Mode(), "mismatched seeded mode for %s", e.name)
+	}
 }

--- a/pkg/apk/fs/rwosfs_test.go
+++ b/pkg/apk/fs/rwosfs_test.go
@@ -15,6 +15,7 @@
 package fs
 
 import (
+	"archive/tar"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -966,5 +967,44 @@ func TestSeedOverride_SpecialModeBits(t *testing.T) {
 		fi, err := fsys.Stat(e.name)
 		require.NoError(t, err, "error statting %s", e.name)
 		assert.Equal(t, want, fi.Mode(), "mismatched seeded mode for %s", e.name)
+
+		// The owner has to come over with the mode: a node seeded setuid but
+		// left at uid 0 would serialize as setuid root.
+		diskFI, err := os.Stat(filepath.Join(dir, e.name))
+		require.NoError(t, err)
+		diskSt, ok := diskFI.Sys().(*syscall.Stat_t)
+		require.True(t, ok, "no *syscall.Stat_t for %s", e.name)
+		hdr, ok := fi.Sys().(*tar.Header)
+		require.True(t, ok, "no *tar.Header from Sys() for %s", e.name)
+		assert.Equal(t, int(diskSt.Uid), hdr.Uid, "mismatched seeded uid for %s", e.name)
+		assert.Equal(t, int(diskSt.Gid), hdr.Gid, "mismatched seeded gid for %s", e.name)
 	}
+}
+
+// ownerlessFileInfo is a FileInfo whose Sys() carries no owner, which is what
+// a non-unix platform or a memFS-synthesized FileInfo looks like.
+type ownerlessFileInfo struct {
+	fs.FileInfo
+	mode fs.FileMode
+}
+
+func (o ownerlessFileInfo) Mode() fs.FileMode { return o.mode }
+func (o ownerlessFileInfo) Sys() any          { return nil }
+
+// TestSeedOverride_NoOwnerDropsSetidBits pins the safe direction of the
+// mode/ownership pairing: with no owner to attach them to, setuid and setgid
+// are dropped rather than seeded against the default uid 0.
+func TestSeedOverride_NoOwnerDropsSetidBits(t *testing.T) {
+	fsys := DirFS(t.Context(), t.TempDir())
+	require.NotNil(t, fsys)
+	d, ok := fsys.(*dirFS)
+	require.True(t, ok)
+
+	mode := fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky | 0o755
+	require.NoError(t, d.seedOverride("binary", ownerlessFileInfo{mode: mode}, nil))
+
+	fi, err := d.overrides.Stat("binary")
+	require.NoError(t, err)
+	require.Equal(t, fs.ModeSticky|0o755, fi.Mode(),
+		"setuid/setgid must not be seeded without an owner")
 }


### PR DESCRIPTION
Fixes #2456 — both findings, in `pkg/apk/apk`, plus the one thing in
`pkg/apk/fs` that kept the second fix from working end to end.

### 1. The streaming install path drops dir mode bits and all ownership

`installAPKFiles` is the install path taken whenever the target filesystem is
not an `apk.WriteHeaderer` — in tree `apko build-cpio`, out of tree melange's
qemu runner. Two defects, the same ones #2455 fixes for `pkg/tarfs`:

- `MkdirAll` was passed `header.FileInfo().Mode().Perm()`, which masks to
  0o777, so setuid/setgid/sticky on a directory header were dropped.
- Nothing applied `header.Uid`/`header.Gid`, so everything installed came out
  `0:0`. A setgid binary such as wolfi postfix's `/usr/bin/postdrop`
  (`0o2755`, gid 101) kept its setgid bit but ended up setgid to *root*
  instead of to the group the package asked for.

So `Chmod` newly created directories with every non-type bit, and `Chown` both
directories and files. The directory metadata is applied only when we created
the directory — `InitDB` makes `/tmp` 1777 before any package installs, and
packages ship a `tmp` header without the sticky bit. Regular files get a
`Chmod` too, because `dirFS.OpenFile` strips the special bits for the on-disk
write and Linux clears them again on the next write by an unprivileged
process.

Symlinks and hardlinks are left alone: `FullFS` has no `Lchown`, and `Chown`
would follow the link and retarget its target's ownership.

**The order is load-bearing** (caught in review by @mattmoor, commit 4):
`chown(2)` on a regular file clears setuid/setgid — for root too, and even for
a chown that changes nothing — so `Chown` has to come *before* the `Chmod`
that restores those bits. The old order left an installed setgid binary at
0755 on disk while the in-memory overrides still said 02755, so the
serialized image was right and the tree melange's qemu runner boots was
wrong.

### 2. `InitDB`'s base-directory permission check could never match for /tmp

It compared `stat.Mode().Perm()` against entries whose perms carry
`fs.ModeSticky`, so the `/tmp` entry never matched and any call where `/tmp`
already existed as 1777 failed with `base directory /tmp has incorrect
permissions: 777`. Now it compares every non-type bit and reports both got and
want. I kept the check as strict as it was, just correct.

### 3. `seedOverride` dropped the same bits (commits 2 and 3)

`DirFS` mirrors the tree it wraps into its in-memory overrides, and those
overrides are what all mode lookups resolve against. `seedOverride` seeded
only `mode.Perm()`, so a sticky directory or setgid binary *already on disk*
was reported — and written into the layer — without those bits. That is also
what kept fix 2 from working for a `DirFS` over a tree that already had `/tmp`
as 1777.

Seeding those bits only works if the owner comes with them, which review
caught (thanks @depthfirst-app): a node seeded setuid but left at the default
uid 0 would serialize as setuid *root*, and `apk.New`'s fallback filesystem is
`DirFS(ctx, "/")`, so the tree walked can be a whole host root. So the owner
is taken from the same `Sys()` as the mode and applied with `Chown`; symlinks
stay unowned (`memFS.getNode` resolves the final component, so a `Chown` would
retarget the link's target, and `FullFS` has no `Lchown`); and when `Sys()`
carries no owner, setuid/setgid are dropped rather than paired with uid 0.

### Testing

Six new tests, each mutation-checked against the pre-fix code:

- `TestInstallAPKFilesModesAndOwnership` — sticky and setgid dirs, a setgid
  file, gid 101, and a pre-existing 1777 `/tmp` whose mode and owner must
  survive a package's `tmp` header.
- `TestInstallAPKFilesModesOnDisk` — the same over `apkfs.DirFS`, asserting
  the bits reach the real disk. One entry's header uid/gid are the test
  process's own, which is the one case where the disk `Chown` succeeds
  unprivileged and so reaches the kernel's clearing of setuid/setgid instead
  of an `EPERM` the filesystem swallows; that entry fails against the wrong
  call order, with no root needed.
- `TestInstallAPKFilesMetadataOrder` — pins `Chown` before `Chmod` with a
  recording `FullFS` that wraps a real memFS and only logs which call reaches
  each path first, covering the directory path where no kernel behavior is
  observable.
- `TestInitDBBaseDirectoryPerms` — sticky `/tmp` accepted, non-sticky
  rejected.
- `TestSeedOverride_SpecialModeBits` — setuid/setgid/sticky on disk survive
  seeding, with the uid/gid asserted against the on-disk `*syscall.Stat_t`.
- `TestSeedOverride_NoOwnerDropsSetidBits` — with no owner available, setuid
  and setgid are dropped instead of seeded against uid 0.

`go test ./pkg/... ./internal/...` passes and `golangci-lint run ./pkg/...` is
clean. No golden digests moved: the paths this touches are not the ones the
`internal/cli` fixtures build through.

### Not in scope

`pkg/cpio/layer.go` never sets `Record.UID`/`GID`, so `apko build-cpio` output
still lands `0:0` no matter what the filesystem records. The metadata is now
correct up to the cpio conversion; that last step wants its own change.
