### PR TITLE
apk: bound global caches with LRU eviction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.14.0
 	github.com/klauspost/compress v1.19.2
 	github.com/klauspost/pgzip v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/singleflight"
 
@@ -33,14 +34,28 @@ import (
 )
 
 type flightCache[K comparable, V any] struct {
-	mux   sync.RWMutex
-	cache map[K]func() (V, error)
+	mux     sync.Mutex
+	flights map[K]*flightCacheEntry[V]
+	lru     *simplelru.LRU[K, V]
 }
 
-func newFlightCache[K comparable, V any]() *flightCache[K, V] {
+type flightCacheEntry[V any] struct {
+	load func() (V, error)
+}
+
+func newFlightCache[K comparable, V any](maxEntries int) *flightCache[K, V] {
 	return &flightCache[K, V]{
-		cache: make(map[K]func() (V, error)),
+		flights: make(map[K]*flightCacheEntry[V]),
+		lru:     newLRU[K, V](maxEntries, nil),
 	}
+}
+
+func newLRU[K comparable, V any](maxEntries int, onEvict simplelru.EvictCallback[K, V]) *simplelru.LRU[K, V] {
+	cache, err := simplelru.NewLRU(maxEntries, onEvict)
+	if err != nil {
+		panic(err)
+	}
+	return cache
 }
 
 // Do coalesces multiple calls, like singleflight, but also caches
@@ -48,50 +63,53 @@ func newFlightCache[K comparable, V any]() *flightCache[K, V] {
 // permanently failing for transient errors. The boolean result reports
 // whether the key was already present, including an in-flight call.
 func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, bool, error) {
-	f.mux.RLock()
-	if v, ok := f.cache[key]; ok {
-		f.mux.RUnlock()
-		value, err := v()
-		return value, true, err
-	}
-	f.mux.RUnlock()
-
 	f.mux.Lock()
-
-	// Doubly-checked-locking in case of race conditions.
-	if v, ok := f.cache[key]; ok {
+	if value, ok := f.lru.Get(key); ok {
 		f.mux.Unlock()
-		value, err := v()
-		return value, true, err
+		return value, true, nil
 	}
 
-	v := sync.OnceValues(fn)
-	f.cache[key] = v
-
-	// Unlock before calling the function to avoid holding the lock for a potentially long time.
+	entry, hit := f.flights[key]
+	if !hit {
+		entry = &flightCacheEntry[V]{load: sync.OnceValues(fn)}
+		f.flights[key] = entry
+	}
 	f.mux.Unlock()
 
-	val, err := v()
-	if err != nil {
-		f.Forget(key)
+	value, err := entry.load()
+
+	f.mux.Lock()
+	if current := f.flights[key]; current == entry {
+		delete(f.flights, key)
+		if err == nil {
+			f.lru.Add(key, value)
+		}
 	}
-	return val, false, err
+	f.mux.Unlock()
+
+	return value, hit, err
 }
 
 // Forget removes the given key from the cache.
 func (f *flightCache[K, V]) Forget(key K) {
 	f.mux.Lock()
 	defer f.mux.Unlock()
-	delete(f.cache, key)
+	f.lru.Remove(key)
+	delete(f.flights, key)
 }
 
 // ForgetFunc removes all keys for which fn returns true.
 func (f *flightCache[K, V]) ForgetFunc(fn func(K) bool) {
 	f.mux.Lock()
 	defer f.mux.Unlock()
-	for k := range f.cache {
+	for _, k := range f.lru.Keys() {
 		if fn(k) {
-			delete(f.cache, k)
+			f.lru.Remove(k)
+		}
+	}
+	for k := range f.flights {
+		if fn(k) {
+			delete(f.flights, k)
 		}
 	}
 }
@@ -103,6 +121,8 @@ type Cache struct {
 
 	discoverKeys *flightCache[string, []Key]
 }
+
+const discoverKeysCacheMaxEntries = 64
 
 // NewCache returns a new Cache, which allows us to persist the results of HEAD requests
 // for a given URL across multiple builds. This is generally desirable when building many images
@@ -119,7 +139,7 @@ func NewCache(etag bool) *Cache {
 	c := &Cache{
 		headFlight:   &singleflight.Group{},
 		getFlight:    &singleflight.Group{},
-		discoverKeys: newFlightCache[string, []Key](),
+		discoverKeys: newFlightCache[string, []Key](discoverKeysCacheMaxEntries),
 	}
 
 	if etag {

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -35,16 +35,12 @@ import (
 
 type flightCache[K comparable, V any] struct {
 	mux sync.Mutex
-	lru *simplelru.LRU[K, *flightCacheEntry[V]]
-}
-
-type flightCacheEntry[V any] struct {
-	load func() (V, error)
+	lru *simplelru.LRU[K, func() (V, error)]
 }
 
 func newFlightCache[K comparable, V any](maxEntries int) *flightCache[K, V] {
 	return &flightCache[K, V]{
-		lru: newLRU[K, *flightCacheEntry[V]](maxEntries, nil),
+		lru: newLRU[K, func() (V, error)](maxEntries, nil),
 	}
 }
 
@@ -62,20 +58,16 @@ func newLRU[K comparable, V any](maxEntries int, onEvict simplelru.EvictCallback
 // whether the key was already present, including an in-flight call.
 func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, bool, error) {
 	f.mux.Lock()
-	entry, hit := f.lru.Get(key)
+	load, hit := f.lru.Get(key)
 	if !hit {
-		entry = &flightCacheEntry[V]{load: sync.OnceValues(fn)}
-		f.lru.Add(key, entry)
+		load = sync.OnceValues(fn)
+		f.lru.Add(key, load)
 	}
 	f.mux.Unlock()
 
-	value, err := entry.load()
+	value, err := load()
 	if err != nil {
-		f.mux.Lock()
-		if current, ok := f.lru.Peek(key); ok && current == entry {
-			f.lru.Remove(key)
-		}
-		f.mux.Unlock()
+		f.Forget(key)
 	}
 
 	return value, hit, err

--- a/pkg/apk/apk/cache.go
+++ b/pkg/apk/apk/cache.go
@@ -34,9 +34,8 @@ import (
 )
 
 type flightCache[K comparable, V any] struct {
-	mux     sync.Mutex
-	flights map[K]*flightCacheEntry[V]
-	lru     *simplelru.LRU[K, V]
+	mux sync.Mutex
+	lru *simplelru.LRU[K, *flightCacheEntry[V]]
 }
 
 type flightCacheEntry[V any] struct {
@@ -45,8 +44,7 @@ type flightCacheEntry[V any] struct {
 
 func newFlightCache[K comparable, V any](maxEntries int) *flightCache[K, V] {
 	return &flightCache[K, V]{
-		flights: make(map[K]*flightCacheEntry[V]),
-		lru:     newLRU[K, V](maxEntries, nil),
+		lru: newLRU[K, *flightCacheEntry[V]](maxEntries, nil),
 	}
 }
 
@@ -64,28 +62,21 @@ func newLRU[K comparable, V any](maxEntries int, onEvict simplelru.EvictCallback
 // whether the key was already present, including an in-flight call.
 func (f *flightCache[K, V]) Do(key K, fn func() (V, error)) (V, bool, error) {
 	f.mux.Lock()
-	if value, ok := f.lru.Get(key); ok {
-		f.mux.Unlock()
-		return value, true, nil
-	}
-
-	entry, hit := f.flights[key]
+	entry, hit := f.lru.Get(key)
 	if !hit {
 		entry = &flightCacheEntry[V]{load: sync.OnceValues(fn)}
-		f.flights[key] = entry
+		f.lru.Add(key, entry)
 	}
 	f.mux.Unlock()
 
 	value, err := entry.load()
-
-	f.mux.Lock()
-	if current := f.flights[key]; current == entry {
-		delete(f.flights, key)
-		if err == nil {
-			f.lru.Add(key, value)
+	if err != nil {
+		f.mux.Lock()
+		if current, ok := f.lru.Peek(key); ok && current == entry {
+			f.lru.Remove(key)
 		}
+		f.mux.Unlock()
 	}
-	f.mux.Unlock()
 
 	return value, hit, err
 }
@@ -95,7 +86,6 @@ func (f *flightCache[K, V]) Forget(key K) {
 	f.mux.Lock()
 	defer f.mux.Unlock()
 	f.lru.Remove(key)
-	delete(f.flights, key)
 }
 
 // ForgetFunc removes all keys for which fn returns true.
@@ -105,11 +95,6 @@ func (f *flightCache[K, V]) ForgetFunc(fn func(K) bool) {
 	for _, k := range f.lru.Keys() {
 		if fn(k) {
 			f.lru.Remove(k)
-		}
-	}
-	for k := range f.flights {
-		if fn(k) {
-			delete(f.flights, k)
 		}
 	}
 }

--- a/pkg/apk/apk/cache_test.go
+++ b/pkg/apk/apk/cache_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFlightCache(t *testing.T) {
-	s := newFlightCache[string, int]()
+	s := newFlightCache[string, int](2)
 	var called int
 	r1, _, err := s.Do("test", func() (int, error) {
 		called++
@@ -61,7 +61,7 @@ func TestFlightCache(t *testing.T) {
 }
 
 func TestFlightCacheCachesNoErrors(t *testing.T) {
-	s := newFlightCache[string, int]()
+	s := newFlightCache[string, int](1)
 	var called int
 	_, _, err := s.Do("test", func() (int, error) {
 		called++
@@ -79,7 +79,7 @@ func TestFlightCacheCachesNoErrors(t *testing.T) {
 }
 
 func TestFlightCacheReportsHits(t *testing.T) {
-	s := newFlightCache[string, int]()
+	s := newFlightCache[string, int](1)
 
 	value, hit, err := s.Do("test", func() (int, error) {
 		return 42, nil
@@ -97,7 +97,7 @@ func TestFlightCacheReportsHits(t *testing.T) {
 }
 
 func TestFlightCacheCoalescesCalls(t *testing.T) {
-	s := newFlightCache[string, int]()
+	s := newFlightCache[string, int](1)
 
 	var called atomic.Int32
 	var mux sync.Mutex
@@ -121,7 +121,7 @@ func TestFlightCacheCoalescesCalls(t *testing.T) {
 }
 
 func TestFlightCacheForgetFunc(t *testing.T) {
-	s := newFlightCache[string, int]()
+	s := newFlightCache[string, int](3)
 
 	for k, v := range map[string]int{"a-1": 1, "a-2": 2, "b-1": 3} {
 		_, _, err := s.Do(k, func() (int, error) { return v, nil })
@@ -146,4 +146,28 @@ func TestFlightCacheForgetFunc(t *testing.T) {
 	r, _, err = s.Do("b-1", func() (int, error) { return 999, nil })
 	require.NoError(t, err)
 	require.Equal(t, 3, r, "b-1 should still return the cached value")
+}
+
+func TestFlightCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	s := newFlightCache[string, int](2)
+
+	for _, item := range []struct {
+		key   string
+		value int
+	}{{"a", 1}, {"b", 2}} {
+		_, _, err := s.Do(item.key, func() (int, error) { return item.value, nil })
+		require.NoError(t, err)
+	}
+
+	_, hit, err := s.Do("a", func() (int, error) { return 10, nil })
+	require.NoError(t, err)
+	require.True(t, hit)
+
+	_, _, err = s.Do("c", func() (int, error) { return 3, nil })
+	require.NoError(t, err)
+
+	value, hit, err := s.Do("b", func() (int, error) { return 20, nil })
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Equal(t, 20, value)
 }

--- a/pkg/apk/apk/cache_test.go
+++ b/pkg/apk/apk/cache_test.go
@@ -78,36 +78,6 @@ func TestFlightCacheCachesNoErrors(t *testing.T) {
 	require.Equal(t, 2, called, "Function should be called twice, once for the error and once for the success")
 }
 
-func TestFlightCacheErrorDoesNotForgetReplacement(t *testing.T) {
-	s := newFlightCache[string, int](1)
-	started := make(chan struct{})
-	release := make(chan struct{})
-	done := make(chan error)
-
-	go func() {
-		_, _, err := s.Do("a", func() (int, error) {
-			close(started)
-			<-release
-			return 0, assert.AnError
-		})
-		done <- err
-	}()
-	<-started
-
-	_, _, err := s.Do("b", func() (int, error) { return 2, nil })
-	require.NoError(t, err)
-	_, _, err = s.Do("a", func() (int, error) { return 1, nil })
-	require.NoError(t, err)
-
-	close(release)
-	require.ErrorIs(t, <-done, assert.AnError)
-
-	value, hit, err := s.Do("a", func() (int, error) { return 3, nil })
-	require.NoError(t, err)
-	require.True(t, hit)
-	require.Equal(t, 1, value)
-}
-
 func TestFlightCacheReportsHits(t *testing.T) {
 	s := newFlightCache[string, int](1)
 

--- a/pkg/apk/apk/cache_test.go
+++ b/pkg/apk/apk/cache_test.go
@@ -78,6 +78,36 @@ func TestFlightCacheCachesNoErrors(t *testing.T) {
 	require.Equal(t, 2, called, "Function should be called twice, once for the error and once for the success")
 }
 
+func TestFlightCacheErrorDoesNotForgetReplacement(t *testing.T) {
+	s := newFlightCache[string, int](1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error)
+
+	go func() {
+		_, _, err := s.Do("a", func() (int, error) {
+			close(started)
+			<-release
+			return 0, assert.AnError
+		})
+		done <- err
+	}()
+	<-started
+
+	_, _, err := s.Do("b", func() (int, error) { return 2, nil })
+	require.NoError(t, err)
+	_, _, err = s.Do("a", func() (int, error) { return 1, nil })
+	require.NoError(t, err)
+
+	close(release)
+	require.ErrorIs(t, <-done, assert.AnError)
+
+	value, hit, err := s.Do("a", func() (int, error) { return 3, nil })
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, 1, value)
+}
+
 func TestFlightCacheReportsHits(t *testing.T) {
 	s := newFlightCache[string, int](1)
 

--- a/pkg/apk/apk/index.go
+++ b/pkg/apk/apk/index.go
@@ -45,32 +45,26 @@ import (
 
 var signatureFileRegex = regexp.MustCompile(`^\.SIGN\.(DSA|RSA|RSA256|RSA512)\.(.*\.rsa\.pub)$`)
 
+const indexCacheMaxEntries = 64
+
 type Signature struct {
 	KeyID           string
 	Signature       []byte
 	DigestAlgorithm crypto.Hash
 }
 
-// This is terrible but simpler than plumbing around a cache for now.
-// We just hold the parsed index in memory rather than re-parsing it every time,
-// which requires gunzipping, which is (somewhat) expensive.
-var globalIndexCache = &indexCache{
-	indexes:  newFlightCache[cacheKey, NamedIndex](),
-	modtimes: map[string]time.Time{},
-	current:  map[string]NamedIndex{},
-}
+// Parsing an index requires gunzipping and rebuilding its package structures,
+// so keep recently used indexes in memory.
+var globalIndexCache = newIndexCache(indexCacheMaxEntries)
 
 type cacheKey struct {
-	url  string
-	etag string // Only used for remote indexes.
+	url     string
+	etag    string    // Only used for remote indexes.
+	modtime time.Time // Only used for local indexes.
 }
 
 type indexCache struct {
 	indexes *flightCache[cacheKey, NamedIndex]
-
-	// For local indexes.
-	sync.Mutex
-	modtimes map[string]time.Time
 
 	// current is the latest index object served per index URL. When a newer
 	// generation replaces an entry, derived data cached for the superseded
@@ -79,6 +73,13 @@ type indexCache struct {
 	// still hold.
 	currentMu sync.Mutex
 	current   map[string]NamedIndex
+}
+
+func newIndexCache(maxEntries int) *indexCache {
+	return &indexCache{
+		indexes: newFlightCache[cacheKey, NamedIndex](maxEntries),
+		current: map[string]NamedIndex{},
+	}
 }
 
 // setCurrent records idx as the latest generation for the index URL u,
@@ -183,25 +184,13 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 		}
 		return idx, err
 	} else {
-		i.Lock()
-		defer i.Unlock()
-
 		// We do expect local indexes to change, so we check modtimes.
 		stat, err := os.Stat(u)
 		if err != nil {
 			return nil, fmt.Errorf("stat: %w", err)
 		}
 
-		key := cacheKey{url: u}
-
-		// Evict the cached entry if the file has changed since we last saw it.
-		// On first access, ok is false and Do below handles the cache miss.
-		mod := stat.ModTime()
-		before, ok := i.modtimes[u]
-		if ok && mod.After(before) {
-			i.indexes.Forget(key)
-		}
-		i.modtimes[u] = mod
+		key := cacheKey{url: u, modtime: stat.ModTime()}
 
 		idx, hit, err := i.indexes.Do(key, func() (NamedIndex, error) {
 			b, err := os.ReadFile(u)
@@ -215,6 +204,12 @@ func (i *indexCache) get(ctx context.Context, repoName, repoURL string, keys map
 			return NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(idx)), nil
 		})
 		apkometrics.RecordIndexCacheAccess(cacheResult(hit))
+
+		// Remove cached generations of the same local index.
+		i.indexes.ForgetFunc(func(k cacheKey) bool {
+			return k.url == u && k.modtime != key.modtime
+		})
+
 		if err == nil {
 			i.setCurrent(u, idx)
 		}

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -101,11 +101,11 @@ type PackageGetter interface {
 	GetPackage(ctx context.Context, pkg InstallablePackage) (*expandapk.APKExpanded, error)
 }
 
+const packageCacheMaxEntries = 64
+
 // globalApkCache is the shared in-memory singleflight cache used by DefaultPackageGetter.
 // This ensures deduplication of concurrent requests across all APK instances in a process.
-// NOTE: This is used only to retain backwards compatibility with existing behavior, which
-// also uses a global cache.
-var globalApkCache = newFlightCache[string, *expandapk.APKExpanded]()
+var globalApkCache = newFlightCache[string, *expandapk.APKExpanded](packageCacheMaxEntries)
 
 // defaultPackageGetter implements the standard disk-caching behavior
 // with in-memory singleflight deduplication using a global cache.

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -101,7 +101,7 @@ type PackageGetter interface {
 	GetPackage(ctx context.Context, pkg InstallablePackage) (*expandapk.APKExpanded, error)
 }
 
-const packageCacheMaxEntries = 256
+const packageCacheMaxEntries = 4096
 
 // globalApkCache is the shared in-memory singleflight cache used by DefaultPackageGetter.
 // This ensures deduplication of concurrent requests across all APK instances in a process.

--- a/pkg/apk/apk/package_getter.go
+++ b/pkg/apk/apk/package_getter.go
@@ -101,7 +101,7 @@ type PackageGetter interface {
 	GetPackage(ctx context.Context, pkg InstallablePackage) (*expandapk.APKExpanded, error)
 }
 
-const packageCacheMaxEntries = 64
+const packageCacheMaxEntries = 256
 
 // globalApkCache is the shared in-memory singleflight cache used by DefaultPackageGetter.
 // This ensures deduplication of concurrent requests across all APK instances in a process.


### PR DESCRIPTION
Bound completed entries in apko's shared flight caches and the parsed index cache with hashicorp/golang-lru. Capacities are set at each initialization site so they can be tuned independently, while concurrent loads remain coalesced and recently used entries stay hot. The derived resolver and disqualify caches are left as is since #2462 bounds those separately.