### PR TITLE
fix(build): validate ImageConfiguration in NewOptions

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -279,6 +279,10 @@ func NewOptions(opts ...Option) (*options.Options, *types.ImageConfiguration, er
 	}
 	bc.resolveImageConfiguration()
 
+	if err := bc.ic.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("failed to validate configuration: %w", err)
+	}
+
 	return &bc.o, &bc.ic, nil
 }
 

--- a/pkg/build/options_test.go
+++ b/pkg/build/options_test.go
@@ -129,3 +129,12 @@ func TestWithFormatInvalid(t *testing.T) {
 		t.Error("NewOptions(WithFormat(\"squashfs\")) = nil error, want an error")
 	}
 }
+
+func TestNewOptionsValidatesImageConfiguration(t *testing.T) {
+	if _, _, err := NewOptions(WithImageConfiguration(types.ImageConfiguration{
+		Format: types.LayerFormat("squashfs"),
+	})); err == nil {
+		t.Error("NewOptions(WithImageConfiguration(invalid)) = nil error, want an error")
+	}
+}
+


### PR DESCRIPTION
## Problem
`build.NewOptions()` evaluates option overrides but never calls `ic.Validate()`, unlike `build.New()`. As a result, library callers using `NewOptions()` receive an `ImageConfiguration` whose fields (such as `Format`) are unvalidated. An invalid layer format (e.g. `"squashfs"`) is accepted without error and silently degrades into a tar archive rather than returning a validation error.

## Root Cause
`NewOptions()` calls `resolveImageConfiguration()` but omits the `bc.ic.Validate()` check that `build.New()` executes.

## Fix
Added `bc.ic.Validate()` check at the end of `build.NewOptions()`, ensuring constructor contract consistency between `NewOptions()` and `New()`. Added unit test `TestNewOptionsValidatesImageConfiguration` in `options_test.go`.

Fixes #2423
