### PR TITLE
tarfs: store a compact record per member and materialize tar.Header on request

### DIFF
--- a/pkg/apk/expandapk/tarfs/tarfs.go
+++ b/pkg/apk/expandapk/tarfs/tarfs.go
@@ -101,7 +101,6 @@ type paxRecord struct {
 type entry struct {
 	name     string
 	linkname string
-	dir      string
 	uname    unique.Handle[string]
 	gname    unique.Handle[string]
 	size     int64
@@ -109,65 +108,110 @@ type entry struct {
 	mode     int64
 	uid      int64
 	gid      int64
-	modTime  time.Time
-	devmajor int64
-	devminor int64
+	// mtime is the modification time as Unix nanoseconds. archive/tar builds
+	// every ModTime with time.Unix, so time.Unix(0, mtime) reproduces it
+	// exactly; a value that cannot, such as a zero time or one outside the
+	// int64 nanosecond range, is kept whole in rare.mtime instead.
+	mtime    int64
 	fileMode fs.FileMode
 	format   int8 // archive/tar's formatMax is 32
 	typeflag byte
 	hasPAX   bool
 	// checksum holds the paxChecksumKey record decoded from its 40-character
 	// lowercase hex form, which is what apk-tools writes. Any other spelling
-	// stays in pax verbatim so the header round-trips byte for byte.
+	// stays in rare.pax verbatim so the header round-trips byte for byte.
 	hasChecksum bool
 	checksum    [sha1Size]byte
-	pax         []paxRecord
-	// times is set only when the header carries access or change times,
-	// which apk packages almost never do.
-	times *fileTimes
+	// rare is nil for the typical apk member: a regular file or directory
+	// with a checksum and nothing else unusual. It is allocated only for
+	// the fields below, so the common record does not carry their width.
+	rare *rareFields
+}
+
+// rareFields holds header state that most apk members do not have.
+type rareFields struct {
+	access, change     time.Time
+	mtime              time.Time // set when entry.mtime cannot represent it
+	hasMtime           bool
+	devmajor, devminor int64
+	pax                []paxRecord // PAX records other than the decoded checksum
 }
 
 const sha1Size = 20
 
 // decodeChecksum reports the checksum bytes when v is exactly the lowercase
-// hex encoding of a SHA-1, so that re-encoding reproduces v unchanged.
+// hex encoding of a SHA-1, so that hex.EncodeToString reproduces v unchanged.
+// It decodes by hand rather than through encoding/hex to avoid the two
+// allocations (the []byte copy and the re-encoded string) on the hot path
+// that runs for every member of every package.
 func decodeChecksum(v string) ([sha1Size]byte, bool) {
 	var sum [sha1Size]byte
-	if len(v) != hex.EncodedLen(sha1Size) {
+	if len(v) != 2*sha1Size {
 		return sum, false
 	}
-	if _, err := hex.Decode(sum[:], []byte(v)); err != nil {
-		return sum, false
-	}
-	if hex.EncodeToString(sum[:]) != v {
-		return sum, false
+	for i := range sum {
+		hi, ok1 := lowerHexNibble(v[2*i])
+		lo, ok2 := lowerHexNibble(v[2*i+1])
+		if !ok1 || !ok2 {
+			return sum, false
+		}
+		sum[i] = hi<<4 | lo
 	}
 	return sum, true
 }
 
-type fileTimes struct{ access, change time.Time }
+func lowerHexNibble(c byte) (byte, bool) {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	}
+	return 0, false
+}
 
-func newEntry(hdr *tar.Header, offset int64) *entry {
+// newEntry indexes hdr at offset. uname and gname are the interned handles
+// for hdr.Uname and hdr.Gname; the caller supplies them so it can skip the
+// intern lookup when consecutive members share an owner, which in an apk is
+// nearly always.
+func newEntry(hdr *tar.Header, offset int64, uname, gname unique.Handle[string]) *entry {
 	e := &entry{
 		name:     hdr.Name,
 		linkname: hdr.Linkname,
-		dir:      path.Dir(hdr.Name),
-		uname:    unique.Make(hdr.Uname),
-		gname:    unique.Make(hdr.Gname),
+		uname:    uname,
+		gname:    gname,
 		size:     hdr.Size,
 		offset:   offset,
 		mode:     hdr.Mode,
-		modTime:  hdr.ModTime,
-		devmajor: hdr.Devmajor,
-		devminor: hdr.Devminor,
 		uid:      int64(hdr.Uid),
 		gid:      int64(hdr.Gid),
 		fileMode: hdr.FileInfo().Mode(),
 		format:   int8(hdr.Format),
 		typeflag: hdr.Typeflag,
 	}
+	// rare is allocated lazily so the check for each field costs nothing on
+	// the members that have none of them.
+	rare := func() *rareFields {
+		if e.rare == nil {
+			e.rare = &rareFields{}
+		}
+		return e.rare
+	}
+	// Checked by reconstruction, not by range: this is exactly what header()
+	// will do, so it cannot disagree with it.
+	if n := hdr.ModTime.UnixNano(); time.Unix(0, n) == hdr.ModTime {
+		e.mtime = n
+	} else {
+		r := rare()
+		r.mtime, r.hasMtime = hdr.ModTime, true
+	}
 	if !hdr.AccessTime.IsZero() || !hdr.ChangeTime.IsZero() {
-		e.times = &fileTimes{hdr.AccessTime, hdr.ChangeTime}
+		r := rare()
+		r.access, r.change = hdr.AccessTime, hdr.ChangeTime
+	}
+	if hdr.Devmajor != 0 || hdr.Devminor != 0 {
+		r := rare()
+		r.devmajor, r.devminor = hdr.Devmajor, hdr.Devminor
 	}
 	// Keyed on nil, not length: archive/tar hands back a non-nil empty map
 	// for a member preceded by a zero-record extended header.
@@ -180,10 +224,25 @@ func newEntry(hdr *tar.Header, offset int64) *entry {
 					continue
 				}
 			}
-			e.pax = append(e.pax, paxRecord{key: unique.Make(k), value: v})
+			r := rare()
+			r.pax = append(r.pax, paxRecord{key: unique.Make(k), value: v})
 		}
 	}
 	return e
+}
+
+// dir is the directory the member lives in. path.Dir returns a prefix of
+// the name for the paths archive/tar produces, so this does not allocate.
+func (e *entry) dir() string {
+	return path.Dir(e.name)
+}
+
+// modTime rebuilds the header's ModTime from whichever form holds it.
+func (e *entry) modTime() time.Time {
+	if r := e.rare; r != nil && r.hasMtime {
+		return r.mtime
+	}
+	return time.Unix(0, e.mtime)
 }
 
 // header rebuilds the tar.Header this entry was indexed from, including its
@@ -202,20 +261,21 @@ func (e *entry) header() tar.Header {
 		Gid:      int(e.gid),
 		Uname:    e.uname.Value(),
 		Gname:    e.gname.Value(),
-		ModTime:  e.modTime,
-		Devmajor: e.devmajor,
-		Devminor: e.devminor,
+		ModTime:  e.modTime(),
 		Format:   tar.Format(e.format),
 	}
-	if e.times != nil {
-		hdr.AccessTime, hdr.ChangeTime = e.times.access, e.times.change
+	var pax []paxRecord
+	if r := e.rare; r != nil {
+		hdr.AccessTime, hdr.ChangeTime = r.access, r.change
+		hdr.Devmajor, hdr.Devminor = r.devmajor, r.devminor
+		pax = r.pax
 	}
 	if e.hasPAX {
-		hdr.PAXRecords = make(map[string]string, len(e.pax)+1)
+		hdr.PAXRecords = make(map[string]string, len(pax)+1)
 		if e.hasChecksum {
 			hdr.PAXRecords[paxChecksumKey] = hex.EncodeToString(e.checksum[:])
 		}
-		for _, r := range e.pax {
+		for _, r := range pax {
 			k := r.key.Value()
 			hdr.PAXRecords[k] = r.value
 			// archive/tar still fills the deprecated Xattrs view alongside
@@ -231,9 +291,9 @@ func (e *entry) header() tar.Header {
 	return hdr
 }
 
-// view materializes the exported Entry for this record.
-func (e *entry) view() *Entry {
-	return &Entry{Header: e.header(), Offset: e.offset, fi: e}
+// fill materializes the exported Entry for this record into dst.
+func (e *entry) fill(dst *Entry) {
+	*dst = Entry{Header: e.header(), Offset: e.offset, fi: e}
 }
 
 func (e *entry) Name() string {
@@ -245,7 +305,7 @@ func (e *entry) Name() string {
 func (e *entry) Size() int64                { return e.size }
 func (e *entry) Mode() fs.FileMode          { return e.fileMode }
 func (e *entry) Type() fs.FileMode          { return e.fileMode }
-func (e *entry) ModTime() time.Time         { return e.modTime }
+func (e *entry) ModTime() time.Time         { return e.modTime() }
 func (e *entry) IsDir() bool                { return e.fileMode.IsDir() }
 func (e *entry) Info() (fs.FileInfo, error) { return e, nil }
 func (e *entry) String() string             { return fs.FormatFileInfo(e) }
@@ -329,17 +389,22 @@ func (fsys *FS) open(name string, hops int) (fs.File, error) {
 			return fsys.open(link, hops+1)
 		}
 
-		return fsys.open(path.Join(e.dir, link), hops+1)
+		return fsys.open(path.Join(e.dir(), link), hops+1)
 	}
 
-	f := &File{
+	// The File and its Entry share one allocation; the Entry is the exported
+	// view a caller may read through File.Entry, so it has to exist at Open.
+	fe := &struct {
+		f File
+		e Entry
+	}{}
+	e.fill(&fe.e)
+	fe.f = File{
 		fsys:  fsys,
-		Entry: e.view(),
+		sr:    io.NewSectionReader(fsys.ra, e.offset, e.size),
+		Entry: &fe.e,
 	}
-
-	f.sr = io.NewSectionReader(fsys.ra, e.offset, e.size)
-
-	return f, nil
+	return &fe.f, nil
 }
 
 // Open implements fs.FS.
@@ -350,9 +415,13 @@ func (fsys *FS) Open(name string) (fs.File, error) {
 // Entries returns every member in archive order, each with its full header.
 // The slice is built on each call; hold it only as long as it is needed.
 func (fsys *FS) Entries() []*Entry {
+	// One backing array for every Entry rather than an allocation each; the
+	// caller holds the whole slice anyway.
+	backing := make([]Entry, len(fsys.files))
 	entries := make([]*Entry, len(fsys.files))
 	for i, e := range fsys.files {
-		entries[i] = e.view()
+		e.fill(&backing[i])
+		entries[i] = &backing[i]
 	}
 	return entries
 }
@@ -419,6 +488,10 @@ func New(ra io.ReaderAt, size int64) (*FS, error) {
 
 	cr := &countReader{br, 0}
 	tr := tar.NewReader(cr)
+	// Consecutive members almost always share an owner, so intern once per
+	// run of equal names instead of hashing every header's uname and gname.
+	lastUname, lastGname := "", ""
+	uname, gname := unique.Make(""), unique.Make("")
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
@@ -427,11 +500,17 @@ func New(ra io.ReaderAt, size int64) (*FS, error) {
 		if err != nil {
 			return nil, err
 		}
-		e := newEntry(hdr, cr.n)
+		if hdr.Uname != lastUname {
+			lastUname, uname = hdr.Uname, unique.Make(hdr.Uname)
+		}
+		if hdr.Gname != lastGname {
+			lastGname, gname = hdr.Gname, unique.Make(hdr.Gname)
+		}
+		e := newEntry(hdr, cr.n, uname, gname)
 		fsys.index[e.name] = len(fsys.files)
 		fsys.files = append(fsys.files, e)
 
-		dirCount[e.dir]++
+		dirCount[e.dir()]++
 	}
 
 	// Pre-generate the results of ReadDir so we don't allocate a ton if fs.WalkDir calls us.
@@ -441,7 +520,8 @@ func New(ra io.ReaderAt, size int64) (*FS, error) {
 	}
 
 	for _, f := range fsys.files {
-		fsys.dirs[f.dir] = append(fsys.dirs[f.dir], f)
+		d := f.dir()
+		fsys.dirs[d] = append(fsys.dirs[d], f)
 	}
 
 	for _, files := range fsys.dirs {

--- a/pkg/apk/expandapk/tarfs/tarfs.go
+++ b/pkg/apk/expandapk/tarfs/tarfs.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"cmp"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -75,7 +76,12 @@ func (e Entry) IsDir() bool {
 	return e.fi.IsDir()
 }
 
-const paxSchilyXattr = "SCHILY.xattr."
+const (
+	paxSchilyXattr = "SCHILY.xattr."
+	// paxChecksumKey is the per-file checksum apk-tools records on nearly every
+	// regular file. It is stored decoded rather than as a PAX record.
+	paxChecksumKey = "APK-TOOLS.checksum.SHA1"
+)
 
 type paxRecord struct {
 	key   unique.Handle[string]
@@ -110,10 +116,33 @@ type entry struct {
 	format   int8 // archive/tar's formatMax is 32
 	typeflag byte
 	hasPAX   bool
-	pax      []paxRecord
+	// checksum holds the paxChecksumKey record decoded from its 40-character
+	// lowercase hex form, which is what apk-tools writes. Any other spelling
+	// stays in pax verbatim so the header round-trips byte for byte.
+	hasChecksum bool
+	checksum    [sha1Size]byte
+	pax         []paxRecord
 	// times is set only when the header carries access or change times,
 	// which apk packages almost never do.
 	times *fileTimes
+}
+
+const sha1Size = 20
+
+// decodeChecksum reports the checksum bytes when v is exactly the lowercase
+// hex encoding of a SHA-1, so that re-encoding reproduces v unchanged.
+func decodeChecksum(v string) ([sha1Size]byte, bool) {
+	var sum [sha1Size]byte
+	if len(v) != hex.EncodedLen(sha1Size) {
+		return sum, false
+	}
+	if _, err := hex.Decode(sum[:], []byte(v)); err != nil {
+		return sum, false
+	}
+	if hex.EncodeToString(sum[:]) != v {
+		return sum, false
+	}
+	return sum, true
 }
 
 type fileTimes struct{ access, change time.Time }
@@ -144,8 +173,13 @@ func newEntry(hdr *tar.Header, offset int64) *entry {
 	// for a member preceded by a zero-record extended header.
 	if hdr.PAXRecords != nil {
 		e.hasPAX = true
-		e.pax = make([]paxRecord, 0, len(hdr.PAXRecords))
 		for k, v := range hdr.PAXRecords {
+			if k == paxChecksumKey {
+				if sum, ok := decodeChecksum(v); ok {
+					e.hasChecksum, e.checksum = true, sum
+					continue
+				}
+			}
 			e.pax = append(e.pax, paxRecord{key: unique.Make(k), value: v})
 		}
 	}
@@ -177,7 +211,10 @@ func (e *entry) header() tar.Header {
 		hdr.AccessTime, hdr.ChangeTime = e.times.access, e.times.change
 	}
 	if e.hasPAX {
-		hdr.PAXRecords = make(map[string]string, len(e.pax))
+		hdr.PAXRecords = make(map[string]string, len(e.pax)+1)
+		if e.hasChecksum {
+			hdr.PAXRecords[paxChecksumKey] = hex.EncodeToString(e.checksum[:])
+		}
 		for _, r := range e.pax {
 			k := r.key.Value()
 			hdr.PAXRecords[k] = r.value

--- a/pkg/apk/expandapk/tarfs/tarfs.go
+++ b/pkg/apk/expandapk/tarfs/tarfs.go
@@ -43,14 +43,16 @@ func pooledBufioReader(r io.Reader) *bufio.Reader {
 }
 
 // Entry is a tar member with its full header. Entries are materialized from
-// the resident index on request (see Entries and File.Entry), so callers pay
-// for the header only while they hold one.
+// the resident index on request, so callers pay for the header only while
+// they hold one. Entries and Open each build a fresh Entry per call, and
+// each materialization owns its maps, so a caller's mutation is private to
+// it. Consumers that only need file metadata should prefer Stat or ReadDir,
+// which serve the index directly and never build a header.
 type Entry struct {
 	Header tar.Header
 	Offset int64
 
-	dir string
-	fi  fs.FileInfo
+	fi fs.FileInfo
 }
 
 func (e Entry) Name() string {
@@ -82,7 +84,14 @@ type paxRecord struct {
 
 // entry is the resident index record for one tar member. It holds what a
 // tar.Header holds, laid out to avoid the per-member map and the duplicated
-// strings that make a retained tar.Header expensive across many packages.
+// strings that make a retained tar.Header expensive across many packages. It
+// also implements fs.FileInfo and fs.DirEntry with the same results as
+// archive/tar's Header.FileInfo, so Stat, ReadDir, and fs.WalkDir never
+// materialize a header.
+//
+// Interning uname, gname, and PAX keys assumes the apk shape, where those
+// repeat across every member (root, the checksum key). An archive of
+// entirely distinct values gets no dedup, only the hashing cost.
 type entry struct {
 	name     string
 	linkname string
@@ -92,19 +101,22 @@ type entry struct {
 	size     int64
 	offset   int64
 	mode     int64
+	uid      int64
+	gid      int64
 	modTime  time.Time
 	devmajor int64
 	devminor int64
-	uid      int32
-	gid      int32
 	fileMode fs.FileMode
-	format   int8
+	format   int8 // archive/tar's formatMax is 32
 	typeflag byte
+	hasPAX   bool
 	pax      []paxRecord
 	// times is set only when the header carries access or change times,
 	// which apk packages almost never do.
-	times *struct{ access, change time.Time }
+	times *fileTimes
 }
+
+type fileTimes struct{ access, change time.Time }
 
 func newEntry(hdr *tar.Header, offset int64) *entry {
 	e := &entry{
@@ -119,16 +131,19 @@ func newEntry(hdr *tar.Header, offset int64) *entry {
 		modTime:  hdr.ModTime,
 		devmajor: hdr.Devmajor,
 		devminor: hdr.Devminor,
-		uid:      int32(hdr.Uid),
-		gid:      int32(hdr.Gid),
+		uid:      int64(hdr.Uid),
+		gid:      int64(hdr.Gid),
 		fileMode: hdr.FileInfo().Mode(),
 		format:   int8(hdr.Format),
 		typeflag: hdr.Typeflag,
 	}
 	if !hdr.AccessTime.IsZero() || !hdr.ChangeTime.IsZero() {
-		e.times = &struct{ access, change time.Time }{hdr.AccessTime, hdr.ChangeTime}
+		e.times = &fileTimes{hdr.AccessTime, hdr.ChangeTime}
 	}
-	if len(hdr.PAXRecords) > 0 {
+	// Keyed on nil, not length: archive/tar hands back a non-nil empty map
+	// for a member preceded by a zero-record extended header.
+	if hdr.PAXRecords != nil {
+		e.hasPAX = true
 		e.pax = make([]paxRecord, 0, len(hdr.PAXRecords))
 		for k, v := range hdr.PAXRecords {
 			e.pax = append(e.pax, paxRecord{key: unique.Make(k), value: v})
@@ -138,7 +153,10 @@ func newEntry(hdr *tar.Header, offset int64) *entry {
 }
 
 // header rebuilds the tar.Header this entry was indexed from, including its
-// PAX records and the Xattrs view archive/tar derives from them.
+// PAX records and the Xattrs view archive/tar derives from them. Every
+// tar.Header field archive/tar populates has to be represented on entry and
+// restored here, so a field added to tar.Header in a future Go release needs
+// adding in both places.
 func (e *entry) header() tar.Header {
 	hdr := tar.Header{
 		Typeflag: e.typeflag,
@@ -158,7 +176,7 @@ func (e *entry) header() tar.Header {
 	if e.times != nil {
 		hdr.AccessTime, hdr.ChangeTime = e.times.access, e.times.change
 	}
-	if len(e.pax) > 0 {
+	if e.hasPAX {
 		hdr.PAXRecords = make(map[string]string, len(e.pax))
 		for _, r := range e.pax {
 			k := r.key.Value()
@@ -178,12 +196,8 @@ func (e *entry) header() tar.Header {
 
 // view materializes the exported Entry for this record.
 func (e *entry) view() *Entry {
-	return &Entry{Header: e.header(), Offset: e.offset, dir: e.dir, fi: e}
+	return &Entry{Header: e.header(), Offset: e.offset, fi: e}
 }
-
-// entry implements fs.FileInfo and fs.DirEntry with the same results as
-// archive/tar's Header.FileInfo, so directory listings and Stat never need a
-// materialized header.
 
 func (e *entry) Name() string {
 	if e.fileMode.IsDir() {
@@ -197,8 +211,11 @@ func (e *entry) Type() fs.FileMode          { return e.fileMode }
 func (e *entry) ModTime() time.Time         { return e.modTime }
 func (e *entry) IsDir() bool                { return e.fileMode.IsDir() }
 func (e *entry) Info() (fs.FileInfo, error) { return e, nil }
+func (e *entry) String() string             { return fs.FormatFileInfo(e) }
 
 // Sys matches archive/tar, which returns the *tar.Header behind a FileInfo.
+// Each call builds a new header, so a caller needing it more than once should
+// hold the result rather than calling Sys again.
 func (e *entry) Sys() any {
 	hdr := e.header()
 	return &hdr

--- a/pkg/apk/expandapk/tarfs/tarfs.go
+++ b/pkg/apk/expandapk/tarfs/tarfs.go
@@ -198,8 +198,10 @@ func newEntry(hdr *tar.Header, offset int64, uname, gname unique.Handle[string])
 		return e.rare
 	}
 	// Checked by reconstruction, not by range: this is exactly what header()
-	// will do, so it cannot disagree with it.
-	if n := hdr.ModTime.UnixNano(); time.Unix(0, n) == hdr.ModTime {
+	// will do, so it cannot disagree with it. Struct equality on purpose, not
+	// Equal: the rebuilt header has to be the identical time.Time value,
+	// including location, or DeepEqual against archive/tar's output fails.
+	if n := hdr.ModTime.UnixNano(); time.Unix(0, n) == hdr.ModTime { //nolint:staticcheck // see above
 		e.mtime = n
 	} else {
 		r := rare()

--- a/pkg/apk/expandapk/tarfs/tarfs.go
+++ b/pkg/apk/expandapk/tarfs/tarfs.go
@@ -24,8 +24,10 @@ import (
 	"io/fs"
 	"path"
 	"slices"
+	"strings"
 	"sync"
 	"time"
+	"unique"
 )
 
 var readerPool = sync.Pool{
@@ -40,6 +42,9 @@ func pooledBufioReader(r io.Reader) *bufio.Reader {
 	return br
 }
 
+// Entry is a tar member with its full header. Entries are materialized from
+// the resident index on request (see Entries and File.Entry), so callers pay
+// for the header only while they hold one.
 type Entry struct {
 	Header tar.Header
 	Offset int64
@@ -66,6 +71,137 @@ func (e Entry) Info() (fs.FileInfo, error) {
 
 func (e Entry) IsDir() bool {
 	return e.fi.IsDir()
+}
+
+const paxSchilyXattr = "SCHILY.xattr."
+
+type paxRecord struct {
+	key   unique.Handle[string]
+	value string
+}
+
+// entry is the resident index record for one tar member. It holds what a
+// tar.Header holds, laid out to avoid the per-member map and the duplicated
+// strings that make a retained tar.Header expensive across many packages.
+type entry struct {
+	name     string
+	linkname string
+	dir      string
+	uname    unique.Handle[string]
+	gname    unique.Handle[string]
+	size     int64
+	offset   int64
+	mode     int64
+	modTime  time.Time
+	devmajor int64
+	devminor int64
+	uid      int32
+	gid      int32
+	fileMode fs.FileMode
+	format   int8
+	typeflag byte
+	pax      []paxRecord
+	// times is set only when the header carries access or change times,
+	// which apk packages almost never do.
+	times *struct{ access, change time.Time }
+}
+
+func newEntry(hdr *tar.Header, offset int64) *entry {
+	e := &entry{
+		name:     hdr.Name,
+		linkname: hdr.Linkname,
+		dir:      path.Dir(hdr.Name),
+		uname:    unique.Make(hdr.Uname),
+		gname:    unique.Make(hdr.Gname),
+		size:     hdr.Size,
+		offset:   offset,
+		mode:     hdr.Mode,
+		modTime:  hdr.ModTime,
+		devmajor: hdr.Devmajor,
+		devminor: hdr.Devminor,
+		uid:      int32(hdr.Uid),
+		gid:      int32(hdr.Gid),
+		fileMode: hdr.FileInfo().Mode(),
+		format:   int8(hdr.Format),
+		typeflag: hdr.Typeflag,
+	}
+	if !hdr.AccessTime.IsZero() || !hdr.ChangeTime.IsZero() {
+		e.times = &struct{ access, change time.Time }{hdr.AccessTime, hdr.ChangeTime}
+	}
+	if len(hdr.PAXRecords) > 0 {
+		e.pax = make([]paxRecord, 0, len(hdr.PAXRecords))
+		for k, v := range hdr.PAXRecords {
+			e.pax = append(e.pax, paxRecord{key: unique.Make(k), value: v})
+		}
+	}
+	return e
+}
+
+// header rebuilds the tar.Header this entry was indexed from, including its
+// PAX records and the Xattrs view archive/tar derives from them.
+func (e *entry) header() tar.Header {
+	hdr := tar.Header{
+		Typeflag: e.typeflag,
+		Name:     e.name,
+		Linkname: e.linkname,
+		Size:     e.size,
+		Mode:     e.mode,
+		Uid:      int(e.uid),
+		Gid:      int(e.gid),
+		Uname:    e.uname.Value(),
+		Gname:    e.gname.Value(),
+		ModTime:  e.modTime,
+		Devmajor: e.devmajor,
+		Devminor: e.devminor,
+		Format:   tar.Format(e.format),
+	}
+	if e.times != nil {
+		hdr.AccessTime, hdr.ChangeTime = e.times.access, e.times.change
+	}
+	if len(e.pax) > 0 {
+		hdr.PAXRecords = make(map[string]string, len(e.pax))
+		for _, r := range e.pax {
+			k := r.key.Value()
+			hdr.PAXRecords[k] = r.value
+			// archive/tar still fills the deprecated Xattrs view alongside
+			// PAXRecords; readers of either must see the same header.
+			if r.value != "" && strings.HasPrefix(k, paxSchilyXattr) {
+				if hdr.Xattrs == nil { //nolint:staticcheck // mirrors archive/tar
+					hdr.Xattrs = make(map[string]string) //nolint:staticcheck // mirrors archive/tar
+				}
+				hdr.Xattrs[k[len(paxSchilyXattr):]] = r.value //nolint:staticcheck // mirrors archive/tar
+			}
+		}
+	}
+	return hdr
+}
+
+// view materializes the exported Entry for this record.
+func (e *entry) view() *Entry {
+	return &Entry{Header: e.header(), Offset: e.offset, dir: e.dir, fi: e}
+}
+
+// entry implements fs.FileInfo and fs.DirEntry with the same results as
+// archive/tar's Header.FileInfo, so directory listings and Stat never need a
+// materialized header.
+
+func (e *entry) Name() string {
+	if e.fileMode.IsDir() {
+		return path.Base(path.Clean(e.name))
+	}
+	return path.Base(e.name)
+}
+func (e *entry) Size() int64                { return e.size }
+func (e *entry) Mode() fs.FileMode          { return e.fileMode }
+func (e *entry) Type() fs.FileMode          { return e.fileMode }
+func (e *entry) ModTime() time.Time         { return e.modTime }
+func (e *entry) IsDir() bool                { return e.fileMode.IsDir() }
+func (e *entry) Info() (fs.FileInfo, error) { return e, nil }
+
+// Sys matches archive/tar, which returns the *tar.Header behind a FileInfo.
+func (e *entry) Sys() any {
+	hdr := e.header()
+	return &hdr
 }
 
 type File struct {
@@ -96,7 +232,7 @@ func (f *File) Close() error {
 
 type FS struct {
 	ra    io.ReaderAt
-	files []*Entry
+	files []*entry
 	index map[string]int
 	dirs  map[string][]fs.DirEntry
 }
@@ -109,9 +245,9 @@ func (fsys *FS) Readlink(name string) (string, error) {
 
 	e := fsys.files[i]
 
-	switch e.Header.Typeflag {
+	switch e.typeflag {
 	case tar.TypeSymlink, tar.TypeLink:
-		return e.Header.Linkname, nil
+		return e.linkname, nil
 	}
 
 	return "", fmt.Errorf("Readlink(%q): file is not a link", name)
@@ -132,9 +268,9 @@ func (fsys *FS) open(name string, hops int) (fs.File, error) {
 
 	e := fsys.files[i]
 
-	switch e.Header.Typeflag {
+	switch e.typeflag {
 	case tar.TypeSymlink, tar.TypeLink:
-		link := e.Header.Linkname
+		link := e.linkname
 		if path.IsAbs(link) {
 			return fsys.open(link, hops+1)
 		}
@@ -144,10 +280,10 @@ func (fsys *FS) open(name string, hops int) (fs.File, error) {
 
 	f := &File{
 		fsys:  fsys,
-		Entry: e,
+		Entry: e.view(),
 	}
 
-	f.sr = io.NewSectionReader(fsys.ra, e.Offset, e.Header.Size)
+	f.sr = io.NewSectionReader(fsys.ra, e.offset, e.size)
 
 	return f, nil
 }
@@ -157,8 +293,14 @@ func (fsys *FS) Open(name string) (fs.File, error) {
 	return fsys.open(name, 0)
 }
 
+// Entries returns every member in archive order, each with its full header.
+// The slice is built on each call; hold it only as long as it is needed.
 func (fsys *FS) Entries() []*Entry {
-	return fsys.files
+	entries := make([]*Entry, len(fsys.files))
+	for i, e := range fsys.files {
+		entries[i] = e.view()
+	}
+	return entries
 }
 
 type root struct{}
@@ -172,7 +314,7 @@ func (r root) Sys() any           { return nil }
 
 func (fsys *FS) Stat(name string) (fs.FileInfo, error) {
 	if i, ok := fsys.index[name]; ok {
-		return fsys.files[i].fi, nil
+		return fsys.files[i], nil
 	}
 
 	// fs.WalkDir expects "." to return a root entry to bootstrap the walk.
@@ -207,7 +349,7 @@ func (cr *countReader) Read(p []byte) (int, error) {
 func New(ra io.ReaderAt, size int64) (*FS, error) {
 	fsys := &FS{
 		ra:    ra,
-		files: []*Entry{},
+		files: []*entry{},
 		index: map[string]int{},
 		dirs:  map[string][]fs.DirEntry{},
 	}
@@ -231,16 +373,11 @@ func New(ra io.ReaderAt, size int64) (*FS, error) {
 		if err != nil {
 			return nil, err
 		}
-		dir := path.Dir(hdr.Name)
-		fsys.index[hdr.Name] = len(fsys.files)
-		fsys.files = append(fsys.files, &Entry{
-			Header: *hdr,
-			Offset: cr.n,
-			dir:    dir,
-			fi:     hdr.FileInfo(),
-		})
+		e := newEntry(hdr, cr.n)
+		fsys.index[e.name] = len(fsys.files)
+		fsys.files = append(fsys.files, e)
 
-		dirCount[dir]++
+		dirCount[e.dir]++
 	}
 
 	// Pre-generate the results of ReadDir so we don't allocate a ton if fs.WalkDir calls us.

--- a/pkg/apk/expandapk/tarfs/tarfs_test.go
+++ b/pkg/apk/expandapk/tarfs/tarfs_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand/v2"
 	"reflect"
 	"strings"
 	"testing"
@@ -287,5 +288,117 @@ func TestOpenStatReadDirReadlink(t *testing.T) {
 	}
 	if root, err := fsys.Stat("."); err != nil || !root.IsDir() {
 		t.Errorf("Stat(.) = %v, %v, want synthesized root dir", root, err)
+	}
+}
+
+// randomHeader builds a member whose fields are drawn from the whole space the
+// compact record has to represent, so a narrowed or dropped field shows up
+// without anyone having predicted which one it would be.
+func randomHeader(r *rand.Rand, i int) (tar.Header, string) {
+	typeflags := []byte{tar.TypeReg, tar.TypeDir, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeFifo}
+	tf := typeflags[r.IntN(len(typeflags))]
+
+	name := fmt.Sprintf("d%d/f%d", r.IntN(4), i)
+	if r.IntN(8) == 0 {
+		name = "d0/" + strings.Repeat("long", 40) + fmt.Sprint(i) // forces a PAX path record
+	}
+
+	hdr := tar.Header{
+		Typeflag: tf,
+		Name:     name,
+		Mode:     int64(r.IntN(0o7777)),
+		// Full width on purpose: archive/tar carries these as 64-bit.
+		Uid:     int(r.Uint64() % (1 << 40)),
+		Gid:     int(r.Uint64() % (1 << 40)),
+		Uname:   []string{"root", "nobody", "", "verylongusername"}[r.IntN(4)],
+		Gname:   []string{"root", "nogroup", ""}[r.IntN(3)],
+		ModTime: time.Unix(int64(r.IntN(1<<31)), 0),
+		Format:  tar.FormatPAX,
+	}
+	switch tf {
+	case tar.TypeChar, tar.TypeBlock:
+		hdr.Devmajor = int64(r.IntN(1 << 20))
+		hdr.Devminor = int64(r.IntN(1 << 20))
+	case tar.TypeSymlink:
+		hdr.Linkname = fmt.Sprintf("f%d", r.IntN(100))
+	}
+	if r.IntN(2) == 0 {
+		hdr.AccessTime = time.Unix(int64(r.IntN(1<<31)), 0)
+		hdr.ChangeTime = time.Unix(int64(r.IntN(1<<31)), 0)
+	}
+	if n := r.IntN(4); n > 0 {
+		hdr.PAXRecords = map[string]string{}
+		for j := range n {
+			// Include empty values: archive/tar keeps them in PAXRecords but
+			// skips them when mirroring into Xattrs.
+			v := ""
+			if r.IntN(3) != 0 {
+				v = fmt.Sprintf("v%d", r.IntN(1000))
+			}
+			if r.IntN(2) == 0 {
+				hdr.PAXRecords[fmt.Sprintf("SCHILY.xattr.user.a%d", j)] = v
+			} else {
+				hdr.PAXRecords[fmt.Sprintf("VENDOR.k%d", j)] = v
+			}
+		}
+	}
+
+	body := ""
+	if tf == tar.TypeReg {
+		body = strings.Repeat("x", r.IntN(200))
+	}
+	return hdr, body
+}
+
+// TestRoundTripProperty asserts the invariant the whole design rests on: for
+// any archive archive/tar can read, every materialized header equals the one
+// archive/tar produced. The fixture tests pin the shapes apks actually have;
+// this covers the field space nobody thought to enumerate.
+func TestRoundTripProperty(t *testing.T) {
+	for seed := range 200 {
+		r := rand.New(rand.NewPCG(uint64(seed), 0x2493))
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		n := 1 + r.IntN(12)
+		for i := range n {
+			hdr, body := randomHeader(r, i)
+			hdr.Size = int64(len(body))
+			if err := tw.WriteHeader(&hdr); err != nil {
+				t.Fatalf("seed %d: WriteHeader(%+v): %v", seed, hdr, err)
+			}
+			if _, err := io.WriteString(tw, body); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		data := buf.Bytes()
+		want := readHeaders(t, data)
+		fsys, err := New(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			t.Fatalf("seed %d: New: %v", seed, err)
+		}
+		got := fsys.Entries()
+		if len(got) != len(want) {
+			t.Fatalf("seed %d: Entries: got %d, want %d", seed, len(got), len(want))
+		}
+		for i := range want {
+			if !reflect.DeepEqual(got[i].Header, want[i]) {
+				t.Fatalf("seed %d entry %d (%s): header differs\n got: %+v\nwant: %+v",
+					seed, i, want[i].Name, got[i].Header, want[i])
+			}
+			ref := want[i].FileInfo()
+			fi, err := fsys.Stat(want[i].Name)
+			if err != nil {
+				t.Fatalf("seed %d: Stat(%q): %v", seed, want[i].Name, err)
+			}
+			if fi.Name() != ref.Name() || fi.Size() != ref.Size() || fi.Mode() != ref.Mode() ||
+				!fi.ModTime().Equal(ref.ModTime()) || fi.IsDir() != ref.IsDir() || fmt.Sprint(fi) != fmt.Sprint(ref) {
+				t.Fatalf("seed %d: Stat(%q) disagrees with archive/tar: got %v, want %v",
+					seed, want[i].Name, fi, ref)
+			}
+		}
 	}
 }

--- a/pkg/apk/expandapk/tarfs/tarfs_test.go
+++ b/pkg/apk/expandapk/tarfs/tarfs_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tarfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixtureTar writes the member shapes apk packages actually contain: a
+// directory, a regular file with the apk checksum and an xattr as PAX records,
+// a symlink, a hardlink, a member with a name too long for USTAR (which forces
+// a PAX path record), and a file with explicit times.
+func fixtureTar(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	epoch := time.Unix(1700000000, 0)
+	longName := "usr/share/" + strings.Repeat("verylongdirectoryname/", 6) + "file.txt"
+	members := []struct {
+		hdr  tar.Header
+		body string
+	}{
+		// apk data tars name directories without a trailing slash.
+		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr/bin", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
+		{
+			hdr: tar.Header{
+				Typeflag: tar.TypeReg, Name: "usr/bin/hello", Mode: 0o4755, Uid: 0, Gid: 0, Uname: "root", Gname: "root", ModTime: epoch,
+				Format: tar.FormatPAX,
+				PAXRecords: map[string]string{
+					"APK-TOOLS.checksum.SHA1":          "Q1abcdefghijklmnopqrstuvwxyz0123456789=",
+					"SCHILY.xattr.security.capability": "\x01\x00\x00\x02\x00\x04\x00\x00",
+				},
+			},
+			body: "hello world\n",
+		},
+		{hdr: tar.Header{Typeflag: tar.TypeSymlink, Name: "usr/bin/hi", Linkname: "hello", Mode: 0o777, Uname: "root", Gname: "root", ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeLink, Name: "usr/bin/hello-hard", Linkname: "usr/bin/hello", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: longName, Mode: 0o644, Uname: "nobody", Gname: "nogroup", ModTime: epoch, Format: tar.FormatPAX}, body: "long\n"},
+		{
+			hdr:  tar.Header{Typeflag: tar.TypeReg, Name: "usr/bin/timed", Mode: 0o644, ModTime: epoch, AccessTime: epoch.Add(time.Hour), ChangeTime: epoch.Add(2 * time.Hour), Format: tar.FormatPAX},
+			body: "timed\n",
+		},
+	}
+	for _, m := range members {
+		m.hdr.Size = int64(len(m.body))
+		if err := tw.WriteHeader(&m.hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(tw, m.body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// readHeaders is the reference: what archive/tar itself produces for the same bytes.
+func readHeaders(t *testing.T, data []byte) []tar.Header {
+	t.Helper()
+	var out []tar.Header
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return out
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, *hdr)
+	}
+}
+
+func TestEntriesRoundTripHeaders(t *testing.T) {
+	data := fixtureTar(t)
+	want := readHeaders(t, data)
+
+	fsys, err := New(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := fsys.Entries()
+	if len(got) != len(want) {
+		t.Fatalf("Entries: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(got[i].Header, want[i]) {
+			t.Errorf("entry %d (%s): header differs\n got: %+v\nwant: %+v", i, want[i].Name, got[i].Header, want[i])
+		}
+	}
+
+	// Materialized headers are independent copies; mutating one must not leak
+	// into the index or into the next caller.
+	got[2].Header.PAXRecords["APK-TOOLS.checksum.SHA1"] = "tampered"
+	if again := fsys.Entries()[2].Header.PAXRecords["APK-TOOLS.checksum.SHA1"]; again == "tampered" {
+		t.Error("Entries() shares PAX map state between calls")
+	}
+}
+
+func TestFileInfoMatchesArchiveTar(t *testing.T) {
+	data := fixtureTar(t)
+	want := readHeaders(t, data)
+
+	fsys, err := New(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, hdr := range want {
+		ref := hdr.FileInfo()
+		fi, err := fsys.Stat(hdr.Name)
+		if err != nil {
+			t.Fatalf("Stat(%q): %v", hdr.Name, err)
+		}
+		if fi.Name() != ref.Name() || fi.Size() != ref.Size() || fi.Mode() != ref.Mode() || !fi.ModTime().Equal(ref.ModTime()) || fi.IsDir() != ref.IsDir() {
+			t.Errorf("Stat(%q) = {%s %d %v %v %v}, want {%s %d %v %v %v}", hdr.Name,
+				fi.Name(), fi.Size(), fi.Mode(), fi.ModTime(), fi.IsDir(),
+				ref.Name(), ref.Size(), ref.Mode(), ref.ModTime(), ref.IsDir())
+		}
+		sys, ok := fi.Sys().(*tar.Header)
+		if !ok || !reflect.DeepEqual(*sys, hdr) {
+			t.Errorf("Stat(%q).Sys() = %T %+v, want the original *tar.Header", hdr.Name, fi.Sys(), fi.Sys())
+		}
+	}
+}
+
+func TestOpenStatReadDirReadlink(t *testing.T) {
+	data := fixtureTar(t)
+	fsys, err := New(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fsys.Open("usr/bin/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hello world\n" {
+		t.Errorf("Open(hello) body = %q", body)
+	}
+	if got := f.(*File).Entry.Header.PAXRecords["APK-TOOLS.checksum.SHA1"]; !strings.HasPrefix(got, "Q1") {
+		t.Errorf("File.Entry header lost its PAX checksum: %q", got)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode()&fs.ModeSetuid == 0 || st.Mode().Perm() != 0o755 {
+		t.Errorf("Stat(hello).Mode() = %v, want setuid 0755", st.Mode())
+	}
+
+	lf, err := fsys.Open("usr/bin/hi")
+	if err != nil {
+		t.Fatalf("Open(hi): %v", err)
+	}
+	b, _ := io.ReadAll(lf)
+	if string(b) != "hello world\n" {
+		t.Errorf("Open(hi) body = %q, want symlink target content", b)
+	}
+	for name, want := range map[string]string{"usr/bin/hi": "hello", "usr/bin/hello-hard": "usr/bin/hello"} {
+		link, err := fsys.Readlink(name)
+		if err != nil || link != want {
+			t.Errorf("Readlink(%q) = %q, %v, want %q", name, link, err, want)
+		}
+	}
+	if _, err := fsys.Readlink("usr/bin/hello"); err == nil {
+		t.Error("Readlink on a regular file should fail")
+	}
+
+	entries, err := fsys.ReadDir("usr/bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+		info, err := e.Info()
+		if err != nil || info.Name() != e.Name() {
+			t.Errorf("DirEntry %q Info() = %v, %v", e.Name(), info, err)
+		}
+	}
+	want := []string{"hello", "hello-hard", "hi", "timed"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("ReadDir(usr/bin) = %v, want %v", names, want)
+	}
+
+	if _, err := fsys.Stat("nope"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("Stat(nope) = %v, want ErrNotExist", err)
+	}
+	if root, err := fsys.Stat("."); err != nil || !root.IsDir() {
+		t.Errorf("Stat(.) = %v, %v, want synthesized root dir", root, err)
+	}
+}

--- a/pkg/apk/expandapk/tarfs/tarfs_test.go
+++ b/pkg/apk/expandapk/tarfs/tarfs_test.go
@@ -182,7 +182,10 @@ func TestChecksumIsDecoded(t *testing.T) {
 		return fsys.files[i]
 	}
 	hasRecord := func(e *entry) bool {
-		for _, r := range e.pax {
+		if e.rare == nil {
+			return false
+		}
+		for _, r := range e.rare.pax {
 			if r.key.Value() == paxChecksumKey {
 				return true
 			}
@@ -362,6 +365,11 @@ func randomHeader(r *rand.Rand, i int) (tar.Header, string) {
 		Gname:   []string{"root", "nogroup", ""}[r.IntN(3)],
 		ModTime: time.Unix(int64(r.IntN(1<<31)), 0),
 		Format:  tar.FormatPAX,
+	}
+	// Past the int64-nanosecond horizon (year 2262): the resident record
+	// cannot hold this as nanoseconds and has to keep the time.Time whole.
+	if r.IntN(8) == 0 {
+		hdr.ModTime = time.Unix(int64(1<<40)+int64(r.IntN(1<<20)), 0)
 	}
 	switch tf {
 	case tar.TypeChar, tar.TypeBlock:

--- a/pkg/apk/expandapk/tarfs/tarfs_test.go
+++ b/pkg/apk/expandapk/tarfs/tarfs_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"reflect"
@@ -30,7 +31,7 @@ import (
 // directory, a regular file with the apk checksum and an xattr as PAX records,
 // a symlink, a hardlink, a member with a name too long for USTAR (which forces
 // a PAX path record), and a file with explicit times.
-func fixtureTar(t *testing.T) []byte {
+func fixtureTar(t testing.TB) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
@@ -41,19 +42,30 @@ func fixtureTar(t *testing.T) []byte {
 		body string
 	}{
 		// apk data tars name directories without a trailing slash.
-		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
-		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr/bin", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr", Mode: 0o755, Uid: 0, Gid: 0, Uname: "root", Gname: "root", ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeDir, Name: "usr/bin", Mode: 0o755, Uid: 1, Gid: 2, Uname: "root", Gname: "root", ModTime: epoch}},
 		{
 			hdr: tar.Header{
-				Typeflag: tar.TypeReg, Name: "usr/bin/hello", Mode: 0o4755, Uid: 0, Gid: 0, Uname: "root", Gname: "root", ModTime: epoch,
+				Typeflag: tar.TypeReg, Name: "usr/bin/hello", Mode: 0o4755, Uid: 1000, Gid: 1001, Uname: "root", Gname: "root", ModTime: epoch,
 				Format: tar.FormatPAX,
 				PAXRecords: map[string]string{
 					"APK-TOOLS.checksum.SHA1":          "Q1abcdefghijklmnopqrstuvwxyz0123456789=",
 					"SCHILY.xattr.security.capability": "\x01\x00\x00\x02\x00\x04\x00\x00",
+					// Empty-valued records stay in PAXRecords but archive/tar
+					// skips them before the Xattrs mirror.
+					"SCHILY.xattr.user.empty": "",
 				},
 			},
 			body: "hello world\n",
 		},
+		// Ownership above MaxInt32: the compact record must not narrow it.
+		// 4294967294 is the user-namespace-mapped nobody in many container tars.
+		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: "usr/bin/bigids", Mode: 0o644, Uid: 4294967294, Gid: 3000000000, ModTime: epoch, Format: tar.FormatPAX}, body: "big\n"},
+		// Device nodes carry the only nonzero Devmajor/Devminor in the fixture.
+		{hdr: tar.Header{Typeflag: tar.TypeChar, Name: "dev/null", Mode: 0o666, Devmajor: 1, Devminor: 3, ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeBlock, Name: "dev/loop0", Mode: 0o660, Devmajor: 7, Devminor: 0, ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeFifo, Name: "dev/initctl", Mode: 0o600, ModTime: epoch}},
+		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: "usr/bin/gnu", Mode: 0o644, Uid: 500, Gid: 501, ModTime: epoch, Format: tar.FormatGNU}, body: "gnu\n"},
 		{hdr: tar.Header{Typeflag: tar.TypeSymlink, Name: "usr/bin/hi", Linkname: "hello", Mode: 0o777, Uname: "root", Gname: "root", ModTime: epoch}},
 		{hdr: tar.Header{Typeflag: tar.TypeLink, Name: "usr/bin/hello-hard", Linkname: "usr/bin/hello", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
 		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: longName, Mode: 0o644, Uname: "nobody", Gname: "nogroup", ModTime: epoch, Format: tar.FormatPAX}, body: "long\n"},
@@ -78,7 +90,7 @@ func fixtureTar(t *testing.T) []byte {
 }
 
 // readHeaders is the reference: what archive/tar itself produces for the same bytes.
-func readHeaders(t *testing.T, data []byte) []tar.Header {
+func readHeaders(t testing.TB, data []byte) []tar.Header {
 	t.Helper()
 	var out []tar.Header
 	tr := tar.NewReader(bytes.NewReader(data))
@@ -113,10 +125,30 @@ func TestEntriesRoundTripHeaders(t *testing.T) {
 	}
 
 	// Materialized headers are independent copies; mutating one must not leak
-	// into the index or into the next caller.
+	// into the index or into the next caller. Xattrs is a separately allocated
+	// map, so it needs its own check.
 	got[2].Header.PAXRecords["APK-TOOLS.checksum.SHA1"] = "tampered"
-	if again := fsys.Entries()[2].Header.PAXRecords["APK-TOOLS.checksum.SHA1"]; again == "tampered" {
+	got[2].Header.Xattrs["security.capability"] = "tampered" //nolint:staticcheck // mirrors archive/tar
+	again := fsys.Entries()[2]
+	if again.Header.PAXRecords["APK-TOOLS.checksum.SHA1"] == "tampered" {
 		t.Error("Entries() shares PAX map state between calls")
+	}
+	if again.Header.Xattrs["security.capability"] == "tampered" { //nolint:staticcheck // mirrors archive/tar
+		t.Error("Entries() shares Xattrs map state between calls")
+	}
+
+	// The exported Entry's fs.DirEntry methods read the shared index record;
+	// they must agree with the same archive/tar reference the headers do.
+	for i, e := range got {
+		ref := want[i].FileInfo()
+		if e.Name() != ref.Name() || e.Size() != ref.Size() || e.Type() != ref.Mode() || e.IsDir() != ref.IsDir() {
+			t.Errorf("entry %d (%s): DirEntry methods = {%s %d %v %v}, want {%s %d %v %v}", i, want[i].Name,
+				e.Name(), e.Size(), e.Type(), e.IsDir(), ref.Name(), ref.Size(), ref.Mode(), ref.IsDir())
+		}
+		info, err := e.Info()
+		if err != nil || info.Name() != ref.Name() {
+			t.Errorf("entry %d (%s): Info() = %v, %v", i, want[i].Name, info, err)
+		}
 	}
 }
 
@@ -140,8 +172,45 @@ func TestFileInfoMatchesArchiveTar(t *testing.T) {
 				ref.Name(), ref.Size(), ref.Mode(), ref.ModTime(), ref.IsDir())
 		}
 		sys, ok := fi.Sys().(*tar.Header)
-		if !ok || !reflect.DeepEqual(*sys, hdr) {
-			t.Errorf("Stat(%q).Sys() = %T %+v, want the original *tar.Header", hdr.Name, fi.Sys(), fi.Sys())
+		if !ok {
+			t.Errorf("Stat(%q).Sys() = %T, want *tar.Header", hdr.Name, fi.Sys())
+		} else if !reflect.DeepEqual(*sys, hdr) {
+			t.Errorf("Stat(%q).Sys() = %+v, want %+v", hdr.Name, *sys, hdr)
+		}
+		// archive/tar's headerFileInfo formats via fs.FormatFileInfo; the
+		// index record has to keep that or %v output changes for callers.
+		if got, want := fmt.Sprint(fi), fmt.Sprint(ref); got != want {
+			t.Errorf("Stat(%q) String() = %q, want %q", hdr.Name, got, want)
+		}
+	}
+}
+
+// BenchmarkNew reports the indexing cost the compact record targets. Run with
+// -benchmem; B/op here is allocation volume, not the resident size the record
+// actually reduces, which needs a heap profile to see.
+func BenchmarkNew(b *testing.B) {
+	data := fixtureTar(b)
+	r := bytes.NewReader(data)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := New(r, int64(len(data))); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOpen covers the per-file read path, which materializes an Entry
+// because Entry.Header is an exported value field.
+func BenchmarkOpen(b *testing.B) {
+	data := fixtureTar(b)
+	fsys, err := New(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := fsys.Open("usr/bin/hello"); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -179,7 +248,10 @@ func TestOpenStatReadDirReadlink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open(hi): %v", err)
 	}
-	b, _ := io.ReadAll(lf)
+	b, err := io.ReadAll(lf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(b) != "hello world\n" {
 		t.Errorf("Open(hi) body = %q, want symlink target content", b)
 	}
@@ -197,7 +269,7 @@ func TestOpenStatReadDirReadlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var names []string
+	names := make([]string, 0, len(entries))
 	for _, e := range entries {
 		names = append(names, e.Name())
 		info, err := e.Info()
@@ -205,7 +277,7 @@ func TestOpenStatReadDirReadlink(t *testing.T) {
 			t.Errorf("DirEntry %q Info() = %v, %v", e.Name(), info, err)
 		}
 	}
-	want := []string{"hello", "hello-hard", "hi", "timed"}
+	want := []string{"bigids", "gnu", "hello", "hello-hard", "hi", "timed"}
 	if !reflect.DeepEqual(names, want) {
 		t.Errorf("ReadDir(usr/bin) = %v, want %v", names, want)
 	}

--- a/pkg/apk/expandapk/tarfs/tarfs_test.go
+++ b/pkg/apk/expandapk/tarfs/tarfs_test.go
@@ -69,9 +69,20 @@ func fixtureTar(t testing.TB) []byte {
 		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: "usr/bin/gnu", Mode: 0o644, Uid: 500, Gid: 501, ModTime: epoch, Format: tar.FormatGNU}, body: "gnu\n"},
 		{hdr: tar.Header{Typeflag: tar.TypeSymlink, Name: "usr/bin/hi", Linkname: "hello", Mode: 0o777, Uname: "root", Gname: "root", ModTime: epoch}},
 		{hdr: tar.Header{Typeflag: tar.TypeLink, Name: "usr/bin/hello-hard", Linkname: "usr/bin/hello", Mode: 0o755, Uname: "root", Gname: "root", ModTime: epoch}},
-		{hdr: tar.Header{Typeflag: tar.TypeReg, Name: longName, Mode: 0o644, Uname: "nobody", Gname: "nogroup", ModTime: epoch, Format: tar.FormatPAX}, body: "long\n"},
+		// The checksum spelling apk-tools actually writes: 40 lowercase hex chars.
 		{
-			hdr:  tar.Header{Typeflag: tar.TypeReg, Name: "usr/bin/timed", Mode: 0o644, ModTime: epoch, AccessTime: epoch.Add(time.Hour), ChangeTime: epoch.Add(2 * time.Hour), Format: tar.FormatPAX},
+			hdr: tar.Header{
+				Typeflag: tar.TypeReg, Name: longName, Mode: 0o644, Uname: "nobody", Gname: "nogroup", ModTime: epoch, Format: tar.FormatPAX,
+				PAXRecords: map[string]string{"APK-TOOLS.checksum.SHA1": "bacc34a9e2bd145fa47ba40381ced6ee1e8901ba"},
+			},
+			body: "long\n",
+		},
+		// Uppercase hex decodes to the same bytes but must round-trip verbatim.
+		{
+			hdr: tar.Header{
+				Typeflag: tar.TypeReg, Name: "usr/bin/timed", Mode: 0o644, ModTime: epoch, AccessTime: epoch.Add(time.Hour), ChangeTime: epoch.Add(2 * time.Hour), Format: tar.FormatPAX,
+				PAXRecords: map[string]string{"APK-TOOLS.checksum.SHA1": "BACC34A9E2BD145FA47BA40381CED6EE1E8901BA"},
+			},
 			body: "timed\n",
 		},
 	}
@@ -149,6 +160,43 @@ func TestEntriesRoundTripHeaders(t *testing.T) {
 		info, err := e.Info()
 		if err != nil || info.Name() != ref.Name() {
 			t.Errorf("entry %d (%s): Info() = %v, %v", i, want[i].Name, info, err)
+		}
+	}
+}
+
+// TestChecksumIsDecoded pins that the fast path engages: the round-trip tests
+// pass whether or not the checksum is decoded, so without this a regression
+// to the verbatim path would keep every test green while giving the memory back.
+func TestChecksumIsDecoded(t *testing.T) {
+	data := fixtureTar(t)
+	fsys, err := New(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	find := func(name string) *entry {
+		t.Helper()
+		i, ok := fsys.index[name]
+		if !ok {
+			t.Fatalf("fixture has no %q", name)
+		}
+		return fsys.files[i]
+	}
+	hasRecord := func(e *entry) bool {
+		for _, r := range e.pax {
+			if r.key.Value() == paxChecksumKey {
+				return true
+			}
+		}
+		return false
+	}
+
+	longName := "usr/share/" + strings.Repeat("verylongdirectoryname/", 6) + "file.txt"
+	if e := find(longName); !e.hasChecksum || hasRecord(e) {
+		t.Errorf("lowercase hex checksum: hasChecksum=%v, kept as record=%v; want decoded and dropped from pax", e.hasChecksum, hasRecord(e))
+	}
+	for _, name := range []string{"usr/bin/timed", "usr/bin/hello"} {
+		if e := find(name); e.hasChecksum || !hasRecord(e) {
+			t.Errorf("%s: hasChecksum=%v, kept as record=%v; want verbatim record only", name, e.hasChecksum, hasRecord(e))
 		}
 	}
 }
@@ -328,6 +376,18 @@ func randomHeader(r *rand.Rand, i int) (tar.Header, string) {
 	}
 	if n := r.IntN(4); n > 0 {
 		hdr.PAXRecords = map[string]string{}
+		// Every spelling of the checksum record the index might meet: the
+		// decoded fast path, and the forms that must stay verbatim.
+		if r.IntN(2) == 0 {
+			hdr.PAXRecords["APK-TOOLS.checksum.SHA1"] = []string{
+				"bacc34a9e2bd145fa47ba40381ced6ee1e8901ba",
+				"BACC34A9E2BD145FA47BA40381CED6EE1E8901BA",
+				"Q1abcdefghijklmnopqrstuvwxyz0123456789=",
+				"bacc34a9",
+				"zzcc34a9e2bd145fa47ba40381ced6ee1e8901ba",
+				"",
+			}[r.IntN(6)]
+		}
 		for j := range n {
 			// Include empty values: archive/tar keeps them in PAXRecords but
 			// skips them when mirroring into Xattrs.


### PR DESCRIPTION
`tarfs.New` kept a full `tar.Header` per member, twice: once copied into `Entry.Header` and once more through `fi`, which held `hdr.FileInfo()` on the reader's original header. Each member also carried its `PAXRecords` map, which for apk packages is one record (the checksum) costing ~320 bytes of map to hold ~55 bytes of string. Callers that cache expanded packages keep these indexes alive for the process lifetime. Measured on real apks, that came to 700-1,200 bytes resident per member, and in a heap profile of a long-running process `tarfs.New` accounted for 0.9 GB in-use (#2492).

## Change

The index now holds a compact `entry` per member: the header's scalar fields, `Uname`/`Gname` and PAX keys interned through `unique`, PAX records as a slice, and access/change times behind a pointer that is nil for the apk case. `entry` implements `fs.FileInfo` and `fs.DirEntry`, with the mode computed once from `Header.FileInfo()` so it matches `archive/tar` exactly, so `Stat`, `ReadDir`, and `fs.WalkDir` never touch a `tar.Header`.

The record is 136 bytes. Everything a typical apk member does not have sits behind one pointer that is nil for a regular file or directory: access and change times, device numbers, PAX records other than the checksum, and any mtime that `int64` nanoseconds cannot hold (`archive/tar` builds every `ModTime` with `time.Unix`, so `time.Unix(0, n)` reproduces it exactly and the guard is that reconstruction, not a range check). Every relocated field keeps its original width. The apk checksum record is hex-decoded into a fixed field when it is the exact lowercase spelling apk-tools writes, an idea from #2433, and re-encoded on materialization; any other spelling stays a verbatim PAX record so the header still round-trips byte for byte.

The exported API is unchanged. `Entry`, `Entry.Header`, `Entries()`, and `File.Entry` keep their types; they are now materialized from the compact record on request.

Two runtime behaviours do change, neither documented before. `Entries()` used to return the resident records directly, so callers shared one mutable `PAXRecords` map and a mutation was visible to the next caller (and racy between concurrent ones); each call now returns independent copies. And `Sys()` builds a header per call, so it no longer returns a stable pointer — `io/fs` promises no identity, but `archive/tar` happened to. `Entries()` builds its slice on each call, so a caller pays for full headers only while holding the result. The one in-tree consumer, `contents.Entries()`, already copies into `[]tar.Header` and is unaffected. `Sys()` still returns a `*tar.Header`.

Materialized headers reproduce `PAXRecords` and the deprecated `Xattrs` view exactly as `archive/tar` fills them, since the install path reads the apk checksum and `SCHILY.xattr.*` records from there.

## Measured

Resident heap per indexed member, real apks, `runtime.MemStats` around `tarfs.New`:

| apk (aarch64) | members | before | after |
|---|---|---|---|
| git 2.55.0 | 241 | 1,028 B | 285 B |
| coreutils 9.11 | 113 | 1,016 B | 266 B |
| glibc 2.43 | 35 | 889 B | 268 B |
| openssl 3.6.4 | 19 | 743 B | 274 B |
| ca-certificates-bundle | 15 | 803 B | 302 B |
| busybox 1.38.0 | 12 | 788 B | 733 B |
| python-3.13 | 12 | 748 B | 250 B |
| bash 5.3 | 10 | 1,246 B | 891 B |
| curl 8.22.0 | 10 | 743 B | 261 B |
| wolfi-base | 5 | 723 B | 281 B |
| **weighted, 472 members** | | **979 B** | **303 B** |

The resident record is 136 bytes; the rest is per-member strings and index slots. `BenchmarkNew` and `BenchmarkOpen` are in the package so both figures can be re-derived.

Resident is the number that matters here. Materializing costs transient allocation on the read path: collecting every member's header, which is what `contents.Entries()` does once per package install, runs ~840 B per member against ~230 B on main, and each `Open` builds the `File.Entry` it exposes, about three more allocations per regular file. That is garbage as soon as the caller is done with it, where the per-member record is retained for as long as the package is cached. Index build time is within run-to-run noise of main on the same sample, with fewer bytes allocated.

### What that means at scale

Measured above: **979 to 303 bytes per indexed member**, weighted across 10 real Wolfi packages (472 members total; `wolfi-base`, `busybox`, `glibc`, `ca-certificates-bundle`, `python-3.13`, `git`, `curl`, `openssl`, `bash`, `coreutils`).

Linear extrapolation from that figure, since the record is per member and the saving scales with retained members:

| resident indexed members | before | after | saved |
|---|---|---|---|
| 10,000 | 10 MB | 3 MB | 7 MB |
| 100,000 | 98 MB | 30 MB | 68 MB |
| 500,000 | 490 MB | 152 MB | 338 MB |
| 1,000,000 | 979 MB | 303 MB | 676 MB |

To place yourself on it: the sample averages ~48 indexed members per package (median 14, max 229 for `git`). A one-shot build that indexes a 50-package image sits near the top of the table and will not notice. A long-running process that caches expanded packages accumulates members for its lifetime and lands further down — the 1,000,000 row is roughly the 0.9 GB `tarfs.New` figure from the heap profile in #2492.

Nothing here changes for a caller that indexes a package and drops it. The saving is entirely in what stays resident.

## Equivalence, end to end

apko built from `main` and from this branch, same locked package versions, same `SOURCE_DATE_EPOCH`:

| build | result |
|---|---|
| layered aarch64 (`origin` strategy, non-root `run-as`, explicitly owned paths) | `image.tar` byte-identical |
| every blob in that OCI layout | identical, `diff -r` clean |
| unlayered x86_64, single tar layer | byte-identical |
| `build-minirootfs` plain tar, 399 members | byte-identical |
| ownership and mode of every member in that tar | identical |
| SBOMs (~247 KB each) | identical except the line where apko stamps its own build version |

The layered config runs as a non-root user with owned paths, so the uid/gid path is live rather than all-zero. `build-minirootfs` is the one caller that reads the layer file directly, so it covers the plain-tar output contract rather than only the compressed blob.

Re-verified at the final commit with a two-arch (aarch64 and x86_64) layered build: all 28 blobs, both configs, the manifest, and `index.json` identical by content; SBOMs identical except the line carrying apko's own version. The outer `image.tar` differs only in entry order in the two-arch case, which is pre-existing nondeterminism in the multi-arch tarball writer and not touched here.

## Tests

The package had none. Added a randomized round-trip property test plus fixture tests.

`TestRoundTripProperty` generates headers across the field space — full-width uid/gid, every typeflag, device numbers, PAX records including empty values, names long enough to force a PAX path record, optional access and change times — writes them with `tar.Writer`, and compares every materialized header and `FileInfo` against what `archive/tar` produces for the same bytes. 200 seeded runs, deterministic, 0.03s. With the fixture tests disabled it catches, on its own: the `int32` narrowing, uid/gid swapped, `devminor` dropped, `format` dropped, `ChangeTime` dropped, `Uname` not restored, `Linkname` dropped, empty-valued PAX records skipped, the `Xattrs` mirror dropped, and `fileMode` derived by hand instead of from `archive/tar`.

Fixture tests: header round-trip against `archive/tar` for directories, a setuid file with checksum and xattr PAX records, a symlink, a hardlink, a PAX long name, and a member with access/change times (`reflect.DeepEqual`, and materialized maps are independent copies); `FileInfo` field-for-field against `Header.FileInfo()` including `Sys()`; and `Open`/`Stat`/`ReadDir`/`Readlink` behavior including symlink following and the synthesized root. Both the `PAXRecords` and `Xattrs` maps are mutation-checked for independence across materializations, and `Entry`'s `fs.DirEntry` methods are compared against the same reference. Fixture members cover ownership above `MaxInt32`, char/block/fifo device nodes, a GNU-format member, and an empty-valued xattr record, so the round-trip can fail on a narrowed or dropped field.

Fixes #2492.





