### PR TITLE
feat(build): add PrefetchIndexes for resolving against one index snapshot

### DIFF
--- a/pkg/apk/apk/implementation.go
+++ b/pkg/apk/apk/implementation.go
@@ -74,6 +74,13 @@ type APK struct {
 	packageGetter      PackageGetter
 	sizeLimits         *SizeLimits
 
+	// prefetchedIndexes, when non-nil, is returned directly by
+	// GetRepositoryIndexes instead of fetching and revalidating. It lets a
+	// caller resolve every image and arch against one index snapshot captured
+	// once up front (see build.WithPrefetchedIndexes), avoiding the per-resolve
+	// HEAD round-trips and the cross-arch generation skew they can introduce.
+	prefetchedIndexes []NamedIndex
+
 	// filename to owning package, last write wins
 	installedFiles map[string]*Package
 
@@ -153,6 +160,7 @@ func New(ctx context.Context, options ...Option) (*APK, error) {
 		auth:               opt.auth,
 		packageGetter:      packageGetter,
 		sizeLimits:         opt.sizeLimits,
+		prefetchedIndexes:  opt.prefetchedIndexes,
 	}, nil
 }
 

--- a/pkg/apk/apk/options.go
+++ b/pkg/apk/apk/options.go
@@ -40,6 +40,7 @@ type opts struct {
 	transport          http.RoundTripper
 	packageGetter      PackageGetter
 	sizeLimits         *SizeLimits
+	prefetchedIndexes  []NamedIndex
 }
 
 // SizeLimits configures maximum sizes for various APK operations.
@@ -64,6 +65,16 @@ func WithExecutor(executor Executor) Option {
 func WithArch(arch string) Option {
 	return func(o *opts) error {
 		o.arch = arch
+		return nil
+	}
+}
+
+// WithPrefetchedIndexes supplies an index snapshot for this APK's architecture.
+// When set, GetRepositoryIndexes returns it verbatim instead of fetching and
+// revalidating, so a caller can resolve against indexes captured once up front.
+func WithPrefetchedIndexes(indexes []NamedIndex) Option {
+	return func(o *opts) error {
+		o.prefetchedIndexes = indexes
 		return nil
 	}
 }

--- a/pkg/apk/apk/repo.go
+++ b/pkg/apk/apk/repo.go
@@ -142,6 +142,13 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "GetRepositoryIndexes")
 	defer span.End()
 
+	// A caller-supplied snapshot short-circuits fetching entirely: no HEAD, no
+	// revalidation, no disk cache. Every resolve using the same snapshot sees
+	// one consistent index generation.
+	if a.prefetchedIndexes != nil {
+		return a.prefetchedIndexes, nil
+	}
+
 	// get the repository URLs
 	repos, err := a.GetRepositories()
 	if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -353,6 +353,12 @@ func New(ctx context.Context, fs apkfs.FullFS, opts ...Option) (*Context, error)
 	}
 	apkOpts = append(apkOpts, apk.WithOffline(bc.o.Offline))
 
+	// If the caller captured an index snapshot for this arch, hand it to the
+	// APK so its resolve skips fetching and revalidation entirely.
+	if idxs, ok := bc.o.PrefetchedIndexes[bc.o.Arch]; ok {
+		apkOpts = append(apkOpts, apk.WithPrefetchedIndexes(idxs))
+	}
+
 	if bc.ic.Contents.BaseImage != nil {
 		imgPath, err := paths.ResolvePath(bc.ic.Contents.BaseImage.Image, bc.o.IncludePaths)
 		if err != nil {

--- a/pkg/build/lock.go
+++ b/pkg/build/lock.go
@@ -114,6 +114,37 @@ func LockImageConfigurationWithPackages(ctx context.Context, ic types.ImageConfi
 	return ics, missing, resolvedPkgs, nil
 }
 
+// PrefetchIndexes fetches the repository indexes once for each architecture of
+// ic and returns them keyed by APK arch (e.g. "x86_64"). Pass the result to
+// WithPrefetchedIndexes on every subsequent resolve so they all share one index
+// generation instead of each re-fetching and revalidating. Do not pass
+// WithPrefetchedIndexes to this call itself.
+func PrefetchIndexes(ctx context.Context, ic types.ImageConfiguration, opts ...Option) (map[types.Architecture][]apk.NamedIndex, error) {
+	o, input, err := NewOptions(append(slices.Clone(opts), WithImageConfiguration(ic))...)
+	if err != nil {
+		return nil, err
+	}
+
+	input.Contents.BuildRepositories = sets.List(sets.New(input.Contents.BuildRepositories...).Insert(o.ExtraBuildRepos...))
+	input.Contents.Repositories = sets.List(sets.New(input.Contents.Repositories...).Insert(o.ExtraRepos...))
+	input.Contents.Keyring = sets.List(sets.New(input.Contents.Keyring...).Insert(o.ExtraKeyFiles...))
+
+	mc, err := NewMultiArch(ctx, input.Archs, append(slices.Clone(opts), WithImageConfiguration(*input))...)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := make(map[types.Architecture][]apk.NamedIndex, len(mc.Contexts))
+	for arch, bc := range mc.Contexts {
+		idxs, err := bc.APK().GetRepositoryIndexes(ctx, o.IgnoreSignatures)
+		if err != nil {
+			return nil, fmt.Errorf("prefetching indexes for %s: %w", arch, err)
+		}
+		snapshot[arch] = idxs
+	}
+	return snapshot, nil
+}
+
 func resolvePackageList(ctx context.Context, mc *MultiArch) ([]resolved, map[types.Architecture][]*apk.RepositoryPackage, error) {
 	archs := make([]resolved, 0, len(mc.Contexts))
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -171,6 +171,17 @@ func WithExtraRepos(repos []string) Option {
 	}
 }
 
+// WithPrefetchedIndexes supplies a per-architecture index snapshot that
+// resolves use verbatim instead of fetching. Capture it once with
+// PrefetchIndexes and pass it to every resolve so they share one index
+// generation, skipping the per-resolve HEAD round-trips.
+func WithPrefetchedIndexes(byArch map[types.Architecture][]apk.NamedIndex) Option {
+	return func(bc *Context) error {
+		bc.o.PrefetchedIndexes = byArch
+		return nil
+	}
+}
+
 func WithExtraPackages(packages []string) Option {
 	return func(bc *Context) error {
 		bc.o.ExtraPackages = packages

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -90,6 +90,10 @@ type Options struct {
 	Transport           http.RoundTripper     `json:"-"`
 	PackageGetter       apk.PackageGetter     `json:"-"`
 	SizeLimits          SizeLimits            `json:"sizeLimits,omitempty"`
+	// PrefetchedIndexes supplies an index snapshot per architecture. When set
+	// for an arch, that arch's resolve uses the snapshot verbatim instead of
+	// fetching, so all resolves see one generation.
+	PrefetchedIndexes map[types.Architecture][]apk.NamedIndex `json:"-"`
 }
 
 type Auth struct{ User, Pass string }


### PR DESCRIPTION
Resolving many image configurations re-fetches and revalidates the repository indexes for every configuration, variant, and architecture, which is a large number of HEAD and GET round-trips and, because each resolve issues its own HEAD, can bind different architectures to different index generations - so a package published to one architecture mid-resolve resolves as absent on the other. PrefetchIndexes fetches each repository/architecture index once and returns a snapshot; passing it via WithPrefetchedIndexes makes GetRepositoryIndexes return it verbatim, so every resolve shares one consistent generation and the index round-trips collapse to a single fetch per repository and architecture. The snapshot is opt-in and does not change behaviour for callers that do not pass it.
