### PR TITLE
fix: parse and write replaces_priority in the installed apk db

### DIFF
--- a/pkg/apk/apk/installed.go
+++ b/pkg/apk/apk/installed.go
@@ -300,6 +300,12 @@ func ParseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 			pkg.Provides = strings.Split(val, " ")
 		case "r":
 			pkg.Replaces = strings.Split(val, " ")
+		case "q":
+			priority, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse replaces priority field %s: %w", val, err)
+			}
+			pkg.ReplacesPriority = priority
 		case "c":
 			pkg.RepoCommit = val
 		case "t":

--- a/pkg/apk/apk/installed_test.go
+++ b/pkg/apk/apk/installed_test.go
@@ -314,6 +314,26 @@ func TestAddInstalledPackageAdded(t *testing.T) {
 	}
 }
 
+func TestPackageToInstalledReplacesPriority(t *testing.T) {
+	t.Run("zero replaces_priority produces no q: line", func(t *testing.T) {
+		lines := PackageToInstalled(&Package{Name: "testpkg", Version: "1.0.0"})
+		for _, l := range lines {
+			require.False(t, strings.HasPrefix(l, "q:"), "replaces_priority of 0 must not produce a q: line, matching apk-tools")
+		}
+	})
+
+	t.Run("non-zero replaces_priority is written and round-trips", func(t *testing.T) {
+		pkg := &Package{Name: "testpkg", Version: "1.0.0", ReplacesPriority: 7}
+		lines := PackageToInstalled(pkg)
+		require.Contains(t, lines, "q:7")
+
+		installed, err := ParseInstalled(strings.NewReader(strings.Join(lines, "\n") + "\n\n"))
+		require.NoError(t, err)
+		require.Len(t, installed, 1)
+		require.EqualValues(t, 7, installed[0].ReplacesPriority)
+	})
+}
+
 func TestIsInstalledPackage(t *testing.T) {
 	a, _, err := testGetTestAPK()
 	require.NoErrorf(t, err, "unable to initialize APK implementation: %v", err)

--- a/pkg/apk/apk/package.go
+++ b/pkg/apk/apk/package.go
@@ -45,6 +45,9 @@ func PackageToInstalled(pkg *Package) (out []string) {
 	if len(pkg.Replaces) != 0 {
 		out = append(out, fmt.Sprintf("r:%s", strings.Join(pkg.Replaces, " ")))
 	}
+	if pkg.ReplacesPriority != 0 {
+		out = append(out, fmt.Sprintf("q:%d", pkg.ReplacesPriority))
+	}
 	out = append(out, fmt.Sprintf("c:%s", pkg.RepoCommit))
 	out = append(out, fmt.Sprintf("i:%s", pkg.InstallIf))
 	out = append(out, fmt.Sprintf("t:%d", pkg.BuildTime.Unix()))
@@ -133,6 +136,7 @@ func ParsePackage(ctx context.Context, apkPackage io.Reader, size uint64) (*Pack
 		BuildDate:        pkginfo.BuildDate,
 		RepoCommit:       pkginfo.RepoCommit,
 		Replaces:         pkginfo.Replaces,
+		ReplacesPriority: pkginfo.ReplacesPriority,
 		DataHash:         pkginfo.DataHash,
 	}, nil
 }

--- a/pkg/apk/types/package.go
+++ b/pkg/apk/types/package.go
@@ -41,6 +41,7 @@ type PackageInfo struct {
 	BuildDate        int64    `ini:"builddate"`
 	RepoCommit       string   `ini:"commit"`
 	Replaces         []string `ini:"replaces,,allowshadow"`
+	ReplacesPriority uint64   `ini:"replaces_priority"`
 	DataHash         string   `ini:"datahash"`
 	Triggers         []string `ini:"triggers,,allowshadow"`
 }
@@ -64,6 +65,7 @@ func (pkginfo *PackageInfo) AsPackage(controlHash []byte, size uint64) *Package 
 		BuildDate:        pkginfo.BuildDate,
 		RepoCommit:       pkginfo.RepoCommit,
 		Replaces:         pkginfo.Replaces,
+		ReplacesPriority: pkginfo.ReplacesPriority,
 		DataHash:         pkginfo.DataHash,
 
 		BuildTime: time.Unix(pkginfo.BuildDate, 0).UTC(),
@@ -94,6 +96,7 @@ type Package struct {
 	BuildDate        int64    `ini:"builddate"`
 	RepoCommit       string   `ini:"commit"`
 	Replaces         []string `ini:"replaces,,allowshadow"`
+	ReplacesPriority uint64   `ini:"replaces_priority"`
 	DataHash         string   `ini:"datahash"`
 }
 


### PR DESCRIPTION
`types.PackageInfo`/`types.Package` had no field for a package's `replaces_priority`, so the value from `.PKGINFO` was silently dropped and never written to `/lib/apk/db/installed` (no `q:` line), unlike upstream `apk-tools`.

Adds `ReplacesPriority` to both structs and plumbs it through parsing (`.PKGINFO` → `ParsePackage`) and writing (`PackageToInstalled`), mirroring how `ProviderPriority`/`k:` already works. The `q:` line is only written when non-zero, matching `apk-tools`' `database.c`.

**Testing:** added round-trip coverage in `installed_test.go` (write → parse) for both the zero case (no `q:` line) and non-zero case.