### PR TITLE
fix(build): reapply pgzip concurrency cap after Reset, fix layer fd leak

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -415,7 +415,7 @@ type layer struct {
 	desc         *v1.Descriptor
 }
 
-func (l *layer) compress() error {
+func (l *layer) compress() (rerr error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -433,6 +433,11 @@ func (l *layer) compress() error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := out.Close(); err != nil && rerr == nil {
+			rerr = err
+		}
+	}()
 
 	buf := pooledBufioWriter(out)
 	defer bufioPool.Put(buf)
@@ -472,7 +477,7 @@ func (l *layer) compress() error {
 
 	l.compressed = l.uncompressed + ".gz"
 
-	return out.Close()
+	return nil
 }
 
 func (l *layer) DiffID() (v1.Hash, error) {

--- a/pkg/build/build_implementation.go
+++ b/pkg/build/build_implementation.go
@@ -64,6 +64,12 @@ var pgzipPool = sync.Pool{
 func pooledGzipWriter(w io.Writer) *gzip.Writer {
 	zw := pgzipPool.Get().(*gzip.Writer)
 	zw.Reset(w)
+	// Reset reverts the writer to pgzip's default concurrency of
+	// GOMAXPROCS(0) blocks, so the cap has to be reapplied on every reuse.
+	if err := zw.SetConcurrency(1<<20, pgzipThreads); err != nil {
+		// This should never happen.
+		panic(fmt.Errorf("tried to set pgzip concurrency to %d: %w", pgzipThreads, err))
+	}
 	return zw
 }
 


### PR DESCRIPTION
`pgzipPool.New` configures writers with `SetConcurrency(1<<20, pgzipThreads)` to cap compression fan-out at 8 workers, per the comment explaining why GOMAXPROCS is the wrong default for large machines. But `pooledGzipWriter` calls `Reset` on recycled writers, and pgzip's `Reset` internally calls `SetConcurrency(defaultBlockSize, runtime.GOMAXPROCS(0))`, reverting the cap. Since the pool's `New` only runs on a cold pool, effectively every writer after the first few runs uncapped: on a 64-core machine that's 64 concurrent 1 MiB blocks per writer instead of 8.

Reapply the cap after every `Reset`. Block size is unaffected (pgzip's default equals the 1<<20 already in use), so the only behavioral change is restoring the intended worker cap on >8-core machines.

Also, while in `layer.compress`: the output file was only closed on the success path, so every error return after `os.Create` leaked the descriptor. The close now happens in a defer on all paths, propagating its error through the named return unless an earlier error is already headed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
