### PR TITLE
feat(metrics): record compression cache hits and misses

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -42,6 +42,7 @@ import (
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/baseimg"
 	"chainguard.dev/apko/pkg/build/types"
+	apkometrics "chainguard.dev/apko/pkg/metrics"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/paths"
 	"chainguard.dev/apko/pkg/s6"
@@ -413,6 +414,20 @@ type layer struct {
 	compressed   string
 	diffid       *v1.Hash
 	desc         *v1.Descriptor
+	cacheCounted bool // first compression-cache lookup already recorded
+}
+
+// recordCacheAccess reports this layer's first compression-cache outcome.
+// Only the first lookup counts: once a layer has been compressed, compress()
+// short-circuits, so a later lookup saves nothing whether it hits or not.
+func (l *layer) recordCacheAccess(result apkometrics.CacheResult) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cacheCounted {
+		return
+	}
+	l.cacheCounted = true
+	apkometrics.RecordCompressionCacheAccess(result)
 }
 
 func (l *layer) compress() (rerr error) {
@@ -487,11 +502,13 @@ func (l *layer) DiffID() (v1.Hash, error) {
 func (l *layer) Digest() (v1.Hash, error) {
 	// Check if we've already compressed a layer with this diffID
 	if cached, ok := compressionCache.Load(l.diffid.String()); ok {
+		l.recordCacheAccess(apkometrics.CacheResultHit)
 		cachedDesc := cached.(*v1.Descriptor)
 		l.desc.Digest = cachedDesc.Digest
 		l.desc.Size = cachedDesc.Size
 		return l.desc.Digest, nil
 	}
+	l.recordCacheAccess(apkometrics.CacheResultMiss)
 
 	if err := l.compress(); err != nil {
 		return v1.Hash{}, err
@@ -520,11 +537,13 @@ func (l *layer) Uncompressed() (io.ReadCloser, error) {
 func (l *layer) Size() (int64, error) {
 	// Check if we've already compressed a layer with this diffID
 	if cached, ok := compressionCache.Load(l.diffid.String()); ok {
+		l.recordCacheAccess(apkometrics.CacheResultHit)
 		cachedDesc := cached.(*v1.Descriptor)
 		l.desc.Digest = cachedDesc.Digest
 		l.desc.Size = cachedDesc.Size
 		return l.desc.Size, nil
 	}
+	l.recordCacheAccess(apkometrics.CacheResultMiss)
 
 	if err := l.compress(); err != nil {
 		return 0, err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,8 +18,9 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 const (
-	cacheIndex    = "index"
-	cacheResolver = "resolver"
+	cacheIndex       = "index"
+	cacheResolver    = "resolver"
+	cacheCompression = "compression"
 )
 
 // CacheResult describes the outcome of a cache access.
@@ -45,6 +46,10 @@ func init() {
 			cacheAccesses.WithLabelValues(cache, string(result))
 		}
 	}
+	// The compression cache is always consulted, so it has no bypass result.
+	for _, result := range []CacheResult{CacheResultHit, CacheResultMiss} {
+		cacheAccesses.WithLabelValues(cacheCompression, string(result))
+	}
 }
 
 // Register registers APK metrics with registerer.
@@ -60,4 +65,11 @@ func RecordIndexCacheAccess(result CacheResult) {
 // RecordResolverCacheAccess records a package resolver cache access.
 func RecordResolverCacheAccess(result CacheResult) {
 	cacheAccesses.WithLabelValues(cacheResolver, string(result)).Inc()
+}
+
+// RecordCompressionCacheAccess records a diffID to descriptor cache access.
+// A hit means a layer avoided being compressed; only the first lookup per
+// layer is recorded, because later lookups are free either way.
+func RecordCompressionCacheAccess(result CacheResult) {
+	cacheAccesses.WithLabelValues(cacheCompression, string(result)).Inc()
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -30,6 +30,9 @@ func TestCacheAccesses(t *testing.T) {
 	RecordIndexCacheAccess(CacheResultHit)
 	RecordIndexCacheAccess(CacheResultMiss)
 	RecordResolverCacheAccess(CacheResultBypass)
+	RecordCompressionCacheAccess(CacheResultHit)
+	RecordCompressionCacheAccess(CacheResultMiss)
+	RecordCompressionCacheAccess(CacheResultMiss)
 
 	after := cacheValues(t, registry)
 	for key, value := range before {
@@ -37,12 +40,14 @@ func TestCacheAccesses(t *testing.T) {
 	}
 
 	require.Equal(t, map[string]float64{
-		"index/bypass":    0,
-		"index/hit":       2,
-		"index/miss":      1,
-		"resolver/bypass": 1,
-		"resolver/hit":    0,
-		"resolver/miss":   0,
+		"index/bypass":     0,
+		"index/hit":        2,
+		"index/miss":       1,
+		"resolver/bypass":  1,
+		"resolver/hit":     0,
+		"resolver/miss":    0,
+		"compression/hit":  1,
+		"compression/miss": 2,
 	}, after)
 }
 


### PR DESCRIPTION
Adds `compression` as a third cache on the existing `apko_cache_accesses_total{cache,result}` counter, so the diffID to descriptor cache's hit rate can be measured in a real deployment.

Context is #2485. That cache is the reason layer writes are two-pass — deferring compression requires a materialized plain tar to defer against — and whether the trade pays depends on how often the same diffID recurs inside one process. That has never been measured, and local approximation is not convincing for a heavily scaled service where the cache is per-process and builds are spread across many instances.

## Notes

**Nothing to do on the consumer side.** Callers that already run `metrics.Register(...)` pick up the new label value with no change.

**Only the first lookup per layer is recorded.** `compress()` short-circuits once `l.compressed != ""`, so the `Digest()` then `Size()` second lookup on the same layer costs nothing whether it hits or misses. Counting it would roughly double the apparent hit rate and overstate what the cache saves. A hit here means a layer genuinely avoided being compressed.

**No `bypass` result.** The compression cache is always consulted, so unlike the index and resolver caches there is no bypass path, and pre-initialising one would create a series that can never be non-zero.

## Testing

`TestCacheAccesses` extended to cover the new cache. Full `pkg/...` suite passes.
